### PR TITLE
feat(harmony): 完成问题/回答详情页迁移，各信息流页对齐上游，版本号更新为v0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,11 @@
 
 - 四模块架构：`entry`（HAP 主模块）+ `core`/`data`/`reader`（HAR 共享库）；
   `AppScope` 为应用壳（bundleName `com.github.zhuoyi233.zhplus`）。
+
 - 编译：API 26，`targetSdkVersion` `26.0.0`、`compatibleSdkVersion` `6.1.0(23)`——最低支持
   HarmonyOS 6.1.0（API 23）设备（编译/兼容版本拆分背景见 `docs/api26-api24-migration-plan.md`；
   注意 API 10–25 的版本值必须用 `'X.Y.Z(N)'` 旧格式，`'26.0.0'` 新格式仅 API 26+ 合法）。
+
 - 依赖：ohpm（`oh-package.json5`），构建工具 hvigor。
 
 ## 构建与验证（必须按顺序执行）
@@ -23,18 +25,25 @@ pwsh -NoProfile -File scripts/verify-harmony.ps1 -SkipDependencyInstall
 ```
 
 - **必须用 pwsh 7**：Windows PowerShell 5.1 对 UTF-8 无 BOM 中文会乱码，导致脚本失败。
+
 - 用例数由脚本解析 `entry/src/test/List.test.ets` 注册项动态统计，并校验全量通过；
   无需手动维护基线数字，必要时可用 `-ExpectedTestCount` 显式固定。
+
 - 签名：已对 `build-profile.json5` 设置 `git update-index --skip-worktree`，本地签名配置
   （`devecocli signature generate` 写入）不会进入 `git status`/提交，**无需再还原**
   （提交前若出现需还原，说明 skip-worktree 失效，重新设置即可）。证书文件在项目外
   `~/.ohos/config/`；需要提交该文件真实变更（如 targetSdkVersion）时先
   `git update-index --no-skip-worktree build-profile.json5`。
+
 - DevEco/hvigor 工具链需要读写工作区外的 `.hvigor` 缓存、SDK 与 `~/.ohos` 签名目录；
   在受沙箱限制的会话中跑完整构建或 `devecocli signature generate` 需相应提权
   （否则 node 子进程报 ENOENT/Access denied，devecocli 报"安装未找到"）。
 
-## 设备调试（模拟器 ZhihuPlus_API26，127.0.0.1:5555）
+- 本机已安装 `devecocli`（npm 全局，`devecocli --version` 可查），可替代 DevEco Studio 执行
+  命令行操作：`build`/`run`/`signature`/`device`/`emulator`/`auth`/`log`/`ui`/`check`/`docs`
+  等（`devecocli --help` 查看全量）；沙箱会话中同样按上一条提权。
+
+## 设备调试（模拟器 ZhihuPlus\_API26，127.0.0.1:5555）
 
 ```powershell
 # hdc 路径因机器而异，建议加入 PATH 或改用环境变量；此处按 PATH 解析，不硬编码本机绝对路径。
@@ -48,9 +57,12 @@ $hdc = "hdc"
 ```
 
 - 多设备时 `hdc` 必须用 `-t <connectKey>` 指定目标，否则报 "need connect-key"。
+
 - 截图：`hdc shell snapshot_display`（默认写到 `/data/local/tmp/snapshot_*.jpeg`）后 recv。
+
 - UI dump 的节点字段是 `id`（不是 `resourceId`）；软键盘会遮挡底部按钮，操作前先
   `uitest uiInput keyEvent Back` 收起键盘。
+
 - 登录：重装/清数据后登录态丢失，首页出现 `p2_home_error_login` → 登录页手动 Cookie 输入
   （`ZHIHU_COOKIE` 环境变量）→ `p2_login_cookie_submit` → 首页 `p2_home_error_retry`。
 
@@ -59,22 +71,28 @@ $hdc = "hdc"
 - **严格禁止 push**：所有提交仅本地，远端落后属正常。仅当用户**当次明确要求**时才允许 push，
   且一次要求只执行**单次** push（只推用户指定的分支/tag，不顺势推送其他分支、tag 或 `--tags`），
   该许可不延续到后续任务。
+
 - **禁止自动提交**：改动（含修复、重构、文档）完成后一律不主动 commit，仅当用户**当次明确要求**
   提交时才执行。用户要求提交但未说明提交内容/拆分方式时，agent 按 git diff 的实际变更与本节
   规范自行生成 commit message 并做合理的提交拆分，无需逐次询问；与任务无关的未跟踪文件不得
   顺势带入。
+
 - 提交风格：`<type>(harmony): <中文>`，如 `fix(harmony): 修复搜索响应解析`。
+
 - 提交前检查：`git status` 干净（build-profile.json5 因 skip-worktree 不参与提交）、无临时文件（`.tmp_*` 等）。
+
 - 版本号映射：`versionCode` 由 `versionName` 按固定公式推导，二者在 `AppScope/app.json5` 一并更新：
   `versionCode = (主版本号 + 1) × 1000000 + 次版本号 × 100 + 修订号`（如 `0.2.1 → 1000201`，
   `0.3.0 → 1000300`，`1.0.0 → 2000000`）。鸿蒙官方仅要求 versionCode 整数且逐版递增（AGC 规则），
   本公式为本仓库约定；历史 tag（HMOSv0.1.0/0.2.0）的 versionCode 是早期占位值，不回改。
   之后只需提供 versionName 时，agent 按此公式自行补全 versionCode，无需再询问。
+
 - 版本 tag：仅用 `HMOSv<versionName>`（如 `HMOSv0.2.1`，与 `AppScope/app.json5` 的 `versionName` 一致）。
   发版顺序：改 `versionName`/`versionCode` → 完整验证 → 提交（`chore(harmony): 应用版本号升至 x.y.z`）→
   附注 tag（`git tag -a HMOSv0.2.1 -m "<一句里程碑中文摘要>"`）→ 推送仅在用户明确要求时执行
   （`git push origin dev` + 显式列出 HMOS tag）。仓库继承的上游 `0.x`/`nightly` tag 是 zly2006 的
   发布记录，**不要推送**，远端只保留 `HMOS*` tag。
+
 - 发布产物命名：`ZhihuPlusPlus-HMOS-v<version>-unsigned.hap`（如 `ZhihuPlusPlus-HMOS-v0.2.0-unsigned.hap`）。
   `verify-harmony.ps1` 构建校验通过后会自动从 `entry-default-unsigned/signed.hap` 复制出该命名的
   产物（同目录，含 `-signed` 后缀版），无需手动重命名；签名包仅限本机调试，不要分发。
@@ -83,22 +101,36 @@ $hdc = "hdc"
 
 - 显式类型：禁 `any`/`unknown`（用 `Object`）、对象字面量不能作为 `Promise<T>` 返回
   （用 interface）；`catch (e)` 后不能 `throw e`（包装成具体 Error 再抛）。
+
 - 禁解构参数；`Object.entries(...).forEach` 的元组回调改用 `Object.keys`。
+
 - 跨页面状态通道：P1Shell 各 feed 页经 `@Builder` 参数传值（如 reloadToken）在 HdsTabs 的
   TabContent 构建树下**不会触发已挂载子组件更新**，`@Provide`/`@Consume` 在该树形下也实测
   **不链接**（页面各持本地兜底实例）。跨页面信号一律走 AppStorage 广播 + `@StorageProp`+`@Watch`
   （如 `loginFeedReloadTick`，同 `bottomRectHeight` 模式）；signal 处理需容忍控制器失活态
   （refresh/reloadNow 对 inactive 自行 no-op）。
+
+- `@BuilderParam` 传入的箭头闭包体内**只能直接调用 @Builder 方法**，不得再包 `if` 等语句——
+  否则编译器不转换 builder 调用，运行时**静默不渲染**（无报错）；条件守卫写在 @Builder 内部
+  （UI 层 `if` 合法）。@Builder 体内禁止非 UI 语句（含 hilog），否则编译错误
+  "does not meet UI component syntax"。
+
+- `SegmentButton` 的 `options` 是 `@ObjectLink`：必须存 `@State` 字段再传入，内联对象字面量
+  在真机上会丢点击回调；并需显式 `.width()`，否则两键段控会溢出父边距。
+
 - 无 `TextEncoder`：用 `data` 模块 `Utf8.ets` 的 `utf8Encode`。
+
 - 最低兼容 API 23：`uiMaterial` 全家族（`@ohos.arkui.uiMaterial`，含 `ImmersiveMaterial`/
   `systemMaterial`/`getMaterialInfo`）是 API 26 专属，**禁止 import**，否则 API 23 设备载入
   即崩；普通组件玻璃效果用 `backgroundBlurStyle(BlurStyle.COMPONENT_ULTRA_THIN)` 兜底，
   系统材质只能走 HDS 组件（`hdsMaterial`/`HdsTabs` 等，自 6.1.0(23) 起可用）。
   新 API 起始版本可在 SDK `hms/ets/api/device-define/api-version/*.json` 查表核实。
+
 - 图标用鸿蒙官方 Symbol：`SymbolGlyph($r('sys.symbol.xxx'))`（如 `more`/`arrow_up`/
   `bookmark`/`message`），名称以官方符号库为准，勿猜（`ellipsis` 等不存在）。
-  符号库：https://developer.huawei.com/consumer/cn/design/harmonyos-symbol ；
-  使用说明：https://developer.huawei.com/consumer/cn/doc/design-guides/system-icons-0000001929854962 。
+  符号库：<https://developer.huawei.com/consumer/cn/design/harmonyos-symbol> ；
+  使用说明：<https://developer.huawei.com/consumer/cn/doc/design-guides/system-icons-0000001929854962> 。
+
 - ArkWeb（Web 组件）：`setUserAgentForHosts` 是**静态方法**；清 cookie 用
   `WebCookieManager.clearAllCookiesSync()`；登录/风控页用默认移动 UA（桌面 UA 会让页面
   按桌面视口渲染、字体过小）。
@@ -107,6 +139,7 @@ $hdc = "hdc"
 
 - 用 git worktree：`git worktree add .worktrees/<name> -b feature/<name>`（`.worktrees/`
   已被 .gitignore 忽略），完成后 `git worktree remove` + `git branch -D`。
+
 - 上游参考：保留 `refs/remotes/upstream/master` 与本地 `Android-master`
   （跟踪 upstream/master），需要看安卓实现时
   `git worktree add --detach .worktrees/_ref refs/remotes/upstream/master`。
@@ -114,4 +147,6 @@ $hdc = "hdc"
 ## 文档与行为基线
 
 - 阶段文档在 `docs/p0`–`docs/p5`；清理/迁移分析在 `docs/cleanup/`。
+
 - 行为对齐安卓 Lite：登录三模式（手机号/扫码/网页）、信息流屏蔽、风控 ArkWeb 验证等。
+

--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -2,8 +2,8 @@
   "app": {
     "bundleName": "com.github.zhuoyi233.zhplus",
     "vendor": "zhuoyi233",
-    "versionCode": 1000302,
-    "versionName": "0.3.2",
+    "versionCode": 1000400,
+    "versionName": "0.4.0",
     "buildVersion": "1",
     "icon": "$media:app_icon",
     "label": "$string:app_name"

--- a/AppScope/resources/base/element/string.json
+++ b/AppScope/resources/base/element/string.json
@@ -2,7 +2,7 @@
   "string": [
     {
       "name": "app_name",
-      "value": "Zhihu++"
+      "value": "知乎++"
     }
   ]
 }

--- a/core/src/main/ets/navigation/P1Destination.ets
+++ b/core/src/main/ets/navigation/P1Destination.ets
@@ -23,6 +23,7 @@ export enum P1DestinationName {
   BLOCKING_RULES = 'BlockingRules',
   BLOCKED_FEED_HISTORY = 'BlockedFeedHistory',
   READ_HISTORY = 'ReadHistory',
+  LOCAL_HISTORY = 'LocalHistory',
   TECHNICAL_LAB = 'TechnicalLab',
   READER_PROBE = 'ReaderProbe',
   IMAGE_PROBE = 'ImageProbe',
@@ -44,7 +45,8 @@ export interface StatelessDestination {
 
 export interface InfrastructureDestination {
   readonly name: P1DestinationName.LOGIN | P1DestinationName.SETTINGS | P1DestinationName.BLOCKING_RULES |
-    P1DestinationName.BLOCKED_FEED_HISTORY | P1DestinationName.READ_HISTORY | P1DestinationName.TECHNICAL_LAB |
+    P1DestinationName.BLOCKED_FEED_HISTORY | P1DestinationName.READ_HISTORY | P1DestinationName.LOCAL_HISTORY |
+    P1DestinationName.TECHNICAL_LAB |
     P1DestinationName.NOTIFICATION_SETTINGS |
     P1DestinationName.READER_PROBE | P1DestinationName.IMAGE_PROBE |
     P1DestinationName.DATABASE_PROBE | P1DestinationName.DEEP_LINK_PROBE |
@@ -138,6 +140,7 @@ export function isP1DestinationName(name: string): boolean {
     case P1DestinationName.BLOCKING_RULES:
     case P1DestinationName.BLOCKED_FEED_HISTORY:
     case P1DestinationName.READ_HISTORY:
+    case P1DestinationName.LOCAL_HISTORY:
     case P1DestinationName.TECHNICAL_LAB:
     case P1DestinationName.READER_PROBE:
     case P1DestinationName.IMAGE_PROBE:
@@ -200,6 +203,8 @@ export function decodeP1Destination(name: string, param: Object): P1Destination 
       return hasNoParameters(wire) ? { name: P1DestinationName.BLOCKED_FEED_HISTORY } : undefined;
     case P1DestinationName.READ_HISTORY:
       return hasNoParameters(wire) ? { name: P1DestinationName.READ_HISTORY } : undefined;
+    case P1DestinationName.LOCAL_HISTORY:
+      return hasNoParameters(wire) ? { name: P1DestinationName.LOCAL_HISTORY } : undefined;
     case P1DestinationName.TECHNICAL_LAB:
       return hasNoParameters(wire) ? { name: P1DestinationName.TECHNICAL_LAB } : undefined;
     case P1DestinationName.READER_PROBE:
@@ -275,6 +280,7 @@ export function isInfrastructureDestination(destination: P1Destination): boolean
     case P1DestinationName.BLOCKING_RULES:
     case P1DestinationName.BLOCKED_FEED_HISTORY:
     case P1DestinationName.READ_HISTORY:
+    case P1DestinationName.LOCAL_HISTORY:
     case P1DestinationName.TECHNICAL_LAB:
     case P1DestinationName.NOTIFICATION_SETTINGS:
     case P1DestinationName.READER_PROBE:

--- a/data/Index.ets
+++ b/data/Index.ets
@@ -40,6 +40,7 @@ export * from './src/main/ets/repository/CommentRepository';
 export * from './src/main/ets/repository/DailyStoryRepository';
 export * from './src/main/ets/repository/DefaultContentRepository';
 export * from './src/main/ets/repository/DefaultChannelFeedRepository';
+export * from './src/main/ets/repository/QuestionAnswerFeedRepository';
 export * from './src/main/ets/repository/DefaultCollectionRepository';
 export * from './src/main/ets/repository/DefaultCommentRepository';
 export * from './src/main/ets/repository/NotificationRepository';

--- a/data/Index.ets
+++ b/data/Index.ets
@@ -40,6 +40,8 @@ export * from './src/main/ets/repository/CommentRepository';
 export * from './src/main/ets/repository/DailyStoryRepository';
 export * from './src/main/ets/repository/DefaultContentRepository';
 export * from './src/main/ets/repository/DefaultChannelFeedRepository';
+export * from './src/main/ets/repository/RecentFollowingUsersRepository';
+export * from './src/main/ets/repository/DefaultRecentFollowingUsersRepository';
 export * from './src/main/ets/repository/QuestionAnswerFeedRepository';
 export * from './src/main/ets/repository/DefaultCollectionRepository';
 export * from './src/main/ets/repository/DefaultCommentRepository';

--- a/data/src/main/ets/domain/ChannelFeedModels.ets
+++ b/data/src/main/ets/domain/ChannelFeedModels.ets
@@ -40,6 +40,19 @@ export interface ChannelFeedPage {
   readonly cursor: PageCursor;
 }
 
+/** 对齐上游 RecentMomentsViewModel.FollowingUserItem：最近有更新的关注用户。 */
+export interface RecentFollowingActor {
+  readonly id: string;
+  readonly urlToken: string;
+  readonly name: string;
+  readonly avatarUrl: string;
+}
+
+export interface RecentFollowingUser {
+  readonly actor: RecentFollowingActor;
+  readonly unreadCount: number;
+}
+
 export function isDailyFeedDateCursor(value: string): boolean {
   if (!/^\d{8}$/.test(value)) {
     return false;

--- a/data/src/main/ets/domain/CommentModels.ets
+++ b/data/src/main/ets/domain/CommentModels.ets
@@ -74,7 +74,8 @@ export function commentIdentity(comment: CommentItem): string {
 }
 
 /** 返回带新点赞状态/计数的新评论对象，供乐观更新替换列表项（保持其余字段不变）。 */
-export function copyCommentWithLike(comment: CommentItem, liked: boolean, likeCount: number): CommentItem {
+export function copyCommentWithLike(comment: CommentItem, liked: boolean, likeCount: number,
+  children: Array<CommentItem> = comment.childComments): CommentItem {
   return {
     id: comment.id,
     contentHtml: comment.contentHtml,
@@ -93,6 +94,6 @@ export function copyCommentWithLike(comment: CommentItem, liked: boolean, likeCo
     authorTag: comment.authorTag,
     commentTags: comment.commentTags,
     childCommentCount: comment.childCommentCount,
-    childComments: comment.childComments
+    childComments: children
   };
 }

--- a/data/src/main/ets/domain/ContentDetailDecoder.ets
+++ b/data/src/main/ets/domain/ContentDetailDecoder.ets
@@ -5,12 +5,13 @@ import {
   JsonNullValue,
   JsonNumberValue,
   JsonObjectValue,
+  jsonString,
   JsonStringValue,
   JsonValue,
   parseStrictJson,
   StrictJsonError
 } from 'core';
-import { Answer, AnswerEndorsementDisplay, Article, ContentVoteState, Question, UserProfile } from './DomainModels';
+import { Answer, AnswerEndorsementDisplay, Article, ContentVoteState, Question, QuestionTopicSummary, UserProfile } from './DomainModels';
 import { DomainDecodeError, DomainDecodeFailureKind } from './ZhihuDomainDecoder';
 
 function parseRoot(json: string, contentName: string): JsonObjectValue {
@@ -289,13 +290,45 @@ export function decodeQuestionDetail(json: string, expectedId: string): Question
     answerCount: nonNegativeInteger(wire.get('answer_count'), 'question.answer_count'),
     commentCount: nonNegativeInteger(wire.get('comment_count'), 'question.comment_count'),
     followerCount: nonNegativeInteger(wire.get('follower_count'), 'question.follower_count'),
+    visitCount: questionVisitCount(wire.get('visit_count')),
     createdAt: nonNegativeInteger(wire.get('created'), 'question.created'),
     updatedAt: nonNegativeInteger(wire.get('updated_time'), 'question.updated_time'),
     author: authorFromWire(optionalObject(wire.get('author'), 'author')),
     isFollowing: relationship === undefined
       ? undefined
-      : optionalBoolean(relationship.get('is_following'), 'question.relationship.is_following')
+      : optionalBoolean(relationship.get('is_following'), 'question.relationship.is_following'),
+    topics: questionTopicsFromWire(wire.get('topics'))
   };
+}
+
+function questionVisitCount(value: JsonValue | undefined): number | undefined {
+  if (value === undefined || value instanceof JsonNullValue) {
+    return undefined;
+  }
+  return nonNegativeInteger(value, 'question.visit_count');
+}
+
+function questionTopicsFromWire(value: JsonValue | undefined): QuestionTopicSummary[] {
+  if (value === undefined || value instanceof JsonNullValue) {
+    return [];
+  }
+  if (!(value instanceof JsonArrayValue)) {
+    throw invalid('question.topics 结构无效');
+  }
+  const topics: QuestionTopicSummary[] = [];
+  value.items.forEach((item: JsonValue): void => {
+    const object = item instanceof JsonObjectValue ? item : undefined;
+    if (object === undefined) {
+      return;
+    }
+    const id = jsonString(object.get('id')) ?? jsonIntegerLiteral(object.get('id'));
+    const name = jsonString(object.get('name')) ?? jsonString(object.get('title'));
+    if (id === undefined || id.trim().length === 0 || name === undefined || name.trim().length === 0) {
+      return;
+    }
+    topics.push({ id: id, name: name });
+  });
+  return topics;
 }
 
 export function decodeAnswerDetail(json: string, expectedId: string): Answer {

--- a/data/src/main/ets/domain/DomainModels.ets
+++ b/data/src/main/ets/domain/DomainModels.ets
@@ -134,6 +134,9 @@ export interface FeedTargetSummary {
   url: string;
   voteupCount: number;
   commentCount: number;
+  answerCount?: number;
+  visitCount?: number;
+  followerCount?: number;
   author?: UserProfile;
   topicIds: Array<string>;
 }

--- a/data/src/main/ets/domain/DomainModels.ets
+++ b/data/src/main/ets/domain/DomainModels.ets
@@ -39,6 +39,11 @@ export interface PinDetail {
   topics: Array<PinTopic>;
 }
 
+export interface QuestionTopicSummary {
+  id: string;
+  name: string;
+}
+
 export interface Question {
   id: string;
   title: string;
@@ -47,11 +52,15 @@ export interface Question {
   answerCount: number;
   commentCount: number;
   followerCount: number;
+  /** 浏览数（详情 include 的 visit_count）；未返回时缺省。 */
+  visitCount?: number;
   createdAt: number;
   updatedAt: number;
   author?: UserProfile;
   /** 当前登录用户是否已关注该问题；详情接口未返回时缺省。 */
   isFollowing?: boolean;
+  /** 问题关联话题（详情 include 的 topics）；未返回时缺省。 */
+  topics?: QuestionTopicSummary[];
 }
 
 export interface AnswerEndorsementDisplay {

--- a/data/src/main/ets/domain/SearchModels.ets
+++ b/data/src/main/ets/domain/SearchModels.ets
@@ -13,11 +13,113 @@ export interface SearchResultItem {
   readonly commentCount: number;
 }
 
+/** 用户搜索结果：name 保留 `<em>` 原文，由 UI 层做高亮拆分。 */
+export interface SearchPersonItem {
+  readonly id: string;
+  readonly name: string;
+  readonly urlToken?: string;
+  readonly avatarUrl?: string;
+  readonly headline: string;
+  readonly followerCount: number;
+  readonly answerCount: number;
+}
+
+/** 话题搜索结果：name/excerpt 保留 `<em>` 原文，由 UI 层做高亮拆分。 */
+export interface SearchTopicItem {
+  readonly id: string;
+  readonly name: string;
+  readonly avatarUrl?: string;
+  readonly excerpt: string;
+  readonly visitCount: number;
+  readonly discussCount: number;
+  readonly isFollowing: boolean;
+}
+
+export enum SearchEntityKind {
+  CONTENT = 'content',
+  PERSON = 'person',
+  TOPIC = 'topic'
+}
+
+/** 搜索结果统一实体：内容/用户/话题三态，kind 决定哪个字段有效。 */
+export interface SearchEntity {
+  readonly id: string;
+  readonly kind: SearchEntityKind;
+  readonly content?: SearchResultItem;
+  readonly person?: SearchPersonItem;
+  readonly topic?: SearchTopicItem;
+}
+
+export function searchEntityOfContent(item: SearchResultItem): SearchEntity {
+  return { id: searchResultIdentity(item), kind: SearchEntityKind.CONTENT, content: item };
+}
+
+export function searchEntityOfPerson(item: SearchPersonItem): SearchEntity {
+  return { id: `person:${item.id}`, kind: SearchEntityKind.PERSON, person: item };
+}
+
+export function searchEntityOfTopic(item: SearchTopicItem): SearchEntity {
+  return { id: `topic:${item.id}`, kind: SearchEntityKind.TOPIC, topic: item };
+}
+
+export function searchEntityIdentity(entity: SearchEntity): string {
+  return entity.id;
+}
+
 export interface SearchResultPage {
-  readonly items: Array<SearchResultItem>;
+  readonly entities: Array<SearchEntity>;
   readonly cursor: PageCursor;
 }
 
 export function searchResultIdentity(item: SearchResultItem): string {
   return `${item.kind}:${item.contentId}`;
+}
+
+/** 热搜词条：query 为搜索词，hotShow 为热度展示文本（可空）。 */
+export interface SearchHotItem {
+  readonly query: string;
+  readonly hotShow: string;
+  readonly label: string;
+}
+
+/**
+ * 搜索范围（对齐上游 SearchTab 与 vertical 筛选的组合）：
+ * 回答/文章两个 tab 复用 t=general 接口，通过 vertical 参数让服务端过滤内容类型。
+ */
+export enum SearchTab {
+  GENERAL = 'general',
+  PEOPLE = 'people',
+  ANSWER = 'answer',
+  ARTICLE = 'article',
+  TOPIC = 'topic'
+}
+
+export enum SearchSortOption {
+  DEFAULT = 'default',
+  LATEST = 'latest',
+  MOST_VOTED = 'most_voted'
+}
+
+export enum SearchTimeRange {
+  ALL = 'all',
+  DAY = 'day',
+  WEEK = 'week',
+  MONTH = 'month',
+  THREE_MONTHS = 'three_months',
+  HALF_YEAR = 'half_year',
+  YEAR = 'year'
+}
+
+/** 搜索请求筛选参数（对齐上游 SearchFilters 的 sort + timeRange；内容类型由 SearchTab 承载）。 */
+export interface SearchFilters {
+  readonly sort: SearchSortOption;
+  readonly timeRange: SearchTimeRange;
+}
+
+export function defaultSearchFilters(): SearchFilters {
+  return { sort: SearchSortOption.DEFAULT, timeRange: SearchTimeRange.ALL };
+}
+
+export function areDefaultSearchFilters(filters: SearchFilters): boolean {
+  return filters.sort === SearchSortOption.DEFAULT && filters.timeRange === SearchTimeRange.ALL;
 }

--- a/data/src/main/ets/domain/ZhihuChannelFeedDecoder.ets
+++ b/data/src/main/ets/domain/ZhihuChannelFeedDecoder.ets
@@ -7,9 +7,10 @@ import {
   DailyStorySummary,
   isDailyFeedDateCursor
 } from './ChannelFeedModels';
-import { FeedItem, FeedPage, PageCursor } from './DomainModels';
+import { FeedItem, FeedPage, FeedTargetKind, FeedTargetSummary, PageCursor, UserProfile } from './DomainModels';
 import {
   JsonArrayValue,
+  JsonBooleanValue,
   jsonIntegerLiteral,
   jsonNumber,
   JsonNumberValue,
@@ -203,4 +204,85 @@ export function decodeDailyFeedPage(json: string): ChannelFeedPage {
 
 function invalid(message: string): DomainDecodeError {
   return new DomainDecodeError(DomainDecodeFailureKind.MISSING_FIELD, message);
+}
+
+/**
+ * 问题回答信息流（/api/v4/questions/{id}/feeds）解码。
+ * 与 moments/hot 条目不同：条目无顶层 id/verb，形如
+ * {type:'question_feed_card', target_type:'answer', target:{...}}；
+ * target 亦无嵌套 question 对象，标题从 target 自身尽力取值。
+ */
+export function decodeQuestionAnswerFeedPage(json: string): ChannelFeedPage {
+  const object = root(json, '问题回答信息流');
+  const data = requiredArray(object, 'data', 'feed.data');
+  const items: Array<ChannelContentItem> = [];
+  data.items.forEach((value: JsonValue): void => {
+    const item = jsonObject(value);
+    if (item === undefined) {
+      return;
+    }
+    const target = jsonObject(item.get('target'));
+    const targetType = jsonString(item.get('target_type')) ?? jsonString(target?.get('type')) ??
+      jsonString(item.get('type'));
+    if (targetType !== 'answer') {
+      // 跳过置顶/聚合等非内容条目，对齐上游按 target 类型过滤的语义。
+      return;
+    }
+    if (target === undefined) {
+      return;
+    }
+    const targetId = wireId(target.get('id'), 'feed.target.id');
+    const kind: FeedTargetKind = FeedTargetKind.ANSWER;
+    const question = jsonObject(target.get('question'));
+    const title = jsonString(target.get('title')) ?? jsonString(target.get('name')) ??
+      (question === undefined ? undefined : jsonString(question.get('title'))) ?? '';
+    const authorObject = jsonObject(target.get('author'));
+    const author: UserProfile = {
+      id: jsonString(authorObject?.get('id')) ?? '',
+      name: jsonString(authorObject?.get('name')) ?? '',
+      headline: jsonString(authorObject?.get('headline')) ?? '',
+      urlToken: jsonString(authorObject?.get('url_token')),
+      avatarUrl: jsonString(authorObject?.get('avatar_url')),
+      followerCount: 0,
+      isFollowing: false,
+      isOrganization: false
+    };
+    const targetTopicIds = topicIds(target);
+    const feedTarget: FeedTargetSummary = {
+      kind: kind,
+      id: targetId,
+      title: title,
+      excerpt: jsonString(target.get('excerpt')) ?? '',
+      url: jsonString(target.get('url')) ?? '',
+      voteupCount: jsonNumber(target.get('voteup_count')) ?? 0,
+      commentCount: jsonNumber(target.get('comment_count')) ?? 0,
+      author: author,
+      topicIds: targetTopicIds
+    };
+    const feedEntry: FeedItem = {
+      id: targetId,
+      verb: '',
+      createdAt: jsonNumber(target.get('created_time')) ?? 0,
+      updatedAt: jsonNumber(target.get('updated_time')) ?? 0,
+      target: feedTarget
+    };
+    const contentItem: ChannelContentItem = {
+      kind: ChannelFeedItemKind.CONTENT,
+      feedItem: feedEntry,
+      topicIds: targetTopicIds
+    };
+    items.push(contentItem);
+  });
+  const paging = jsonObject(object.get('paging'));
+  const next = paging === undefined ? undefined : jsonString(paging.get('next'));
+  const end = paging?.get('is_end');
+  const isEnd = (end instanceof JsonBooleanValue && end.value) || next === undefined || next.trim().length === 0;
+  const cursor: PageCursor = {
+    isEnd: isEnd,
+    isStart: false,
+    next: !isEnd ? next : undefined,
+    page: -1,
+    total: items.length
+  };
+  return { items: items, cursor: cursor };
 }

--- a/data/src/main/ets/domain/ZhihuChannelFeedDecoder.ets
+++ b/data/src/main/ets/domain/ZhihuChannelFeedDecoder.ets
@@ -5,7 +5,8 @@ import {
   ChannelFeedItemKind,
   ChannelFeedPage,
   DailyStorySummary,
-  isDailyFeedDateCursor
+  isDailyFeedDateCursor,
+  RecentFollowingUser
 } from './ChannelFeedModels';
 import { FeedItem, FeedPage, FeedTargetKind, FeedTargetSummary, PageCursor, UserProfile } from './DomainModels';
 import {
@@ -200,6 +201,45 @@ export function decodeDailyFeedPage(json: string): ChannelFeedPage {
     total: items.length
   };
   return { items: items, cursor: cursor };
+}
+
+/**
+ * 最近更新的关注用户（/moments/recent?type=raw）解码。
+ * 对齐上游 RecentMomentsViewModel：逐条独立解析，失败条目直接跳过不中断整行。
+ */
+export function decodeRecentFollowingUsers(json: string): Array<RecentFollowingUser> {
+  const object = root(json, '关注动态');
+  const data = requiredArray(object, 'data', 'recent.data');
+  const users: Array<RecentFollowingUser> = [];
+  data.items.forEach((value: JsonValue): void => {
+    const item = jsonObject(value);
+    if (item === undefined) {
+      return;
+    }
+    const actor = jsonObject(item.get('actor'));
+    if (actor === undefined) {
+      return;
+    }
+    const id = optionalText(actor.get('id'), 'recent.actor.id');
+    const name = requiredText(actor.get('name'), 'recent.actor.name');
+    const avatarUrl = optionalText(actor.get('avatar_url'), 'recent.actor.avatar_url');
+    const urlToken = optionalText(actor.get('url_token'), 'recent.actor.url_token');
+    if (id.trim().length === 0 || name.trim().length === 0 || avatarUrl.trim().length === 0) {
+      return;
+    }
+    const unreadCount = jsonNumber(item.get('unread_count'));
+    users.push({
+      actor: {
+        id: id,
+        urlToken: urlToken.trim().length > 0 ? urlToken : id,
+        name: name,
+        avatarUrl: avatarUrl
+      },
+      unreadCount: unreadCount !== undefined && Number.isSafeInteger(unreadCount) && unreadCount > 0
+        ? unreadCount : 0
+    });
+  });
+  return users;
 }
 
 function invalid(message: string): DomainDecodeError {

--- a/data/src/main/ets/domain/ZhihuDomainDecoder.ets
+++ b/data/src/main/ets/domain/ZhihuDomainDecoder.ets
@@ -267,6 +267,13 @@ function feedTargetFromObject(object: JsonObjectValue): FeedTargetSummary {
     url: textOrEmpty(object.get('url'), 'feed.target.url'),
     voteupCount: numberOrDefault(object.get('voteup_count'), 0, 'feed.target.voteup_count'),
     commentCount: numberOrDefault(object.get('comment_count'), 0, 'feed.target.comment_count'),
+    answerCount: kind === FeedTargetKind.QUESTION
+      ? numberOrDefault(object.get('answer_count'), 0, 'feed.target.answer_count') : undefined,
+    visitCount: kind === FeedTargetKind.QUESTION && object.get('visit_count') !== undefined &&
+      !(object.get('visit_count') instanceof JsonNullValue)
+      ? numberOrDefault(object.get('visit_count'), 0, 'feed.target.visit_count') : undefined,
+    followerCount: kind === FeedTargetKind.QUESTION
+      ? numberOrDefault(object.get('follower_count'), 0, 'feed.target.follower_count') : undefined,
     author: optionalUser(object.get('author')),
     topicIds: topicIdsFromObject(object)
   };

--- a/data/src/main/ets/domain/ZhihuSearchDecoder.ets
+++ b/data/src/main/ets/domain/ZhihuSearchDecoder.ets
@@ -1,5 +1,13 @@
 import { FeedTargetKind, PageCursor } from './DomainModels';
-import { SearchResultItem, SearchResultPage } from './SearchModels';
+import {
+  SearchEntity,
+  SearchHotItem,
+  searchEntityOfContent,
+  searchEntityOfPerson,
+  searchEntityOfTopic,
+  SearchResultItem,
+  SearchResultPage
+} from './SearchModels';
 import {
   JsonArrayValue,
   jsonIntegerLiteral,
@@ -32,6 +40,12 @@ export class SearchDecodeError extends Error {
   }
 }
 
+interface IndexedEntry {
+  readonly order: number;
+  readonly index: number;
+  readonly value: JsonObjectValue;
+}
+
 export function decodeSearchResultPage(json: string): SearchResultPage {
   const envelope = root(json);
   const errorValue = envelope.get('error');
@@ -50,12 +64,21 @@ export function decodeSearchResultPage(json: string): SearchResultPage {
     !(pagingValue instanceof JsonObjectValue)) {
     throw malformed('search.paging 结构无效');
   }
-  const items: Array<SearchResultItem> = [];
-  data.items.forEach((value: JsonValue): void => {
+  // 对齐上游：search_result 包裹层带 index 字段时按其重排序（服务端顺序信号），缺失时保持响应顺序。
+  const entries: Array<IndexedEntry> = [];
+  data.items.forEach((value: JsonValue, order: number): void => {
     const candidate = jsonObject(value);
     if (candidate === undefined) {
       throw malformed('search.item 结构无效');
     }
+    entries.push({ order: order, index: wrapperIndex(candidate), value: candidate });
+  });
+  entries.sort((left: IndexedEntry, right: IndexedEntry): number => {
+    return left.index !== right.index ? left.index - right.index : left.order - right.order;
+  });
+  const entities: Array<SearchEntity> = [];
+  entries.forEach((entry: IndexedEntry): void => {
+    const candidate = entry.value;
     const wrapperType = requiredText(candidate.get('type'), 'search.item.type');
     if (wrapperType !== 'search_result') {
       return;
@@ -64,28 +87,110 @@ export function decodeSearchResultPage(json: string): SearchResultPage {
     if (object === undefined) {
       throw malformed('search.item.object 结构无效');
     }
-    const kind = searchKind(requiredText(object.get('type'), 'search.item.object.type'));
-    if (kind === undefined) {
-      return;
+    const objectType = requiredText(object.get('type'), 'search.item.object.type');
+    let entity: SearchEntity | undefined;
+    if (objectType === 'people') {
+      entity = decodePerson(object);
+    } else if (objectType === 'topic') {
+      entity = decodeTopic(object);
+    } else {
+      const item = decodeContent(object, candidate.get('id'), objectType);
+      entity = item === undefined ? undefined : searchEntityOfContent(item);
     }
-    const contentId = requiredId(object.get('id'), 'search.item.object.id');
-    const author = optionalObject(object.get('author'), 'search.item.object.author');
-    items.push({
-      wrapperId: searchWrapperId(candidate.get('id'), contentId),
-      kind: kind,
-      contentId: contentId,
-      title: searchTitle(object, kind),
-      excerpt: textOrEmpty(object.get('excerpt'), 'search.item.object.excerpt'),
-      authorId: authorId(author),
-      authorName: author === undefined ? undefined : optionalText(author.get('name'),
-        'search.item.object.author.name'),
-      topicIds: searchTopicIds(object),
-      voteupCount: numberOrDefault(object.get('voteup_count'), 0, 'search.item.object.voteup_count'),
-      commentCount: numberOrDefault(object.get('comment_count'), 0, 'search.item.object.comment_count')
-    });
+    if (entity !== undefined) {
+      entities.push(entity);
+    }
   });
   const paging = pagingValue instanceof JsonObjectValue ? pagingValue : undefined;
-  return { items: items, cursor: searchCursor(paging) };
+  return { entities: entities, cursor: searchCursor(paging) };
+}
+
+/** 热搜接口：`hot_search_queries` 缺失或为空时返回空数组（对齐上游失败静默降级）。 */
+export function decodeSearchHotList(json: string): Array<SearchHotItem> {
+  const envelope = root(json);
+  const queries = envelope.get('hot_search_queries');
+  if (queries === undefined || queries instanceof JsonNullValue) {
+    return [];
+  }
+  if (!(queries instanceof JsonArrayValue)) {
+    throw malformed('search.hot_search_queries 结构无效');
+  }
+  const items: Array<SearchHotItem> = [];
+  queries.items.forEach((value: JsonValue): void => {
+    const object = jsonObject(value);
+    if (object === undefined) {
+      throw malformed('search.hot_search_queries.item 结构无效');
+    }
+    const query = requiredText(object.get('query'), 'search.hot_search_queries.item.query');
+    items.push({
+      query: query,
+      hotShow: textOrEmpty(object.get('hot_show'), 'search.hot_search_queries.item.hot_show'),
+      label: textOrEmpty(object.get('label'), 'search.hot_search_queries.item.label')
+    });
+  });
+  return items;
+}
+
+/** 包裹层 index 排序键：服务端返回数字或数字字符串（对齐上游 toIntOrNull 容忍），无效时保持响应顺序。 */
+function wrapperIndex(candidate: JsonObjectValue): number {
+  const value = candidate.get('index');
+  const integerLiteral = jsonIntegerLiteral(value);
+  if (integerLiteral !== undefined && integerLiteral.length <= 7) {
+    return parseInt(integerLiteral, 10);
+  }
+  if (value instanceof JsonStringValue && /^[0-9]{1,7}$/.test(value.value.trim())) {
+    return parseInt(value.value.trim(), 10);
+  }
+  return -1;
+}
+
+function decodePerson(object: JsonObjectValue): SearchEntity {
+  const id = requiredId(object.get('id'), 'search.item.object.id');
+  return searchEntityOfPerson({
+    id: id,
+    name: requiredText(object.get('name'), 'search.item.object.name'),
+    urlToken: optionalText(object.get('url_token'), 'search.item.object.url_token'),
+    avatarUrl: optionalText(object.get('avatar_url'), 'search.item.object.avatar_url'),
+    headline: textOrEmpty(object.get('headline'), 'search.item.object.headline'),
+    followerCount: numberOrDefault(object.get('follower_count'), 0, 'search.item.object.follower_count'),
+    answerCount: numberOrDefault(object.get('answer_count'), 0, 'search.item.object.answer_count')
+  });
+}
+
+function decodeTopic(object: JsonObjectValue): SearchEntity {
+  const id = requiredId(object.get('id'), 'search.item.object.id');
+  return searchEntityOfTopic({
+    id: id,
+    name: requiredText(object.get('name'), 'search.item.object.name'),
+    avatarUrl: optionalText(object.get('avatar_url'), 'search.item.object.avatar_url'),
+    excerpt: textOrEmpty(object.get('excerpt'), 'search.item.object.excerpt'),
+    visitCount: numberOrDefault(object.get('visit_count'), 0, 'search.item.object.visit_count'),
+    discussCount: numberOrDefault(object.get('top_answer_count'), 0, 'search.item.object.top_answer_count'),
+    isFollowing: booleanOrDefault(object.get('is_following'), false, 'search.item.object.is_following')
+  });
+}
+
+function decodeContent(object: JsonObjectValue, wrapperIdValue: JsonValue | undefined,
+  objectType: string): SearchResultItem | undefined {
+  const kind = searchKind(objectType);
+  if (kind === undefined) {
+    return undefined;
+  }
+  const contentId = requiredId(object.get('id'), 'search.item.object.id');
+  const author = optionalObject(object.get('author'), 'search.item.object.author');
+  return {
+    wrapperId: searchWrapperId(wrapperIdValue, contentId),
+    kind: kind,
+    contentId: contentId,
+    title: searchTitle(object, kind),
+    excerpt: textOrEmpty(object.get('excerpt'), 'search.item.object.excerpt'),
+    authorId: authorId(author),
+    authorName: author === undefined ? undefined : optionalText(author.get('name'),
+      'search.item.object.author.name'),
+    topicIds: searchTopicIds(object),
+    voteupCount: numberOrDefault(object.get('voteup_count'), 0, 'search.item.object.voteup_count'),
+    commentCount: numberOrDefault(object.get('comment_count'), 0, 'search.item.object.comment_count')
+  };
 }
 
 function root(json: string): JsonObjectValue {

--- a/data/src/main/ets/network/ZhihuHttpClient.ets
+++ b/data/src/main/ets/network/ZhihuHttpClient.ets
@@ -1,5 +1,6 @@
 import { http } from '@kit.NetworkKit';
 import { BusinessError } from '@kit.BasicServicesKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
 import { SessionCookie, toCookieHeader } from '../session/CookieSession';
 import { HttpFailure, HttpFailureKind, httpFailureFromStatus, httpFailureFromTransport } from './HttpFailure';
 import { createZse96Header, ZHIHU_WEB_ZSE93 } from './ZhihuFetchSignature';
@@ -343,8 +344,12 @@ export class ZhihuHttpClient {
       return response;
     } catch (error) {
       if (error instanceof HttpFailure) {
+        hilog.warn(0xD001, 'ZhihuHttp', 'kind=%{public}s status=%{public}d transport=%{public}d',
+          error.kind, error.status ?? 0, error.transportCode ?? 0);
         throw new HttpFailure(error.kind, error.status, error.transportCode);
       }
+      // 只记录错误类别和错误码，不输出 URL、Cookie、请求体或原始错误文本。
+      hilog.warn(0xD001, 'ZhihuHttp', 'kind=unexpected');
       throw httpFailureFromTransport();
     } finally {
       if (activeRequest !== undefined) {

--- a/data/src/main/ets/preferences/AppPreferencesStore.ets
+++ b/data/src/main/ets/preferences/AppPreferencesStore.ets
@@ -23,6 +23,8 @@ const TOPIC_BLOCKING_THRESHOLD_KEY = 'topic_blocking_threshold';
 const NOTIFICATION_DISPLAY_PREFIX = 'notification_display_in_app_';
 const NOTIFICATION_AUTO_MARK_READ_KEY = 'notification_auto_mark_as_read';
 const NOTIFICATION_UNREAD_BADGE_KEY = 'notification_unread_badge';
+// 键与存储值对齐上游 answerDoubleTapAction 偏好（"none"/"ask"/"voteUp"/"openComments"/"toggleImmersive"）。
+const ANSWER_DOUBLE_TAP_ACTION_KEY = 'answerDoubleTapAction';
 
 function notificationDisplayKey(kind: NotificationKind): string {
   if (kind === NotificationKind.LIKE_COMMENT) {
@@ -51,6 +53,76 @@ export function decodeAppThemeMode(value: preferences.ValueType): AppThemeMode {
     return AppThemeMode.DARK;
   }
   return AppThemeMode.SYSTEM;
+}
+
+/** 回答页双击正文动作（对齐上游 AnswerDoubleTapAction），默认询问并记住。 */
+export enum AnswerDoubleTapAction {
+  NONE = 0,
+  ASK = 1,
+  VOTE_UP = 2,
+  OPEN_COMMENTS = 3,
+  TOGGLE_IMMERSIVE = 4
+}
+
+export function answerDoubleTapActionPreferenceValue(action: AnswerDoubleTapAction): string {
+  switch (action) {
+    case AnswerDoubleTapAction.NONE:
+      return 'none';
+    case AnswerDoubleTapAction.VOTE_UP:
+      return 'voteUp';
+    case AnswerDoubleTapAction.OPEN_COMMENTS:
+      return 'openComments';
+    case AnswerDoubleTapAction.TOGGLE_IMMERSIVE:
+      return 'toggleImmersive';
+    default:
+      return 'ask';
+  }
+}
+
+export function answerDoubleTapActionLabel(action: AnswerDoubleTapAction): string {
+  switch (action) {
+    case AnswerDoubleTapAction.NONE:
+      return '无操作';
+    case AnswerDoubleTapAction.ASK:
+      return '询问并记住';
+    case AnswerDoubleTapAction.VOTE_UP:
+      return '点赞';
+    case AnswerDoubleTapAction.OPEN_COMMENTS:
+      return '打开评论区';
+    case AnswerDoubleTapAction.TOGGLE_IMMERSIVE:
+      return '开关沉浸式';
+    default:
+      return '询问并记住';
+  }
+}
+
+/** 未知/缺失值一律回退 Ask（对齐上游 fromPreference）。 */
+export function decodeAnswerDoubleTapAction(value: preferences.ValueType): AnswerDoubleTapAction {
+  if (typeof value === 'string') {
+    if (value === 'none') {
+      return AnswerDoubleTapAction.NONE;
+    }
+    if (value === 'voteUp') {
+      return AnswerDoubleTapAction.VOTE_UP;
+    }
+    if (value === 'openComments') {
+      return AnswerDoubleTapAction.OPEN_COMMENTS;
+    }
+    if (value === 'toggleImmersive') {
+      return AnswerDoubleTapAction.TOGGLE_IMMERSIVE;
+    }
+  }
+  return AnswerDoubleTapAction.ASK;
+}
+
+export function allAnswerDoubleTapActions(): AnswerDoubleTapAction[] {
+  return [
+    AnswerDoubleTapAction.NONE,
+    AnswerDoubleTapAction.ASK,
+    AnswerDoubleTapAction.VOTE_UP,
+    AnswerDoubleTapAction.OPEN_COMMENTS,
+    AnswerDoubleTapAction.TOGGLE_IMMERSIVE
+  ];
 }
 
 export function appPreferencesFailureMessage(operation: string, error: Object | null | undefined): string {
@@ -93,6 +165,30 @@ export class AppPreferencesStore implements BlockingPreferencesGateway, Notifica
       (): void => {},
       (): void => {}
     );
+    return operation;
+  }
+
+  async loadAnswerDoubleTapAction(): Promise<AnswerDoubleTapAction> {
+    await this.saveQueue;
+    try {
+      const store = await preferences.getPreferences(this.context, PREFERENCES_NAME);
+      return decodeAnswerDoubleTapAction(await store.get(ANSWER_DOUBLE_TAP_ACTION_KEY,
+        answerDoubleTapActionPreferenceValue(AnswerDoubleTapAction.ASK)));
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(appPreferencesFailureMessage('Answer double tap action load', error));
+      }
+      throw new Error(appPreferencesFailureMessage('Answer double tap action load', undefined));
+    }
+  }
+
+  saveAnswerDoubleTapAction(action: AnswerDoubleTapAction): Promise<void> {
+    const normalizedAction = decodeAnswerDoubleTapAction(answerDoubleTapActionPreferenceValue(action));
+    const operation = this.saveQueue.then(
+      (): Promise<void> => this.writeAnswerDoubleTapAction(normalizedAction),
+      (): Promise<void> => this.writeAnswerDoubleTapAction(normalizedAction)
+    );
+    this.saveQueue = operation.then((): void => {}, (): void => {});
     return operation;
   }
 
@@ -139,6 +235,19 @@ export class AppPreferencesStore implements BlockingPreferencesGateway, Notifica
         throw new Error(appPreferencesFailureMessage('Theme mode save', error));
       }
       throw new Error(appPreferencesFailureMessage('Theme mode save', undefined));
+    }
+  }
+
+  private async writeAnswerDoubleTapAction(action: AnswerDoubleTapAction): Promise<void> {
+    try {
+      const store = await preferences.getPreferences(this.context, PREFERENCES_NAME);
+      await store.put(ANSWER_DOUBLE_TAP_ACTION_KEY, answerDoubleTapActionPreferenceValue(action));
+      await store.flush();
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(appPreferencesFailureMessage('Answer double tap action save', error));
+      }
+      throw new Error(appPreferencesFailureMessage('Answer double tap action save', undefined));
     }
   }
 

--- a/data/src/main/ets/preferences/AppPreferencesStore.ets
+++ b/data/src/main/ets/preferences/AppPreferencesStore.ets
@@ -29,6 +29,8 @@ const ANSWER_DOUBLE_TAP_ACTION_KEY = 'answerDoubleTapAction';
 // 键与容量对齐上游搜索历史（searchHistoryQueries，最多 20 条）。
 const SEARCH_HISTORY_KEY = 'searchHistoryQueries';
 export const SEARCH_HISTORY_MAX_SIZE = 20;
+// 键与语义对齐上游 UpdateManager.PREF_LAST_UPDATE_CHECK（自动检查更新节流时间戳，毫秒）。
+const LAST_UPDATE_CHECK_KEY = 'lastUpdateCheck';
 
 function notificationDisplayKey(kind: NotificationKind): string {
   if (kind === NotificationKind.LIKE_COMMENT) {
@@ -268,6 +270,42 @@ export class AppPreferencesStore implements BlockingPreferencesGateway, Notifica
         throw new Error(appPreferencesFailureMessage('Search history save', error));
       }
       throw new Error(appPreferencesFailureMessage('Search history save', undefined));
+    }
+  }
+
+  async loadLastUpdateCheckAt(): Promise<number> {
+    await this.saveQueue;
+    try {
+      const store = await preferences.getPreferences(this.context, PREFERENCES_NAME);
+      const value = await store.get(LAST_UPDATE_CHECK_KEY, 0);
+      return typeof value === 'number' ? value : 0;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(appPreferencesFailureMessage('Last update check load', error));
+      }
+      throw new Error(appPreferencesFailureMessage('Last update check load', undefined));
+    }
+  }
+
+  saveLastUpdateCheckAt(tick: number): Promise<void> {
+    const operation = this.saveQueue.then(
+      (): Promise<void> => this.writeLastUpdateCheckAt(tick),
+      (): Promise<void> => this.writeLastUpdateCheckAt(tick)
+    );
+    this.saveQueue = operation.then((): void => {}, (): void => {});
+    return operation;
+  }
+
+  private async writeLastUpdateCheckAt(tick: number): Promise<void> {
+    try {
+      const store = await preferences.getPreferences(this.context, PREFERENCES_NAME);
+      await store.put(LAST_UPDATE_CHECK_KEY, tick);
+      await store.flush();
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(appPreferencesFailureMessage('Last update check save', error));
+      }
+      throw new Error(appPreferencesFailureMessage('Last update check save', undefined));
     }
   }
 

--- a/data/src/main/ets/preferences/AppPreferencesStore.ets
+++ b/data/src/main/ets/preferences/AppPreferencesStore.ets
@@ -13,6 +13,7 @@ import {
   NotificationSettingsGateway,
   normalizeNotificationPreferences
 } from '../domain/NotificationModels';
+import { JsonArrayValue, JsonStringValue, parseStrictJson } from 'core';
 
 const PREFERENCES_NAME = 'app_preferences';
 const THEME_MODE_KEY = 'theme_mode';
@@ -25,6 +26,9 @@ const NOTIFICATION_AUTO_MARK_READ_KEY = 'notification_auto_mark_as_read';
 const NOTIFICATION_UNREAD_BADGE_KEY = 'notification_unread_badge';
 // 键与存储值对齐上游 answerDoubleTapAction 偏好（"none"/"ask"/"voteUp"/"openComments"/"toggleImmersive"）。
 const ANSWER_DOUBLE_TAP_ACTION_KEY = 'answerDoubleTapAction';
+// 键与容量对齐上游搜索历史（searchHistoryQueries，最多 20 条）。
+const SEARCH_HISTORY_KEY = 'searchHistoryQueries';
+export const SEARCH_HISTORY_MAX_SIZE = 20;
 
 function notificationDisplayKey(kind: NotificationKind): string {
   if (kind === NotificationKind.LIKE_COMMENT) {
@@ -134,8 +138,41 @@ export function appPreferencesFailureMessage(operation: string, error: Object | 
   return `${operation} failed`;
 }
 
-export class AppPreferencesStore implements BlockingPreferencesGateway, NotificationSettingsGateway {
-  private readonly context: common.Context;
+/** 解析历史 JSON（字符串数组）；损坏内容静默丢弃，最多保留 SEARCH_HISTORY_MAX_SIZE 条。 */
+function decodeSearchHistory(value: string): Array<string> {
+  let parsed: Object;
+  try {
+    parsed = parseStrictJson(value);
+  } catch (_error) {
+    return [];
+  }
+  if (!(parsed instanceof JsonArrayValue)) {
+    return [];
+  }
+  const items: Array<string> = [];
+  parsed.items.forEach((item: Object): void => {
+    if (item instanceof JsonStringValue) {
+      const text = item.value.trim();
+      if (text.length > 0 && !items.includes(text)) {
+        items.push(text);
+      }
+    }
+  });
+  return items.slice(0, SEARCH_HISTORY_MAX_SIZE);
+}
+
+function normalizeSearchHistory(history: Array<string>): Array<string> {
+  const items: Array<string> = [];
+  history.forEach((item: string): void => {
+    const text = item.trim();
+    if (text.length > 0 && text.length <= 200 && !items.includes(text)) {
+      items.push(text);
+    }
+  });
+  return items.slice(0, SEARCH_HISTORY_MAX_SIZE);
+}
+
+export class AppPreferencesStore implements BlockingPreferencesGateway, NotificationSettingsGateway {  private readonly context: common.Context;
   private saveQueue: Promise<void> = Promise.resolve();
 
   constructor(context: common.Context) {
@@ -190,6 +227,48 @@ export class AppPreferencesStore implements BlockingPreferencesGateway, Notifica
     );
     this.saveQueue = operation.then((): void => {}, (): void => {});
     return operation;
+  }
+
+  async loadSearchHistory(): Promise<Array<string>> {
+    await this.saveQueue;
+    try {
+      const store = await preferences.getPreferences(this.context, PREFERENCES_NAME);
+      const value = await store.get(SEARCH_HISTORY_KEY, '[]');
+      if (typeof value !== 'string') {
+        return [];
+      }
+      return decodeSearchHistory(value);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(appPreferencesFailureMessage('Search history load', error));
+      }
+      throw new Error(appPreferencesFailureMessage('Search history load', undefined));
+    }
+  }
+
+  saveSearchHistory(history: Array<string>): Promise<void> {
+    const normalized = normalizeSearchHistory(history);
+    const operation = this.saveQueue.then(
+      (): Promise<void> => this.writeSearchHistory(normalized),
+      (): Promise<void> => this.writeSearchHistory(normalized)
+    );
+    this.saveQueue = operation.then((): void => {
+    }, (): void => {
+    });
+    return operation;
+  }
+
+  private async writeSearchHistory(history: Array<string>): Promise<void> {
+    try {
+      const store = await preferences.getPreferences(this.context, PREFERENCES_NAME);
+      await store.put(SEARCH_HISTORY_KEY, JSON.stringify(history));
+      await store.flush();
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(appPreferencesFailureMessage('Search history save', error));
+      }
+      throw new Error(appPreferencesFailureMessage('Search history save', undefined));
+    }
   }
 
   async loadBlockingPreferences(): Promise<BlockingPreferences> {

--- a/data/src/main/ets/repository/DefaultChannelFeedRepository.ets
+++ b/data/src/main/ets/repository/DefaultChannelFeedRepository.ets
@@ -83,11 +83,8 @@ export function buildChannelFeedRequestUrl(source: ChannelFeedSource, cursor?: s
     if (!isDailyFeedDateCursor(cursor)) {
       throw new ChannelFeedRepositoryFailure(ChannelFeedRepositoryFailureKind.INVALID_CURSOR);
     }
-    // The Zhihu Daily endpoint is exclusive: /before/YYYYMMDD returns the
-    // edition before that date. Add one day so a user-selected date is the
-    // edition rendered by the first page; subsequent cursors are returned by
-    // the API and continue to work unchanged.
-    return `${DAILY_PRIMARY_BASE_URL}/before/${dailyBeforeCursor(cursor)}`;
+    // 分页游标是排他日期：直接读取该日期之前的一期。
+    return `${DAILY_PRIMARY_BASE_URL}/before/${cursor}`;
   }
   const sourceUrl = cursor ?? contentBaseUrl(source);
   if (cursor !== undefined && !isChannelFeedCursorUrl(source, cursor)) {
@@ -187,8 +184,14 @@ export class DefaultChannelFeedRepository implements ChannelFeedRepository {
       throw new ChannelFeedRepositoryFailure(ChannelFeedRepositoryFailureKind.SOURCE_CHANGED);
     }
     const requestGeneration = this.generation;
-    const requestUrl = buildChannelFeedRequestUrl(source, cursor);
-    const cursorKey = canonicalChannelFeedCursorKey(source, cursor);
+    // 只有显式选择日期才加一天；按实际请求游标去重，避免选中日期与下一页冲突。
+    if (source === ChannelFeedSource.DAILY && cursor !== undefined && !isDailyFeedDateCursor(cursor)) {
+      throw new ChannelFeedRepositoryFailure(ChannelFeedRepositoryFailureKind.INVALID_CURSOR);
+    }
+    const requestCursor = source === ChannelFeedSource.DAILY && reset && cursor !== undefined
+      ? dailyBeforeCursor(cursor) : cursor;
+    const requestUrl = buildChannelFeedRequestUrl(source, requestCursor);
+    const cursorKey = canonicalChannelFeedCursorKey(source, requestCursor);
     if (cursor !== undefined && !reset && this.requestedCursors.has(cursorKey)) {
       throw new ChannelFeedRepositoryFailure(ChannelFeedRepositoryFailureKind.REPEATED_CURSOR);
     }

--- a/data/src/main/ets/repository/DefaultCommentRepository.ets
+++ b/data/src/main/ets/repository/DefaultCommentRepository.ets
@@ -129,13 +129,9 @@ export function buildDeleteCommentUrl(commentIdValue: string): string {
   return `https://www.zhihu.com/api/v4/comments/${normalizeCommentId(commentIdValue)}`;
 }
 
-/** 评论点赞端点：与上游 ArticleViewModel 的 /voters 语义一致。 */
+/** 评论使用 /like 空请求体；/voters 是回答投票接口，不能用于评论。 */
 export function buildCommentLikeUrl(commentIdValue: string): string {
-  return `https://www.zhihu.com/api/v4/comments/${normalizeCommentId(commentIdValue)}/voters`;
-}
-
-export function buildCommentLikeBody(): string {
-  return JSON.stringify({ type: 'up' });
+  return `https://www.zhihu.com/api/v4/comments/${normalizeCommentId(commentIdValue)}/like`;
 }
 
 export function buildSubmitCommentBody(input: SubmitCommentInput): string {
@@ -293,8 +289,7 @@ export class DefaultCommentRepository implements CommentRepository {
     const requestGeneration = this.generation;
     await this.execute(
       buildCommentLikeUrl(commentId),
-      liked ? ZhihuHttpMethod.POST : ZhihuHttpMethod.DELETE,
-      buildCommentLikeBody()
+      liked ? ZhihuHttpMethod.POST : ZhihuHttpMethod.DELETE
     );
     if (requestGeneration !== this.generation) {
       throw new CommentRepositoryFailure(CommentRepositoryFailureKind.CANCELLED);

--- a/data/src/main/ets/repository/DefaultOnlineHistoryRepository.ets
+++ b/data/src/main/ets/repository/DefaultOnlineHistoryRepository.ets
@@ -1,9 +1,10 @@
 import { OnlineHistoryEntry, OnlineHistoryPage } from '../domain/OnlineHistoryModels';
 import { decodeOnlineHistoryPage } from '../domain/ZhihuOnlineHistoryDecoder';
-import { ZhihuHttpClient, ZhihuHttpResponse } from '../network/ZhihuHttpClient';
+import { ZhihuHttpClient, ZhihuHttpMethod, ZhihuHttpResponse } from '../network/ZhihuHttpClient';
 import { OnlineHistoryRepository } from './OnlineHistoryRepository';
 
 export const ONLINE_HISTORY_BASE_URL = 'https://www.zhihu.com/api/v4/unify-consumption/read_history';
+export const ONLINE_HISTORY_BATCH_DEL_URL = 'https://api.zhihu.com/read_history/batch_del';
 export const ONLINE_HISTORY_LIMIT: number = 10;
 export const ONLINE_HISTORY_MAX_OFFSET: number = 100000;
 const ONLINE_HISTORY_CURSOR_MAX_LENGTH: number = 4096;
@@ -11,6 +12,7 @@ const ONLINE_HISTORY_CURSOR_MAX_LENGTH: number = 4096;
 export enum OnlineHistoryRepositoryFailureKind {
   INVALID_CURSOR = 'invalid_cursor',
   REPEATED_CURSOR = 'repeated_cursor',
+  INVALID_CONTENT_KEY = 'invalid_content_key',
   CANCELLED = 'cancelled'
 }
 
@@ -23,11 +25,39 @@ export class OnlineHistoryRepositoryFailure extends Error {
       message = '在线历史分页地址不受信任';
     } else if (kind === OnlineHistoryRepositoryFailureKind.REPEATED_CURSOR) {
       message = '在线历史分页游标已被请求';
+    } else if (kind === OnlineHistoryRepositoryFailureKind.INVALID_CONTENT_KEY) {
+      message = '在线历史记录标识无效';
     }
     super(message);
     this.name = 'OnlineHistoryRepositoryFailure';
     this.kind = kind;
   }
+}
+
+/** 对齐上游 OnlineHistoryDeletePair：batch_del 请求的最小删除单元。 */
+export interface OnlineHistoryDeletePair {
+  contentToken: string;
+  contentType: string;
+}
+
+export function buildBatchDelBody(pairs: Array<OnlineHistoryDeletePair>, clear: boolean): string {
+  const encodedPairs = pairs.map((pair: OnlineHistoryDeletePair): string =>
+    `{"content_token":"${pair.contentToken}","content_type":"${pair.contentType}"}`);
+  return `{"pairs":[${encodedPairs.join(',')}],"clear":${clear ? 'true' : 'false'}}`;
+}
+
+/** contentKey 形如 "answer:123456"；与解码器 decodeEntry 的 `${kind}:${id}` 约定一致。 */
+export function onlineHistoryDeletePairOf(contentKey: string): OnlineHistoryDeletePair {
+  const separator = contentKey.indexOf(':');
+  if (separator <= 0 || separator !== contentKey.lastIndexOf(':')) {
+    throw new OnlineHistoryRepositoryFailure(OnlineHistoryRepositoryFailureKind.INVALID_CONTENT_KEY);
+  }
+  const contentType = contentKey.substring(0, separator);
+  const contentToken = contentKey.substring(separator + 1);
+  if (!/^(?:question|answer|article|pin)$/.test(contentType) || !/^[1-9][0-9]{0,29}$/.test(contentToken)) {
+    throw new OnlineHistoryRepositoryFailure(OnlineHistoryRepositoryFailureKind.INVALID_CONTENT_KEY);
+  }
+  return { contentToken: contentToken, contentType: contentType };
 }
 
 export function buildOnlineHistoryUrl(offset: number): string {
@@ -179,6 +209,39 @@ export class DefaultOnlineHistoryRepository implements OnlineHistoryRepository {
       }
     };
     return cursorLoops ? terminalCursor(page) : page;
+  }
+
+  async clearAll(): Promise<void> {
+    const requestGeneration = this.generation;
+    await this.httpClient.execute({
+      url: ONLINE_HISTORY_BATCH_DEL_URL,
+      method: ZhihuHttpMethod.POST,
+      body: buildBatchDelBody([], true),
+      accept: 'application/json',
+      useSession: true,
+      signWithZse: true
+    });
+    if (requestGeneration !== this.generation) {
+      throw new OnlineHistoryRepositoryFailure(OnlineHistoryRepositoryFailureKind.CANCELLED);
+    }
+    this.requestedCursors = new Set<string>();
+    this.deliveredIdentities = new Set<string>();
+  }
+
+  async deleteEntry(contentKey: string): Promise<void> {
+    const pair = onlineHistoryDeletePairOf(contentKey);
+    const requestGeneration = this.generation;
+    await this.httpClient.execute({
+      url: ONLINE_HISTORY_BATCH_DEL_URL,
+      method: ZhihuHttpMethod.POST,
+      body: buildBatchDelBody([pair], false),
+      accept: 'application/json',
+      useSession: true,
+      signWithZse: true
+    });
+    if (requestGeneration !== this.generation) {
+      throw new OnlineHistoryRepositoryFailure(OnlineHistoryRepositoryFailureKind.CANCELLED);
+    }
   }
 }
 

--- a/data/src/main/ets/repository/DefaultRecentFollowingUsersRepository.ets
+++ b/data/src/main/ets/repository/DefaultRecentFollowingUsersRepository.ets
@@ -1,0 +1,34 @@
+import { RecentFollowingUser } from '../domain/ChannelFeedModels';
+import { decodeRecentFollowingUsers } from '../domain/ZhihuChannelFeedDecoder';
+import { ZhihuHttpClient } from '../network/ZhihuHttpClient';
+import { RecentFollowingUsersRepository } from './RecentFollowingUsersRepository';
+
+export const RECENT_FOLLOWING_USERS_URL = 'https://api.zhihu.com/moments/recent?type=raw';
+
+export class DefaultRecentFollowingUsersRepository implements RecentFollowingUsersRepository {
+  private readonly httpClient: ZhihuHttpClient;
+  private generation: number = 0;
+
+  constructor(httpClient: ZhihuHttpClient = new ZhihuHttpClient()) {
+    this.httpClient = httpClient;
+  }
+
+  cancel(): void {
+    this.generation += 1;
+    this.httpClient.cancel();
+  }
+
+  async loadRecentUsers(): Promise<Array<RecentFollowingUser>> {
+    const generation = this.generation;
+    const response = await this.httpClient.execute({
+      url: RECENT_FOLLOWING_USERS_URL,
+      accept: 'application/json',
+      useSession: true,
+      signWithZse: true
+    });
+    if (generation !== this.generation) {
+      return [];
+    }
+    return decodeRecentFollowingUsers(response.body);
+  }
+}

--- a/data/src/main/ets/repository/DefaultSearchRepository.ets
+++ b/data/src/main/ets/repository/DefaultSearchRepository.ets
@@ -1,7 +1,19 @@
 import { PageCursor } from '../domain/DomainModels';
 import { ContentBlockingMatcher, ContentBlockingSession } from '../data/BlockingRuleStore';
-import { SearchResultItem, SearchResultPage, searchResultIdentity } from '../domain/SearchModels';
-import { decodeSearchResultPage } from '../domain/ZhihuSearchDecoder';
+import {
+  areDefaultSearchFilters,
+  defaultSearchFilters,
+  SearchEntity,
+  SearchEntityKind,
+  SearchResultPage,
+  searchEntityIdentity,
+  SearchFilters,
+  SearchHotItem,
+  SearchSortOption,
+  SearchTab,
+  SearchTimeRange
+} from '../domain/SearchModels';
+import { decodeSearchHotList, decodeSearchResultPage } from '../domain/ZhihuSearchDecoder';
 import { ZhihuHttpClient, ZhihuHttpResponse } from '../network/ZhihuHttpClient';
 import { SearchRepository } from './SearchRepository';
 
@@ -10,8 +22,11 @@ export const SEARCH_INCLUDE =
     'object.question.bound_topic_ids';
 const SEARCH_INCLUDE_QUERY = `include=${encodeURIComponent(SEARCH_INCLUDE).replace(/\*/g, '%2A')}`;
 const SEARCH_BASE_URL = 'https://www.zhihu.com/api/v4/search_v3';
+const HOT_SEARCH_URL = 'https://www.zhihu.com/api/v4/search/hot_search';
 const SEARCH_QUERY_MAX_LENGTH = 200;
 const SEARCH_CURSOR_MAX_LENGTH = 4096;
+/** 对齐上游 SEARCH_VERTICAL_INFO：vertical 筛选的固定伴随参数。 */
+const SEARCH_VERTICAL_INFO = '0,0,0,0,0,0,0,0,0,0,0,0';
 
 export enum SearchRepositoryFailureKind {
   INVALID_QUERY = 'invalid_query',
@@ -47,20 +62,94 @@ export function normalizeSearchQuery(query: string): string {
   return normalized;
 }
 
-export function buildInitialSearchUrl(query: string): string {
+/** t 参数：回答/文章 tab 复用 general 接口，由 vertical 区分内容类型（对齐上游）。 */
+export function searchTabParameter(tab: SearchTab): string {
+  if (tab === SearchTab.PEOPLE) {
+    return 'people';
+  }
+  if (tab === SearchTab.TOPIC) {
+    return 'topic';
+  }
+  return 'general';
+}
+
+export function searchVerticalParameter(tab: SearchTab): string {
+  if (tab === SearchTab.ANSWER) {
+    return 'answer';
+  }
+  if (tab === SearchTab.ARTICLE) {
+    return 'article';
+  }
+  return '';
+}
+
+export function searchSortParameter(sort: SearchSortOption): string {
+  if (sort === SearchSortOption.LATEST) {
+    return 'created_time';
+  }
+  if (sort === SearchSortOption.MOST_VOTED) {
+    return 'upvoted_count';
+  }
+  return '';
+}
+
+export function searchTimeRangeParameter(range: SearchTimeRange): string {
+  if (range === SearchTimeRange.DAY) {
+    return 'a_day';
+  }
+  if (range === SearchTimeRange.WEEK) {
+    return 'a_week';
+  }
+  if (range === SearchTimeRange.MONTH) {
+    return 'a_month';
+  }
+  if (range === SearchTimeRange.THREE_MONTHS) {
+    return 'three_months';
+  }
+  if (range === SearchTimeRange.HALF_YEAR) {
+    return 'half_a_year';
+  }
+  if (range === SearchTimeRange.YEAR) {
+    return 'a_year';
+  }
+  return '';
+}
+
+export function buildInitialSearchUrl(query: string, filters: SearchFilters = defaultSearchFilters(),
+  tab: SearchTab = SearchTab.GENERAL): string {
   const normalized = normalizeSearchQuery(query);
+  // 对齐上游：排序/时间筛选只在内容类 tab 生效，用户/话题 tab 忽略（服务端不支持该组合）。
+  const activeFilters = isContentSearchTab(tab) ? filters : defaultSearchFilters();
   const parameters: Array<string> = [
     'gk_version=gz-gaokao',
-    't=general',
+    `t=${searchTabParameter(tab)}`,
     `q=${encodeSearchValue(normalized)}`,
     'correction=1',
     'offset=0',
     'limit=20',
-    'search_source=Normal',
-    'show_all_topics=0',
-    SEARCH_INCLUDE_QUERY
+    `search_source=${areDefaultSearchFilters(activeFilters) && searchVerticalParameter(tab).length === 0
+      ? 'Normal' : 'Filter'}`,
+    `show_all_topics=${tab === SearchTab.TOPIC ? '1' : '0'}`
   ];
+  const vertical = searchVerticalParameter(tab);
+  if (vertical.length > 0) {
+    parameters.push(`vertical=${vertical}`, `vertical_info=${SEARCH_VERTICAL_INFO}`);
+  }
+  const sort = searchSortParameter(activeFilters.sort);
+  if (sort.length > 0) {
+    parameters.push(`sort=${sort}`);
+  }
+  const timeInterval = searchTimeRangeParameter(activeFilters.timeRange);
+  if (timeInterval.length > 0) {
+    parameters.push(`time_interval=${timeInterval}`);
+  }
+  parameters.push(SEARCH_INCLUDE_QUERY);
   return `${SEARCH_BASE_URL}?${parameters.join('&')}`;
+}
+
+/** 内容类 tab（综合/回答/文章）：t=general，支持排序与时间筛选。 */
+export function isContentSearchTab(tab: SearchTab): boolean {
+  return searchTabParameter(tab) === 'general';
 }
 
 export function isSearchCursorUrl(url: string): boolean {
@@ -72,16 +161,17 @@ export function isSearchCursorUrl(url: string): boolean {
     /^https:\/\/api\.zhihu\.com\/search_v3\?[^#]+$/.test(url);
 }
 
-export function buildSearchRequestUrl(query: string, cursor?: string): string {
+export function buildSearchRequestUrl(query: string, filters: SearchFilters = defaultSearchFilters(),
+  tab: SearchTab = SearchTab.GENERAL, cursor?: string): string {
   const normalizedQuery = normalizeSearchQuery(query);
   if (cursor === undefined) {
-    return buildInitialSearchUrl(normalizedQuery);
+    return buildInitialSearchUrl(normalizedQuery, filters, tab);
   }
   const parameters = decodeSearchCursor(cursor);
   const queryValues = parameters.filter((entry: SearchQueryEntry): boolean => entry.name === 'q');
   const typeValues = parameters.filter((entry: SearchQueryEntry): boolean => entry.name === 't');
   if (queryValues.length !== 1 || queryValues[0].value !== normalizedQuery ||
-    typeValues.length !== 1 || typeValues[0].value !== 'general') {
+    typeValues.length !== 1 || typeValues[0].value !== searchTabParameter(tab)) {
     throw new SearchRepositoryFailure(SearchRepositoryFailureKind.INVALID_CURSOR);
   }
   const preserved: Array<string> = [];
@@ -94,8 +184,9 @@ export function buildSearchRequestUrl(query: string, cursor?: string): string {
   return `${SEARCH_BASE_URL}?${preserved.join('&')}`;
 }
 
-export function canonicalSearchCursorKey(query: string, cursor?: string): string {
-  const requestUrl = buildSearchRequestUrl(query, cursor);
+export function canonicalSearchCursorKey(query: string, filters: SearchFilters = defaultSearchFilters(),
+  tab: SearchTab = SearchTab.GENERAL, cursor?: string): string {
+  const requestUrl = buildSearchRequestUrl(query, filters, tab, cursor);
   const parts = requestUrl.substring(requestUrl.indexOf('?') + 1).split('&');
   parts.sort();
   return `${SEARCH_BASE_URL}?${parts.join('&')}`;
@@ -167,14 +258,15 @@ export class DefaultSearchRepository implements SearchRepository {
     this.httpClient.cancel();
   }
 
-  async search(query: string, cursor?: string): Promise<SearchResultPage> {
+  async search(query: string, filters: SearchFilters = defaultSearchFilters(),
+    tab: SearchTab = SearchTab.GENERAL, cursor?: string): Promise<SearchResultPage> {
     const normalizedQuery = normalizeSearchQuery(query);
     if (cursor !== undefined && this.activeQuery !== normalizedQuery) {
       throw new SearchRepositoryFailure(SearchRepositoryFailureKind.INVALID_CURSOR);
     }
     const requestGeneration = this.generation;
-    const requestUrl = buildSearchRequestUrl(normalizedQuery, cursor);
-    const cursorKey = canonicalSearchCursorKey(normalizedQuery, cursor);
+    const requestUrl = buildSearchRequestUrl(normalizedQuery, filters, tab, cursor);
+    const cursorKey = canonicalSearchCursorKey(normalizedQuery, filters, tab, cursor);
     if (cursor !== undefined && this.requestedCursors.has(cursorKey)) {
       throw new SearchRepositoryFailure(SearchRepositoryFailureKind.REPEATED_CURSOR);
     }
@@ -188,10 +280,15 @@ export class DefaultSearchRepository implements SearchRepository {
       throw new SearchRepositoryFailure(SearchRepositoryFailureKind.CANCELLED);
     }
     const decoded = decodeSearchResultPage(response.body);
-    let visibleItems = decoded.items;
+    let visibleEntities = decoded.entities;
     if (this.blockingMatcher !== undefined) {
       const blockingSession: ContentBlockingSession = await this.blockingMatcher.createSession();
-      visibleItems = decoded.items.filter((item: SearchResultItem): boolean => {
+      visibleEntities = decoded.entities.filter((entity: SearchEntity): boolean => {
+        // 内容实体参与屏蔽匹配；用户/话题结果不作为内容屏蔽对象（对齐上游仅过滤内容 feed）。
+        if (entity.kind !== SearchEntityKind.CONTENT || entity.content === undefined) {
+          return true;
+        }
+        const item = entity.content;
         return blockingSession.match(item.authorId === undefined ? {
           title: item.title,
           excerpt: item.excerpt,
@@ -208,12 +305,13 @@ export class DefaultSearchRepository implements SearchRepository {
       throw new SearchRepositoryFailure(SearchRepositoryFailureKind.CANCELLED);
     }
     const next = decoded.cursor.next;
-    const nextKey = next === undefined ? undefined : canonicalSearchCursorKey(normalizedQuery, next);
+    const nextKey = next === undefined ? undefined : canonicalSearchCursorKey(normalizedQuery, filters,
+      tab, next);
     const requested = cursor === undefined ? new Set<string>() : cloneStringSet(this.requestedCursors);
     const delivered = cursor === undefined ? new Set<string>() : cloneStringSet(this.deliveredIdentities);
     requested.add(cursorKey);
-    const items = visibleItems.filter((item: SearchResultItem): boolean => {
-      const identity = searchResultIdentity(item);
+    const entities = visibleEntities.filter((entity: SearchEntity): boolean => {
+      const identity = searchEntityIdentity(entity);
       if (delivered.has(identity)) {
         return false;
       }
@@ -226,9 +324,23 @@ export class DefaultSearchRepository implements SearchRepository {
     this.requestedCursors = requested;
     this.deliveredIdentities = delivered;
     return {
-      items: items,
+      entities: entities,
       cursor: cursorLoops ? terminalCursor(decoded.cursor) : decoded.cursor
     };
+  }
+
+  async hotSearch(): Promise<Array<SearchHotItem>> {
+    const requestGeneration = this.generation;
+    const response: ZhihuHttpResponse = await this.httpClient.execute({
+      url: HOT_SEARCH_URL,
+      accept: 'application/json',
+      useSession: true,
+      signWithZse: true
+    });
+    if (requestGeneration !== this.generation) {
+      throw new SearchRepositoryFailure(SearchRepositoryFailureKind.CANCELLED);
+    }
+    return decodeSearchHotList(response.body);
   }
 }
 

--- a/data/src/main/ets/repository/OnlineHistoryRepository.ets
+++ b/data/src/main/ets/repository/OnlineHistoryRepository.ets
@@ -2,5 +2,9 @@ import { OnlineHistoryPage } from '../domain/OnlineHistoryModels';
 
 export interface OnlineHistoryRepository {
   loadPage(cursor?: string): Promise<OnlineHistoryPage>;
+  /** 对齐上游 clearAllHistory：batch_del(clear=true) 清空服务端全部浏览历史。 */
+  clearAll(): Promise<void>;
+  /** 对齐上游 deleteItem：batch_del 单条删除，contentKey 形如 "answer:123456"。 */
+  deleteEntry(contentKey: string): Promise<void>;
   cancel(): void;
 }

--- a/data/src/main/ets/repository/QuestionAnswerFeedRepository.ets
+++ b/data/src/main/ets/repository/QuestionAnswerFeedRepository.ets
@@ -1,0 +1,192 @@
+import { PageCursor, feedItemIdentity } from '../domain/DomainModels';
+import {
+  ChannelContentItem,
+  ChannelFeedItem,
+  ChannelFeedItemKind
+} from '../domain/ChannelFeedModels';
+import { decodeQuestionAnswerFeedPage } from '../domain/ZhihuChannelFeedDecoder';
+import {
+  BlockableContentSummary,
+  ContentBlockingMatcher,
+  ContentBlockingSession
+} from '../data/BlockingRuleStore';
+import { normalizeContentId } from './DefaultContentRepository';
+import { ZhihuHttpClient } from '../network/ZhihuHttpClient';
+
+/** 问题回答信息流排序：对齐上游 QuestionFeedViewModel 的 order 参数。 */
+export enum QuestionAnswerSortOrder {
+  DEFAULT = 'default',
+  UPDATED = 'updated'
+}
+
+export const QUESTION_ANSWER_FEED_BASE_URL = 'https://www.zhihu.com/api/v4/questions';
+export const QUESTION_ANSWER_FEED_LIMIT = 20;
+
+export enum QuestionAnswerFeedFailureKind {
+  INVALID_CURSOR = 'invalid_cursor',
+  REPEATED_CURSOR = 'repeated_cursor',
+  CANCELLED = 'cancelled'
+}
+
+export class QuestionAnswerFeedFailure extends Error {
+  readonly kind: QuestionAnswerFeedFailureKind;
+
+  constructor(kind: QuestionAnswerFeedFailureKind) {
+    let message = '回答请求已取消';
+    if (kind === QuestionAnswerFeedFailureKind.INVALID_CURSOR) {
+      message = '回答信息流返回了不受信任的分页游标';
+    } else if (kind === QuestionAnswerFeedFailureKind.REPEATED_CURSOR) {
+      message = '回答信息流分页游标已被请求';
+    }
+    super(message);
+    this.name = 'QuestionAnswerFeedFailure';
+    this.kind = kind;
+  }
+}
+
+/** 问题回答信息流分页结果（条目恒为内容型，target 为回答）。 */
+export interface QuestionAnswerFeedPage {
+  readonly items: Array<ChannelContentItem>;
+  readonly cursor: PageCursor;
+}
+
+export interface QuestionAnswerFeedRepository {
+  loadPage(questionId: string, order: QuestionAnswerSortOrder, cursor?: string, reset?: boolean):
+    Promise<QuestionAnswerFeedPage>;
+  cancel(): void;
+}
+
+export function isQuestionAnswerFeedCursorUrl(questionId: string, cursor: string): boolean {
+  if (/[\u0000-\u0020\u007F-\uFFFF]/.test(cursor)) {
+    return false;
+  }
+  return new RegExp(`^https://www\\.zhihu\\.com/api/v4/questions/${questionId}/feeds(?:\\?[^#]*)?$`)
+    .test(cursor);
+}
+
+export function buildQuestionAnswerFeedRequestUrl(questionId: string, order: QuestionAnswerSortOrder,
+  cursor?: string): string {
+  const id = normalizeContentId(questionId);
+  if (cursor !== undefined) {
+    if (!isQuestionAnswerFeedCursorUrl(id, cursor)) {
+      throw new QuestionAnswerFeedFailure(QuestionAnswerFeedFailureKind.INVALID_CURSOR);
+    }
+    return cursor;
+  }
+  return `${QUESTION_ANSWER_FEED_BASE_URL}/${id}/feeds?limit=${QUESTION_ANSWER_FEED_LIMIT}&order=${order}`;
+}
+
+function cloneStringSet(source: Set<string>): Set<string> {
+  const copy = new Set<string>();
+  source.forEach((value: string): void => {
+    copy.add(value);
+  });
+  return copy;
+}
+
+export class DefaultQuestionAnswerFeedRepository implements QuestionAnswerFeedRepository {
+  private readonly httpClient: ZhihuHttpClient;
+  private readonly blockingMatcher?: ContentBlockingMatcher;
+  private generation: number = 0;
+  private requestedCursorKeys: Set<string> = new Set<string>();
+  private deliveredIdentities: Set<string> = new Set<string>();
+
+  constructor(httpClient: ZhihuHttpClient = new ZhihuHttpClient(), blockingMatcher?: ContentBlockingMatcher) {
+    this.httpClient = httpClient;
+    this.blockingMatcher = blockingMatcher;
+  }
+
+  cancel(): void {
+    this.generation += 1;
+    this.httpClient.cancel();
+  }
+
+  async loadPage(questionId: string, order: QuestionAnswerSortOrder, cursor?: string, reset: boolean = false):
+    Promise<QuestionAnswerFeedPage> {
+    const requestGeneration = this.generation;
+    const requestUrl = buildQuestionAnswerFeedRequestUrl(questionId, order, cursor);
+    if (cursor !== undefined && !reset && this.requestedCursorKeys.has(requestUrl)) {
+      throw new QuestionAnswerFeedFailure(QuestionAnswerFeedFailureKind.REPEATED_CURSOR);
+    }
+
+    const response = await this.httpClient.execute({
+      url: requestUrl,
+      accept: 'application/json',
+      useSession: true,
+      signWithZse: true
+    });
+    if (requestGeneration !== this.generation) {
+      throw new QuestionAnswerFeedFailure(QuestionAnswerFeedFailureKind.CANCELLED);
+    }
+    const decoded = decodeQuestionAnswerFeedPage(response.body);
+    if (requestGeneration !== this.generation) {
+      throw new QuestionAnswerFeedFailure(QuestionAnswerFeedFailureKind.CANCELLED);
+    }
+    const contentItems: Array<ChannelContentItem> = [];
+    decoded.items.forEach((item: ChannelFeedItem): void => {
+      if (item.kind === ChannelFeedItemKind.CONTENT) {
+        contentItems.push(item);
+      }
+    });
+    const visible = await this.filterBlockedItems(contentItems);
+    if (requestGeneration !== this.generation) {
+      throw new QuestionAnswerFeedFailure(QuestionAnswerFeedFailureKind.CANCELLED);
+    }
+    const next = decoded.cursor.next;
+    if (next !== undefined && !isQuestionAnswerFeedCursorUrl(normalizeContentId(questionId), next)) {
+      throw new QuestionAnswerFeedFailure(QuestionAnswerFeedFailureKind.INVALID_CURSOR);
+    }
+    const requested = cursor === undefined || reset ? new Set<string>() : cloneStringSet(this.requestedCursorKeys);
+    const delivered = cursor === undefined || reset ? new Set<string>() : cloneStringSet(this.deliveredIdentities);
+    requested.add(requestUrl);
+    const items: Array<ChannelContentItem> = [];
+    visible.forEach((item: ChannelContentItem): void => {
+      const identity = feedItemIdentity(item.feedItem);
+      if (delivered.has(identity)) {
+        return;
+      }
+      delivered.add(identity);
+      items.push(item);
+    });
+    this.requestedCursorKeys = requested;
+    this.deliveredIdentities = delivered;
+    const nextRepeated = next !== undefined && requested.has(next);
+    const cursorLoops = (next === undefined && !decoded.cursor.isEnd) || nextRepeated;
+    return {
+      items: items,
+      cursor: cursorLoops ? {
+        isEnd: true,
+        isStart: decoded.cursor.isStart,
+        previous: decoded.cursor.previous,
+        page: decoded.cursor.page,
+        total: decoded.cursor.total
+      } : decoded.cursor
+    };
+  }
+
+  private async filterBlockedItems(items: Array<ChannelContentItem>): Promise<Array<ChannelContentItem>> {
+    const matcher = this.blockingMatcher;
+    if (matcher === undefined) {
+      return items;
+    }
+    const session: ContentBlockingSession = await matcher.createSession();
+    const visible: Array<ChannelContentItem> = [];
+    items.forEach((item: ChannelContentItem): void => {
+      const authorId = item.feedItem.target.author?.id;
+      const summary: BlockableContentSummary = authorId === undefined ? {
+        title: item.feedItem.target.title,
+        excerpt: item.feedItem.target.excerpt,
+        topicIds: item.topicIds
+      } : {
+        title: item.feedItem.target.title,
+        excerpt: item.feedItem.target.excerpt,
+        authorId: authorId,
+        topicIds: item.topicIds
+      };
+      if (session.match(summary) === undefined) {
+        visible.push(item);
+      }
+    });
+    return visible;
+  }
+}

--- a/data/src/main/ets/repository/RecentFollowingUsersRepository.ets
+++ b/data/src/main/ets/repository/RecentFollowingUsersRepository.ets
@@ -1,0 +1,7 @@
+import { RecentFollowingUser } from '../domain/ChannelFeedModels';
+
+/** 关注推荐页顶部“最近更新的关注用户”一行，行为对齐上游 RecentMomentsViewModel。 */
+export interface RecentFollowingUsersRepository {
+  loadRecentUsers(): Promise<Array<RecentFollowingUser>>;
+  cancel(): void;
+}

--- a/data/src/main/ets/repository/SearchRepository.ets
+++ b/data/src/main/ets/repository/SearchRepository.ets
@@ -1,6 +1,7 @@
-import { SearchResultPage } from '../domain/SearchModels';
+import { SearchFilters, SearchHotItem, SearchTab, SearchResultPage } from '../domain/SearchModels';
 
 export interface SearchRepository {
-  search(query: string, cursor?: string): Promise<SearchResultPage>;
+  search(query: string, filters?: SearchFilters, tab?: SearchTab, cursor?: string): Promise<SearchResultPage>;
+  hotSearch(): Promise<Array<SearchHotItem>>;
   cancel(): void;
 }

--- a/data/src/main/ets/update/AppUpdateParser.ets
+++ b/data/src/main/ets/update/AppUpdateParser.ets
@@ -79,6 +79,22 @@ export function decodeLatestRelease(payload: string): AppUpdateRelease | undefin
   return release;
 }
 
+/** 自动检查更新的节流间隔，对齐上游 UpdateManager 的 3 小时。 */
+export const AUTO_UPDATE_CHECK_INTERVAL_MS: number = 3 * 60 * 60 * 1000;
+
+/** 距上次检查超过节流间隔才允许自动检查（对齐上游 shouldPerformAutoCheck）；从未检查或时钟回拨视为到期。 */
+export function shouldAutoCheckForUpdate(lastUpdateCheckAt: number, now: number): boolean {
+  if (lastUpdateCheckAt <= 0) {
+    return true;
+  }
+  return now - lastUpdateCheckAt >= AUTO_UPDATE_CHECK_INTERVAL_MS;
+}
+
+/** 首页更新卡片可见性：有待更新版本且未在本次会话内被“以后”忽略。 */
+export function isUpdateAnnouncementVisible(pendingVersion: string, dismissedVersion: string): boolean {
+  return pendingVersion.length > 0 && pendingVersion !== dismissedVersion;
+}
+
 /** 结合本机版本得出检测结论：本机不比远端新时视为已是最新。 */
 export function resolveAppUpdateCheck(localVersionName: string, release: AppUpdateRelease | undefined,
   message: string): AppUpdateCheckResult {

--- a/docs/harmonyos-migration-plan.md
+++ b/docs/harmonyos-migration-plan.md
@@ -3,9 +3,9 @@
 > 状态：规划稿<br>
 > 制定日期：2026-07-20<br>
 > 迁移基线：Android Lite 版本<br>
-> 开发工具：DevEco Studio 6.1.1 Release<br>
-> HarmonyOS SDK：26.0.0（API 26）<br>
-> 目标兼容版本：HarmonyOS 26.0.0（API 26）<br>
+> 开发工具：DevEco Studio 26.0.0 Beta2<br>
+> HarmonyOS SDK（编译）：26.0.0（API 26）<br>
+> 目标版本：HarmonyOS 26.0.0（API 26）；最低兼容：HarmonyOS 6.1.0（API 23）<br>
 > 目标分支：`dev`（开发）、`main`（发布）<br>
 > Android 上游镜像：`Android-master`
 
@@ -26,9 +26,9 @@
 
 ## 2. 目标平台与官方技术基线
 
-- 开发工具固定为 DevEco Studio 6.1.1 Release。
-- HarmonyOS 开发、运行与验证主基线固定为 26.0.0（API 26）。工程的 `targetSdkVersion` 与 `compatibleSdkVersion` 均使用 API 26，编译环境使用 DevEco Studio 的 API 26 SDK。
-- 不再维护 API 24 或更低版本的兼容路径；设备验收只在 `ZhihuPlus_API26` 模拟器与后续 API 26 设备上进行。
+- 开发工具为 DevEco Studio 26.0.0 Beta2，配套 HarmonyOS 26.0.0（API 26）编译 SDK；工程不显式配置 `compileSdkVersion`，实际编译 SDK 由 Studio 配套 SDK 决定。
+- 版本矩阵为「API 26 编译 + API 26 目标行为 + API 23 最低兼容」：`targetSdkVersion` 为 `26.0.0`，`compatibleSdkVersion` 为 `6.1.0(23)`，最低支持 HarmonyOS 6.1.0（API 23）设备。
+- 设备验收主基线为 `ZhihuPlus_API26` 模拟器与 API 26 设备，API 23 真机承担最低兼容抽验；API 26 专属能力（如 `uiMaterial` 全家族）禁止无门禁直接使用，需以版本门禁或 HDS 组件兜底，避免 API 23 设备载入即崩。
 - 使用 Stage 模型。
 - 第一阶段支持 Phone，随后适配 Tablet、折叠屏和自由窗口。
 - 开发语言为 ArkTS，UI 使用 ArkUI 声明式范式。
@@ -49,6 +49,8 @@
 从 2026-08-10 起，版本矩阵收敛为 API 24 单一基线：开发、编译、目标行为、最低兼容和设备回归均只考虑 API 24。DevEco Studio 6.1.1 官方模板不单独写 `compileSdkVersion`；实际编译 SDK 由构建环境中的 API 24 SDK 决定。此前 API 20 的实验结果保留为历史记录，但不再约束新实现，也不再要求 API 20 降级路径。
 
 从 2026-08-25 起，P4 将版本矩阵升级为 API 26 单一基线：`targetSdkVersion`、`compatibleSdkVersion`、构建和设备验收统一为 API 26。此前 API 24 的阶段记录保留为历史证据，不再构成后续 P4 的实现或验收约束。
+
+从 2026-08-30 起，最低兼容版本放宽至 HarmonyOS 6.1.0（API 23）：`targetSdkVersion` 保持 `26.0.0`，`compatibleSdkVersion` 调整为 `6.1.0(23)`，编译 SDK 仍为 API 26。版本矩阵从「API 26 单一基线」变为「API 26 编译与目标行为 + API 23 最低兼容」；API 26 专属接口必须带版本门禁或降级路径（如 `uiMaterial` 全家族禁止直接 import，普通玻璃效果用 `backgroundBlurStyle` 兜底、系统材质走 HDS 组件）。注意 API 10–25 的版本值必须使用 `'X.Y.Z(N)'` 旧格式，`'26.0.0'` 新格式仅 API 26+ 合法。编译/兼容版本拆分背景见 [`docs/api26-api24-migration-plan.md`](api26-api24-migration-plan.md)。
 
 ## 3. AI 能力边界
 
@@ -403,7 +405,7 @@ P0 阶段结论（2026-08-10）：TaskPool 只解决并发计算，不提供后�
 
 执行切片、依赖顺序和验收门禁见 [`docs/p4/p4-slicing-plan.md`](p4/p4-slicing-plan.md)。
 
-状态（2026-08-26）：P4-0～P4-7 的 API 26 生产接线、自动化和无写入模拟器回归已完成；回答/想法图片发布链路受最终确认保护，自动化 Hypium `516/516` 通过，签名 HAP 为 `target=26`、`compatible=26`。真实发布、真实 OSS 上传、电脑端登录确认、真实视频和外部分享会改变外部状态，只由用户在专用测试目标手动验收；P4-8 以 TTS 可行性后置结论收口。详见 [`p4-api26-final-validation.md`](p4/p4-api26-final-validation.md)。
+状态（2026-08-26）：P4-0～P4-7 的 API 26 生产接线、自动化和无写入模拟器回归已完成；回答/想法图片发布链路受最终确认保护，自动化 Hypium `516/516` 通过，签名 HAP 为 `target=26`、`compatible=26`（2026-08-30 起 `compatibleSdkVersion` 已放宽至 `6.1.0(23)`，见第 2 节）。真实发布、真实 OSS 上传、电脑端登录确认、真实视频和外部分享会改变外部状态，只由用户在专用测试目标手动验收；P4-8 以 TTS 可行性后置结论收口。详见 [`p4-api26-final-validation.md`](p4/p4-api26-final-validation.md)。
 
 - 写回答和写想法
 - 草稿恢复

--- a/docs/upstream-question-page-migration-study.md
+++ b/docs/upstream-question-page-migration-study.md
@@ -1,0 +1,218 @@
+# 上游问题详情页实现剖析与鸿蒙端仿制指南
+
+> 研究日期：2026-08-31<br>
+> 上游基线：zly2006/zhihu-plus-plus，快照 `22f6313c`（#716；问题页自研究快照 `ec77d309` 以来仅 #701
+> 改了一处回答切换状态的获取方式，页面结构与数据协议未变）<br>
+> 本侧基线：`dev` `a70b983e`（问题详情页已具备标题/统计/正文渲染、关注、问题评论、底栏对齐回答页）<br>
+> 范围：剖析上游问题详情页（QuestionScreen）的独立实现，给出鸿蒙 ArkTS/ArkUI 端的仿制方案、
+> 图标映射（已逐一验证）与实施步骤；不含代码实施。
+
+## 实施状态（2026-09-04）
+
+本文所列 P1、P2、P3 已在鸿蒙端完成：
+
+- **P1**：问题回答 feeds、真实线格式解码、登录门禁、屏蔽过滤、游标分页、空页续拉、
+  下拉刷新、默认/最新排序、与正文贯通的单一懒加载列表、共享回答卡片内容组件均已落地；
+- **P2**：标题可复制、浏览/关注/评论图标统计、topics 解码和话题胶囊、写回答入口、
+  180vp 正文折叠视口、自然高度测量、420ms 展开动画、渐变遮罩和自动化 testId 均已落地；
+- **P3**：问题日志浏览器入口、系统分享、滚动超过 160px 后顶栏显示问题标题，以及继承
+  当前排序/已加载列表/下一页游标的上一答、下一答连续阅读均已落地。连续阅读使用独占的
+  feeds 仓库会话，避免与返回栈中的问题页互相取消请求。
+
+验证结果：API 26 完整构建及签名通过，Hypium `536/536`；API 26 模拟器以 `ZHIHU_COOKIE`
+完成登录后，真实问题 `1991678138325934210` 的问题详情、回答流、最新排序、正文展开、滚动
+标题、回答连续切换和日志浏览器入口均已实测通过。
+
+## 一、上游实现剖析
+
+上游问题页是**独立于回答详情页的完整实现**，回答详情页与问题页通过"回答切换状态"衔接。
+核心文件（`shared/src/commonMain/kotlin/com/github/zly2006/zhihu/` 下）：
+
+| 文件 | 规模 | 职责 |
+| --- | --- | --- |
+| `ui/QuestionScreen.kt` | 843 行 | 页面 UI 全部组合 |
+| `viewmodel/feed/QuestionFeedViewModel.kt` | 116 行 | 回答信息流状态：排序/分页/屏蔽过滤/关注 |
+| `navigation/AnswerNavigator.kt` | — | `zhihuQuestionFeedsUrl` URL 构造 + `QuestionAnswerNavigator` 连续阅读 |
+
+### 1.1 页面结构（自上而下）
+
+```
+Scaffold
+├─ QuestionTopBar（TopAppBar）
+│   ├─ 返回（ArrowBack）
+│   ├─ 标题动画切换：未滚动显示"问题"，列表滚动超过 160px 后渐变为问题标题
+│   │   （AnimatedContent：fadeIn + slideInVertically，退出反向）
+│   ├─ 日志按钮（History 图标 → 系统浏览器打开 zhihu.com/question/{id}/log）
+│   └─ 分享按钮（Share 图标 → ShareDialog，正文纯文本可分享时才启用）
+└─ FeedPullToRefresh（下拉刷新，复用全局组件）
+    └─ PaginatedList（回答信息流：cursor 分页，footer 进度条，key=stableKey）
+        ├─ topContent（列表头部固定 section，随列表滚动）
+        │   ├─ QuestionHeaderSection
+        │   │   ├─ 标题（headlineSmall Bold，SelectionContainer 可长按选择复制）
+        │   │   └─ 统计行：Eye 浏览数 · ChatBubble 评论数 · Heart 关注数
+        │   │       （FlowRow 小图标 16dp + 辅助文字）＋ 右侧"评论 N" OutlinedButton
+        │   └─ QuestionAnimatedBodyHeader（仅问题数据加载完成后渲染）
+        │       ├─ 可折叠问题正文视口（见 1.2）
+        │       ├─ 话题 chips：FilterChip "#话题名"，点击进话题页
+        │       ├─ QuestionPrimaryActions：写回答（Edit 图标，secondaryContainer 底）
+        │       │   ＋ 关注问题（Check/Add 随态切换，FilledTonal，已关注 tertiaryContainer）
+        │       └─ 排序行："N 回答" ＋ 默认/最新 两个 FilterChip（切换即重置信息流）
+        └─ 回答卡片 FeedCard（AnswerTarget：作者名/头像/摘要/详情文本）
+            └─ 点击进回答详情，同时挂 QuestionAnswerNavigator（见 1.3）
+└─ CommentScreenComponent（问题评论底部面板，comment_v5 通用端点）
+```
+
+### 1.2 正文折叠/展开动画（QuestionAnimatedBodyHeader，约 200 行）
+
+- **是否可折叠**：正文纯文本 ≥ 100 字符或 HTML 含 `<img`；否则静态全展示不可折叠。
+- **折叠态**：视口高度固定 180dp；底部 88dp 渐变遮罩（透明 → surface 0.7 → surface，
+  叠加 12dp blur）；右下角"展开详情/收起详情" TextButton（ExpandMore/ExpandLess 图标），
+  按钮热区高 56dp。
+- **展开动画**：`Animatable` + 420ms `FastOutSlowInEasing`，在"折叠高（≤全高）"与
+  "实测全高"之间插值；全高用 SubcomposeLayout 以无约束测量内容后回填；展开进度
+  （0→1）反向驱动遮罩透明度，完全展开后遮罩消失。
+- 短正文（不可折叠）直接静态渲染并同样回填高度。
+
+### 1.3 数据流与行为
+
+| 用途 | 端点/方式 | 说明 |
+| --- | --- | --- |
+| 问题详情 | `GET /api/v4/questions/{id}?include=read_count,visit_count,answer_count,voteup_count,comment_count,follower_count,detail,excerpt,author,relationship.is_following,topics` | 与本侧 `QUESTION_DETAIL_INCLUDE` **逐字一致** |
+| 回答信息流 | `GET /api/v4/questions/{id}/feeds?limit=20&order=default\|updated`，cursor 分页 | `AnswerNavigator.kt` 构造；条目为 AnswerTarget |
+| 关注/取关 | `POST` / `DELETE /api/v4/questions/{id}/followers` | 带 d_c0 登录态；成功后本地计数 ±1 + toast |
+| 问题评论 | `comment_v5/questions/{id}/...` | 通用评论端点 |
+| 问题日志 | 网页 `zhihu.com/question/{id}/log` | 浏览器打开 |
+| 排序 | `order=default`（默认）/ `updated`（最新） | 切换即 `updateSortOrder` + `refresh` |
+
+其他行为与约束：
+
+- **匿名禁用**：`rememberPaginationEnvironment(allowGuestAccess = false)`——未登录不拉取
+  回答信息流（feeds 端点本身也要求登录态）；
+- **屏蔽过滤**：`processResponse` 按 `blockedUserIds` 过滤 AnswerTarget 作者；
+- **连续阅读**：`QuestionAnswerNavigator` 携带当前回答之后的剩余列表 + 之前的列表 +
+  下一页 URL，进入回答详情后可"上一答/下一答"连续切换并接续分页；
+- 加载问题详情前写入阅读历史（`addReadHistory`）并上报内容打开事件。
+
+## 二、鸿蒙端仿制方案
+
+### 2.1 组件/机制映射总表
+
+| 上游（Compose） | 鸿蒙端方案 | 本侧现状 |
+| --- | --- | --- |
+| Scaffold + TopAppBar | `P1Shell` 的 `HdsNavDestination.titleBar(stackBuilder: detailTitleBar('问题'))` | ✅ 已有 |
+| 顶栏标题随滚动切换（160px） | 复用回答页 `topBarScrolled` 折叠模式（`onDidScroll` 像素偏移驱动） | 骨架已有，加状态即可（P2） |
+| FeedPullToRefresh | `Refresh` + `refreshingContent`（蓝色加载圆圈，`ComponentContent`） + `onRefreshing(controller.refresh)` | ✅ 本周已建同款 |
+| PaginatedList 分页 | `List` + `LazyForEach` + `.onReachEnd(loadMore)` + `LoadingProgress` footer | ✅ 上拉动画已统一 |
+| FeedCard 回答卡片 | 复用信息流卡片渲染（`HomeFeedPage.feedCard` / `ChannelFeedPage.contentCard` 抽共享 builder） | 部分复用（见 2.3） |
+| FilterChip 排序（默认/最新） | `SegmentButton` 两项（关注页"推荐/动态"同款先例） | ❌ 待做 |
+| Animatable 展开动画 | `@State` 高度 + `animateTo({ duration: 420, curve: Curve.FastOutSlowIn })` + `.clip(true)` | ❌ 待做 |
+| SubcomposeLayout 实测全高 | 内层内容 `onAreaChange` 回填 @State（内容始终按自然高度布局，外层裁剪） | ❌ 待做 |
+| 88dp 渐变遮罩 + 12dp blur | Stack 底部覆盖层 `.linearGradient`（透明→背景色 0.7→背景色）+ 可选 `backgroundBlurStyle` | ❌ 待做 |
+| 话题 FilterChip | 边框胶囊 Row；点击暂路由搜索页（Topic 目的地后补） | ❌ 待做 |
+| SelectionContainer 标题 | `Text` `.copyOption(CopyOptions.LocalDevice)` 长按复制 | 可选 |
+| CommentScreenComponent | `CommentLayer`（contentType `question`） | ✅ 本周已接线 |
+| 统计行小图标 | `SymbolGlyph` 16fp + 辅助文字 | ❌ 待做（现为纯文本统计） |
+
+### 2.2 数据层改造
+
+1. **解码器补字段**（P2，小改）：include 已请求 `topics` 与 `relationship.is_following`，
+   但 `Question` 模型与 `ContentDetailDecoder` 未提取——补 `topics: TopicSummary[]`（id/name）
+   与 `isFollowing: boolean` 即可，无新网络请求。
+2. **新增 `QuestionAnswerFeedRepository`**（P1 核心）：
+   - `getAnswerPage(questionId: string, order: 'default' | 'updated', cursor?: string)`：
+     走 `/api/v4/questions/{id}/feeds`，响应为与首页/热榜同族的 Feed 结构
+     （`FeedTargetKind.ANSWER` 已存在），**预计直接复用现有 feed 解码**与
+     `ZhihuHttpClient(session)`；实现时先抓一次真实响应固定线格式（与现有解码对齐）；
+   - 分页/取消/代际控制照抄 `ChannelFeedController` 模式（generation + cancel）；
+   - 屏蔽过滤复用 `BlockingRuleGateway`。
+3. **关注**：`DefaultFollowRepository` 已有 `questions/{id}/followers` 端点与底栏接线，
+   无需新增；如要做"关注计数本地 ±1"在上层补。
+4. **登录门禁**：未登录不请求 feeds，信息流位置显示 `AppPageStatusPanel` 引导登录
+   （对齐上游 allowGuestAccess=false，也规避 feeds 端点的风控拒绝）。
+
+### 2.3 UI 组装（QuestionDetailPage 改造清单，自上而下）
+
+1. 固定信息头：标题 + 统计行（补 eye/message/heart 小图标与浏览/关注计数）+ 评论按钮
+   （评论已接线，样式对齐上游 outlined 风格可选）；
+2. **正文折叠视口**（新 `@Builder` 或子组件）：
+   ```
+   Stack(clip: true, height: 动画高度) {
+     Column { 正文分块渲染; 话题胶囊行 }.onAreaChange(回填 fullHeight)
+     if (折叠中) 底部渐变遮罩层
+     右下角 展开详情/收起详情 按钮（chevron_down/chevron_up + 文字）
+   }
+   ```
+   折叠条件对齐上游（纯文本 ≥100 字或含图）；高度在 `min(fullHeight, 180vp)` 与
+   `fullHeight` 间 `animateTo`；
+3. **主操作行 + 排序行**：见 2.6 决策点；排序用 SegmentButton，切换即重置回答列表；
+4. **回答信息流**：正文同一 `List` 的后续 `ListItem`（推荐——一次滚动贯通，结构最简，
+   topContent 即列表头），或独立 List；卡片复用共享 feed 卡片 builder；
+5. 未登录/空态/加载态/错误态：`AppPageStatusPanel` 复用；
+6. 新交互补 testId（对齐上游 testTag 命名：`question_sort_default`、`question_follow_button`
+   等），便于自动化回归。
+
+### 2.4 图标映射（官方符号库，已逐一验证精确命中）
+
+| 上游 Material 图标 | 用途 | `sys.symbol` | 备注 |
+| --- | --- | --- | --- |
+| AutoMirrored.Filled.ArrowBack | 返回 | `chevron_left` | 项目已用 |
+| Filled.History | 顶栏日志 | `clock` | 符号库无 history，clock 为语义最近官方替代 |
+| Filled.Share | 顶栏分享 | `share` | |
+| AutoMirrored.Filled.Comment / ChatBubbleOutline | 评论 | `message` | 项目已用 |
+| Outlined.Visibility | 浏览统计 | `eye`（或精确的 `visibility`） | |
+| Outlined.FavoriteBorder | 关注统计 | `heart`（关注态可用 `heart_fill`） | |
+| Filled.ExpandLess / ExpandMore | 收起/展开详情 | `chevron_up` / `chevron_down` | |
+| Filled.Edit | 写回答 | `square_and_pencil` | 项目已用 |
+| Filled.Check / Add | 已关注/关注 | `checkmark` / `plus` | 项目已用 |
+
+验证方法：遍历 DevEco SDK 全量符号表 `ets-loader/sysResource.js`（AGENTS.md 指引方式）。
+**图标不构成迁移障碍。**
+
+### 2.5 状态管理约束
+
+- 页面内状态（排序、展开态、回答列表）用 `@State` + 控制器，不出页面；
+- 若需跨页面信号（如登录返回后刷新回答流），一律走 **AppStorage 广播 +
+  `@StorageProp`+`@Watch`**（`loginFeedReloadTick`/`tabRefreshTick` 先例）——
+  `@Builder` 参数传值与 `@Provide/@Consume` 在 HdsTabs/NavDestination 构建树下实测不可靠；
+- 控制器对失活态自行 no-op（`refresh`/`reloadNow` 已有该语义）。
+
+### 2.6 布局决策点（需产品拍板）
+
+上游把**写回答 + 关注**放在正文下方的"主操作行"（不在底栏）；本侧现状是底栏左"关注问题"、
+右"评论/更多"（本周按用户要求对齐回答页，且已移除写回答）。完全仿上游 vs 维持本侧底栏，
+三种选项：
+
+1. **推荐**：维持本侧底栏不动，正文操作行只加"写回答"（补上游核心转化入口，避免与底栏
+   关注重复）；
+2. 完全仿上游：正文操作行放写回答+关注，底栏关注移除；
+3. 最小改动：不加写回答（上游差异项记入差异清单）。
+
+## 三、实施步骤与工作量
+
+| 阶段 | 内容 | 预估 |
+| --- | --- | --- |
+| P1 主体验 | `QuestionAnswerFeedRepository` + 登录门禁 + 排序切换 + 回答流嵌入（共享卡片） | 2~3 人日 |
+| P2 细节对齐 | 正文折叠/展开动画 + 话题胶囊 + 统计行图标化 + 解码补 topics/is_following + testId | 1~2 人日 |
+| P3 暂缓 | `QuestionAnswerNavigator`（上一答/下一答连续阅读）、日志网页入口、顶栏标题随滚动切换 | 视反馈 |
+
+P1 完成即解决"问题页读不到回答"的核心缺口，形成可用的最小闭环。
+
+## 四、风险与注意事项
+
+- **feeds 端点需登录且受风控**：上游同样禁用匿名访问；模拟器环境可能整链路被拒
+  （参考手机号登录在模拟器被风控的先例），服务端联调需真机 + 登录态；
+- **折叠动画帧率**：长正文 + 渐变遮罩 + 模糊在低端机/模拟器上的流畅度需实测调参
+  （必要时去 blur 只留渐变）；
+- **feeds 线格式**：与现有 feed 解码同族、预期直接复用，但实施时必须先固定一次真实
+  响应做单测夹具，防止字段漂移；
+- **解析健壮性**：`detail` 为 HTML，沿用 reader 分块渲染与 WebView/Markdown 设置开关，
+  不新增渲染路径。
+
+## 五、参考
+
+- 上游：`ui/QuestionScreen.kt`、`viewmodel/feed/QuestionFeedViewModel.kt`、
+  `navigation/AnswerNavigator.kt`（快照 `22f6313c`，问题页与 `ec77d309` 研究版一致）
+- 本侧：`ContentDetailPages.ets`（QuestionDetailPage/ContentDetailPage）、
+  `DefaultContentRepository.ets`（QUESTION_DETAIL_INCLUDE）、`DefaultFollowRepository.ets`、
+  `DefaultCommentRepository.ets`、`HomeFeedPage.ets`/`ChannelFeedPage.ets`（卡片与分页先例）
+- 图标库：HarmonyOS Symbol（developer.huawei.com/consumer/cn/design/harmonyos-symbol）

--- a/entry/src/main/ets/common/platform/HarmonyOSCapabilities.ets
+++ b/entry/src/main/ets/common/platform/HarmonyOSCapabilities.ets
@@ -1,3 +1,4 @@
+import { deviceInfo } from '@kit.BasicServicesKit';
 import { hdsMaterial } from '@kit.UIDesignKit';
 
 export class HarmonyOSCapabilities {
@@ -5,6 +6,8 @@ export class HarmonyOSCapabilities {
    * 沉浸材质能力检测：hdsMaterial 自 6.1.0(23) 起可用，按设备实际能力判定。
    * 勿改用 deviceInfo.apiAvailable('26.0.0') 之类的版本判断——该 API 本身是
    * API 26 专属，在 API 23 设备上函数不存在，调用即崩。
+   *
+   * 供 HdsTabs 浮动玻璃画布（底栏/返回键胶囊）使用：23 真机材质渲染正常。
    */
   static supportsImmersiveMaterial(): boolean {
     try {
@@ -12,5 +15,15 @@ export class HarmonyOSCapabilities {
     } catch (_error) {
       return false;
     }
+  }
+
+  /**
+   * 沉浸式标题栏样式（HdsNavigation titleBar 的 systemMaterialEffect +
+   * IMMERSIVE_GRADIENT_BLUR 滚动效果）仅在 API 26 真机验证过渲染正常；
+   * API 23 真机上会渲染为不透明白色遮挡条盖住滚动正文（材质层降级为
+   * 不透明白底的已知问题族），故按版本门禁，勿改回材质能力判断。
+   */
+  static supportsImmersiveTitleBarStyle(): boolean {
+    return deviceInfo.sdkApiVersion >= 26;
   }
 }

--- a/entry/src/main/ets/common/style/NavStyles.ets
+++ b/entry/src/main/ets/common/style/NavStyles.ets
@@ -3,7 +3,9 @@ import { hdsMaterial, ScrollEffectType, TitleBarStyleOptions } from '@kit.UIDesi
 import { HarmonyOSCapabilities } from '../platform/HarmonyOSCapabilities';
 
 export function getImmersiveTitleBarStyle(): TitleBarStyleOptions {
-  if (HarmonyOSCapabilities.supportsImmersiveMaterial()) {
+  // 标题栏沉浸样式（材质层+渐变模糊滚动效果）仅 API 26+ 渲染正常；
+  // 23 真机渲染白色遮挡条（见 HarmonyOSCapabilities.supportsImmersiveTitleBarStyle）。
+  if (HarmonyOSCapabilities.supportsImmersiveTitleBarStyle()) {
     return {
       scrollEffectOpts: {
         enableScrollEffect: true,

--- a/entry/src/main/ets/pages/AnswerTitleBar.ets
+++ b/entry/src/main/ets/pages/AnswerTitleBar.ets
@@ -1,0 +1,160 @@
+import { hdsMaterial } from '@kit.UIDesignKit';
+import { materialCanvas } from './components/MaterialCanvas';
+
+/** 回答页顶栏状态：问题标题 + 答主摘要 + 滚动折叠信号。
+ * 跨页面经 AppStorage 广播（同 QuestionTitleBar 模式，HDS 标题栏 stackBuilder 树下
+ * 常规传值不更新，必须走存储通道）。 */
+export interface AnswerTitleState {
+  id: string;
+  questionTitle: string;
+  authorName: string;
+  authorAvatarUrl: string;
+  scrolled: boolean;
+}
+
+export function publishAnswerTitle(state: AnswerTitleState): void {
+  const states = AppStorage.get<AnswerTitleState[]>('answerTitleStates') ?? [];
+  const previous = states.find((item: AnswerTitleState): boolean => item.id === state.id);
+  if (previous?.questionTitle === state.questionTitle && previous.authorName === state.authorName &&
+    previous.authorAvatarUrl === state.authorAvatarUrl && previous.scrolled === state.scrolled) {
+    return;
+  }
+  AppStorage.setOrCreate('answerTitleStates',
+    states.filter((item: AnswerTitleState): boolean => item.id !== state.id).concat([state]));
+}
+
+export function removeAnswerTitle(id: string): void {
+  const states = AppStorage.get<AnswerTitleState[]>('answerTitleStates') ?? [];
+  AppStorage.setOrCreate('answerTitleStates',
+    states.filter((item: AnswerTitleState): boolean => item.id !== id));
+}
+
+/** 回答页 HDS 标题栏：默认返回键 + "回答"占位；正文滚过问题标题后折叠为
+ * 返回键右侧问题单行（溢出省略）+ 下方答主头像/名称（对齐上游 TwoRowsTopAppBar 折叠态）。 */
+@Component
+export struct AnswerTitleBar {
+  answerId: string = '';
+  onBack: () => void = (): void => {
+  };
+  @StorageProp('answerTitleStates') private states: AnswerTitleState[] = [];
+
+  private state(): AnswerTitleState | undefined {
+    return this.states.find((item: AnswerTitleState): boolean => item.id === this.answerId);
+  }
+
+  private supportsImmersiveMaterial(): boolean {
+    try {
+      return hdsMaterial.getSystemMaterialTypes().includes(hdsMaterial.MaterialType.IMMERSIVE);
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  private scrolled(): boolean {
+    return this.state()?.scrolled ?? false;
+  }
+
+  build() {
+    Row({ space: $r('app.float.p1_spacing_small') }) {
+      Stack({ alignContent: Alignment.Center }) {
+        if (this.supportsImmersiveMaterial()) {
+          materialCanvas(52, 52)
+        }
+        Button({ type: ButtonType.Normal, stateEffect: true }) {
+          SymbolGlyph($r('sys.symbol.chevron_left'))
+            .fontSize(20)
+            .fontColor([$r('app.color.primary_text')])
+        }
+          .width(40)
+          .height(40)
+          .padding(0)
+          .borderRadius(20)
+          .backgroundColor(this.supportsImmersiveMaterial()
+            ? Color.Transparent
+            : $r('app.color.surface_background'))
+          .accessibilityText('返回')
+          .onClick((): void => {
+            this.onBack();
+          })
+      }
+        .width(44)
+        .height(44)
+        .borderRadius(22)
+        .clip(true)
+
+      // 标题区：未折叠显示"回答"占位（与旧 detailTitleBar 一致）；
+      // 折叠后交叉淡入问题单行 + 答主摘要行（对齐 QuestionTitleBar 的过渡方式）。
+      Stack({ alignContent: Alignment.Start }) {
+        Column() {
+          Text('回答')
+            .id('answer_top_label')
+            .fontSize($r('app.float.p1_heading_font_size'))
+            .fontWeight(FontWeight.Medium)
+            .fontColor($r('app.color.primary_text'))
+        }
+        .height('100%')
+        .justifyContent(FlexAlign.Center)
+        .opacity(this.scrolled() ? 0 : 1)
+        .translate({ y: this.scrolled() ? -8 : 0 })
+
+        Column({ space: 2 }) {
+          Text(this.state()?.questionTitle ?? '')
+            .id('answer_top_question')
+            .fontSize($r('app.float.p1_body_font_size'))
+            .fontWeight(FontWeight.Medium)
+            .fontColor($r('app.color.primary_text'))
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .width('100%')
+          Row({ space: 4 }) {
+            Stack({ alignContent: Alignment.Center }) {
+              Circle()
+                .width(18)
+                .height(18)
+                .fill($r('app.color.control_background'))
+              if ((this.state()?.authorAvatarUrl ?? '').length > 0) {
+                Image(this.state()?.authorAvatarUrl ?? '')
+                  .id('answer_top_author_avatar')
+                  .width(18)
+                  .height(18)
+                  .borderRadius(9)
+                  .objectFit(ImageFit.Cover)
+              } else if ((this.state()?.authorName ?? '').length > 0) {
+                Text((this.state()?.authorName ?? '').substring(0, 1))
+                  .fontSize($r('app.float.p1_caption_font_size'))
+                  .fontColor($r('app.color.secondary_text'))
+              }
+            }
+              .width(18)
+              .height(18)
+              .clip(true)
+            Text(this.state()?.authorName ?? '')
+              .id('answer_top_author')
+              .fontSize($r('app.float.p1_caption_font_size'))
+              .fontColor($r('app.color.secondary_text'))
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+              .layoutWeight(1)
+          }
+          .width('100%')
+        }
+        .width('100%')
+        .height('100%')
+        .justifyContent(FlexAlign.Center)
+        .opacity(this.scrolled() ? 1 : 0)
+        .translate({ y: this.scrolled() ? 0 : 8 })
+      }
+        .layoutWeight(1)
+        .height(48)
+        .clip(true)
+    }
+    .width('100%')
+    .height(48)
+    .padding({
+      left: $r('app.float.p1_page_padding'),
+      right: $r('app.float.p1_page_padding')
+    })
+    .alignItems(VerticalAlign.Center)
+    .hitTestBehavior(HitTestMode.Transparent)
+  }
+}

--- a/entry/src/main/ets/pages/ArticleTitleBar.ets
+++ b/entry/src/main/ets/pages/ArticleTitleBar.ets
@@ -1,0 +1,160 @@
+import { hdsMaterial } from '@kit.UIDesignKit';
+import { materialCanvas } from './components/MaterialCanvas';
+
+/** 文章页顶栏状态：文章标题 + 作者摘要 + 滚动折叠信号。
+ * 跨页面经 AppStorage 广播（同 AnswerTitleBar 模式，HDS 标题栏 stackBuilder 树下
+ * 常规传值不更新，必须走存储通道）。 */
+export interface ArticleTitleState {
+  id: string;
+  title: string;
+  authorName: string;
+  authorAvatarUrl: string;
+  scrolled: boolean;
+}
+
+export function publishArticleTitle(state: ArticleTitleState): void {
+  const states = AppStorage.get<ArticleTitleState[]>('articleTitleStates') ?? [];
+  const previous = states.find((item: ArticleTitleState): boolean => item.id === state.id);
+  if (previous?.title === state.title && previous.authorName === state.authorName &&
+    previous.authorAvatarUrl === state.authorAvatarUrl && previous.scrolled === state.scrolled) {
+    return;
+  }
+  AppStorage.setOrCreate('articleTitleStates',
+    states.filter((item: ArticleTitleState): boolean => item.id !== state.id).concat([state]));
+}
+
+export function removeArticleTitle(id: string): void {
+  const states = AppStorage.get<ArticleTitleState[]>('articleTitleStates') ?? [];
+  AppStorage.setOrCreate('articleTitleStates',
+    states.filter((item: ArticleTitleState): boolean => item.id !== id));
+}
+
+/** 文章页 HDS 标题栏：默认返回键 + "文章"占位；正文滚过文章标题后折叠为
+ * 返回键右侧文章标题单行 + 下方作者头像/名称（对齐 AnswerTitleBar 折叠态）。 */
+@Component
+export struct ArticleTitleBar {
+  articleId: string = '';
+  onBack: () => void = (): void => {
+  };
+  @StorageProp('articleTitleStates') private states: ArticleTitleState[] = [];
+
+  private state(): ArticleTitleState | undefined {
+    return this.states.find((item: ArticleTitleState): boolean => item.id === this.articleId);
+  }
+
+  private supportsImmersiveMaterial(): boolean {
+    try {
+      return hdsMaterial.getSystemMaterialTypes().includes(hdsMaterial.MaterialType.IMMERSIVE);
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  private scrolled(): boolean {
+    return this.state()?.scrolled ?? false;
+  }
+
+  build() {
+    Row({ space: $r('app.float.p1_spacing_small') }) {
+      Stack({ alignContent: Alignment.Center }) {
+        if (this.supportsImmersiveMaterial()) {
+          materialCanvas(52, 52)
+        }
+        Button({ type: ButtonType.Normal, stateEffect: true }) {
+          SymbolGlyph($r('sys.symbol.chevron_left'))
+            .fontSize(20)
+            .fontColor([$r('app.color.primary_text')])
+        }
+          .width(40)
+          .height(40)
+          .padding(0)
+          .borderRadius(20)
+          .backgroundColor(this.supportsImmersiveMaterial()
+            ? Color.Transparent
+            : $r('app.color.surface_background'))
+          .accessibilityText('返回')
+          .onClick((): void => {
+            this.onBack();
+          })
+      }
+        .width(44)
+        .height(44)
+        .borderRadius(22)
+        .clip(true)
+
+      // 标题区：未折叠显示"文章"占位；折叠后交叉淡入文章标题 + 作者摘要两行
+      // （对齐 AnswerTitleBar 折叠态的过渡方式）。
+      Stack({ alignContent: Alignment.Start }) {
+        Column() {
+          Text('文章')
+            .id('article_top_label')
+            .fontSize($r('app.float.p1_heading_font_size'))
+            .fontWeight(FontWeight.Medium)
+            .fontColor($r('app.color.primary_text'))
+        }
+        .height('100%')
+        .justifyContent(FlexAlign.Center)
+        .opacity(this.scrolled() ? 0 : 1)
+        .translate({ y: this.scrolled() ? -8 : 0 })
+
+        Column({ space: 2 }) {
+          Text(this.state()?.title ?? '')
+            .id('article_top_title')
+            .fontSize($r('app.float.p1_body_font_size'))
+            .fontWeight(FontWeight.Medium)
+            .fontColor($r('app.color.primary_text'))
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .width('100%')
+          Row({ space: 4 }) {
+            Stack({ alignContent: Alignment.Center }) {
+              Circle()
+                .width(18)
+                .height(18)
+                .fill($r('app.color.control_background'))
+              if ((this.state()?.authorAvatarUrl ?? '').length > 0) {
+                Image(this.state()?.authorAvatarUrl ?? '')
+                  .id('article_top_author_avatar')
+                  .width(18)
+                  .height(18)
+                  .borderRadius(9)
+                  .objectFit(ImageFit.Cover)
+              } else if ((this.state()?.authorName ?? '').length > 0) {
+                Text((this.state()?.authorName ?? '').substring(0, 1))
+                  .fontSize($r('app.float.p1_caption_font_size'))
+                  .fontColor($r('app.color.secondary_text'))
+              }
+            }
+              .width(18)
+              .height(18)
+              .clip(true)
+            Text(this.state()?.authorName ?? '')
+              .id('article_top_author')
+              .fontSize($r('app.float.p1_caption_font_size'))
+              .fontColor($r('app.color.secondary_text'))
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+              .layoutWeight(1)
+          }
+          .width('100%')
+        }
+        .width('100%')
+        .height('100%')
+        .justifyContent(FlexAlign.Center)
+        .opacity(this.scrolled() ? 1 : 0)
+        .translate({ y: this.scrolled() ? 0 : 8 })
+      }
+        .layoutWeight(1)
+        .height(48)
+        .clip(true)
+    }
+    .width('100%')
+    .height(48)
+    .padding({
+      left: $r('app.float.p1_page_padding'),
+      right: $r('app.float.p1_page_padding')
+    })
+    .alignItems(VerticalAlign.Center)
+    .hitTestBehavior(HitTestMode.Transparent)
+  }
+}

--- a/entry/src/main/ets/pages/ChannelFeedPage.ets
+++ b/entry/src/main/ets/pages/ChannelFeedPage.ets
@@ -1,4 +1,5 @@
 import { FeedContentSummary } from './components/FeedContentSummary';
+import { HotQuestionStatistics } from './components/HotQuestionStatistics';
 import { isSafeDecimalContentId, P1Destination, P1DestinationName } from 'core';
 import {
   BlockedFeedHistoryGateway,
@@ -10,6 +11,7 @@ import {
   channelFeedItemIdentity,
   ChannelFeedRepository,
   ChannelFeedSource,
+  ContentRepository,
   DailyStoryRepository,
   DefaultChannelFeedRepository,
   FeedItem,
@@ -44,6 +46,7 @@ export struct ChannelFeedPage {
   /** 关注页的两个子 Tab 共用列表实现，标题由外层 Tabs 提供。 */
   showHeader: boolean = true;
   repository: ChannelFeedRepository | undefined = new DefaultChannelFeedRepository();
+  questionRepositoryFactory: () => ContentRepository | undefined = () => undefined;
   dailyStoryRepository: DailyStoryRepository | undefined = undefined;
   rules: BlockingRuleGateway | undefined = undefined;
   history: BlockedFeedHistoryGateway | undefined = undefined;
@@ -387,7 +390,10 @@ export struct ChannelFeedPage {
           .accessibilityText('屏蔽作者或关键词')
         }
         .width('100%')
-        FeedContentSummary({ target: item.feedItem.target })
+        FeedContentSummary({ target: item.feedItem.target, showStatistics: this.source !== ChannelFeedSource.HOT })
+        if (this.source === ChannelFeedSource.HOT) {
+          HotQuestionStatistics({ target: item.feedItem.target, repositoryFactory: this.questionRepositoryFactory })
+        }
       }
       .alignItems(HorizontalAlign.Start)
       .width('100%')

--- a/entry/src/main/ets/pages/ChannelFeedPage.ets
+++ b/entry/src/main/ets/pages/ChannelFeedPage.ets
@@ -46,6 +46,12 @@ export struct ChannelFeedPage {
   source: ChannelFeedSource = ChannelFeedSource.HOT;
   /** 关注页的两个子 Tab 共用列表实现，标题由外层 Tabs 提供。 */
   showHeader: boolean = true;
+  /**
+   * 列表顶部内容插槽（随列表滚动），关注推荐页用于渲染“最近更新的关注用户”一行；
+   * 需与 topContentVisible 同时开启，否则不占列表项。
+   */
+  @BuilderParam topContent: () => void = this.emptyTopContent;
+  topContentVisible: boolean = false;
   repository: ChannelFeedRepository | undefined = new DefaultChannelFeedRepository();
   questionRepositoryFactory: () => ContentRepository | undefined = () => undefined;
   dailyStoryRepository: DailyStoryRepository | undefined = undefined;
@@ -225,6 +231,12 @@ export struct ChannelFeedPage {
           friction: 100
         }) {
           List({ scroller: this.listScroller }) {
+            if (this.topContentVisible) {
+              ListItem() {
+                this.topContent()
+              }
+              .width('100%')
+            }
             ForEach(this.items, (item: ChannelFeedItem, index: number) => {
               ListItem() {
                 if (item.kind === ChannelFeedItemKind.CONTENT) {
@@ -352,6 +364,10 @@ export struct ChannelFeedPage {
     .width('100%')
     .height('100%')
     .backgroundColor($r('app.color.page_background'))
+  }
+
+  @Builder
+  private emptyTopContent() {
   }
 
   @Builder

--- a/entry/src/main/ets/pages/ChannelFeedPage.ets
+++ b/entry/src/main/ets/pages/ChannelFeedPage.ets
@@ -39,6 +39,7 @@ import {
   ChannelFeedInteractionBridge
 } from './ChannelFeedState';
 import { dailyStoryDetailErrorMessage } from './DailyStoryDetailState';
+import { dailyFeedDateAtIndex, formatDailyDate } from './DailyFeedDates';
 
 @Component
 export struct ChannelFeedPage {
@@ -51,7 +52,9 @@ export struct ChannelFeedPage {
   rules: BlockingRuleGateway | undefined = undefined;
   history: BlockedFeedHistoryGateway | undefined = undefined;
   @Prop @Watch('reloadAfterAuthentication') reloadToken: number = 0;
-  @Prop @Watch('loadDateFromTitleBar') dateCursor: string = '';
+  @Prop dateCursor: string = '';
+  @StorageProp('dailySelectedDate') dailySelectedDate: string = '';
+  @StorageProp('dailyDateSelectionTick') @Watch('loadDateFromTitleBar') dailyDateSelectionTick: number = 0;
   // 登录成功重载信号：经 AppStorage 广播（@Consume 在 HdsTabs 树下实测不链接）
   @StorageProp('loginFeedReloadTick') @Watch('onLoginFeedReloadTick') loginFeedReloadTick: number = 0;
   // 双击底栏页签刷新：关注=1、热榜=2、日报=3（P1TopLevelTab），复用下拉刷新链路
@@ -80,8 +83,13 @@ export struct ChannelFeedPage {
   private controller?: ChannelFeedController;
   private blockingAction?: BlockingActionController;
   private pendingBlockItem?: ChannelContentItem = undefined;
+  private readonly listScroller: ListScroller = new ListScroller();
+  private firstVisibleIndex: number = 0;
+  private handledDateSelectionTick: number = 0;
+  private pageActive: boolean = false;
 
   aboutToAppear(): void {
+    this.pageActive = true;
     this.refreshContent = new ComponentContent(this.getUIContext(), wrapBuilder(feedPullDownIndicator),
       new FeedPullDownIndicatorOptions());
     // P3-7：返回栈重显（页面实例与状态保留）时 aboutToAppear 可能再次触发；
@@ -89,6 +97,7 @@ export struct ChannelFeedPage {
     if (this.controller !== undefined) {
       this.controller.activate();
       this.registerTitleBarActions();
+      this.loadDateFromTitleBar();
       return;
     }
     const repository = this.repository;
@@ -102,8 +111,8 @@ export struct ChannelFeedPage {
     });
     this.registerTitleBarActions();
     this.controller.activate();
-    if (this.source === ChannelFeedSource.DAILY && /^\d{8}$/.test(this.dateCursor)) {
-      this.controller.loadDate(this.dateCursor);
+    if (this.source === ChannelFeedSource.DAILY && this.dailyDateSelectionTick > 0) {
+      this.loadDateFromTitleBar();
     } else {
       this.controller.loadInitial();
     }
@@ -111,6 +120,7 @@ export struct ChannelFeedPage {
   }
 
   aboutToDisappear(): void {
+    this.pageActive = false;
     this.refreshContent?.dispose();
     this.refreshContent = undefined;
     this.controller?.deactivate();
@@ -139,13 +149,6 @@ export struct ChannelFeedPage {
     if (this.source === ChannelFeedSource.HOT) {
       this.interactionBridge.registerHotRefresh((): void => {
         controller.reloadNow();
-      });
-    } else if (this.source === ChannelFeedSource.DAILY) {
-      this.interactionBridge.registerDailyRefresh((): void => {
-        controller.reloadNow();
-      });
-      this.interactionBridge.registerDailyDate((date: string): void => {
-        controller.loadDate(date);
       });
     }
   }
@@ -176,8 +179,10 @@ export struct ChannelFeedPage {
   }
 
   private loadDateFromTitleBar(): void {
-    if (this.source === ChannelFeedSource.DAILY && /^\d{8}$/.test(this.dateCursor)) {
-      this.controller?.loadDate(this.dateCursor);
+    if (this.source === ChannelFeedSource.DAILY && this.pageActive && this.controller !== undefined &&
+      this.dailyDateSelectionTick !== this.handledDateSelectionTick && /^\d{8}$/.test(this.dailySelectedDate)) {
+      this.handledDateSelectionTick = this.dailyDateSelectionTick;
+      this.controller.loadDate(this.dailySelectedDate);
     }
   }
 
@@ -219,13 +224,19 @@ export struct ChannelFeedPage {
           offset: 80,
           friction: 100
         }) {
-          List() {
+          List({ scroller: this.listScroller }) {
             ForEach(this.items, (item: ChannelFeedItem, index: number) => {
               ListItem() {
                 if (item.kind === ChannelFeedItemKind.CONTENT) {
                   this.contentCard(item, index);
                 } else {
-                  this.dailyCard(item);
+                  Column({ space: 12 }) {
+                    if (index === 0 || dailyFeedDateAtIndex(this.items, index - 1) !== item.story.date) {
+                      this.dailyDateDivider(item.story.date);
+                    }
+                    this.dailyCard(item);
+                  }
+                  .width('100%')
                 }
               }
               .margin({ bottom: $r('app.float.p1_spacing_medium') })
@@ -251,6 +262,15 @@ export struct ChannelFeedPage {
           .height('100%')
           .edgeEffect(EdgeEffect.Spring)
           .onReachEnd(() => this.controller?.loadMore())
+          .onScrollIndex((start: number, end: number): void => {
+            if (this.source === ChannelFeedSource.DAILY) {
+              this.firstVisibleIndex = start;
+              this.publishDailyViewingDate();
+              if (end >= this.items.length - 3) {
+                this.controller?.loadMore();
+              }
+            }
+          })
         }
         .width('100%')
         .layoutWeight(1)
@@ -413,30 +433,43 @@ export struct ChannelFeedPage {
   }
 
   @Builder
+  private dailyDateDivider(date: string) {
+    Row({ space: 16 }) {
+      Divider().layoutWeight(1).color($r('app.color.secondary_text')).opacity(0.2)
+      Text(formatDailyDate(date))
+        .id(`p2_daily_section_${date}`)
+        .fontSize($r('app.float.p1_body_font_size'))
+        .fontWeight(FontWeight.Medium)
+        .fontColor($r('app.color.brand_primary'))
+      Divider().layoutWeight(1).color($r('app.color.secondary_text')).opacity(0.2)
+    }
+    .width('100%')
+    .padding({ top: 12, bottom: 4 })
+  }
+
+  @Builder
   private dailyCard(item: ChannelDailyStoryItem) {
     Button({ type: ButtonType.Normal, stateEffect: true }) {
       Row({ space: $r('app.float.p1_spacing_medium') }) {
+        if (item.story.imageUrl !== undefined && /^https:\/\/[^\s]+$/i.test(item.story.imageUrl)) {
+          Image(item.story.imageUrl)
+            .width('28%')
+            .aspectRatio(1)
+            .borderRadius($r('app.float.p1_spacing_small'))
+            .objectFit(ImageFit.Cover)
+            .alt('日报缩略图')
+        }
         Column({ space: $r('app.float.p1_spacing_small') }) {
-          Row({ space: $r('app.float.p1_spacing_small') }) {
-            Text('知乎日报')
-              .fontSize($r('app.float.p1_secondary_font_size'))
-              .fontColor($r('app.color.brand_primary'))
-              .layoutWeight(1)
-            Text(formatDailyDate(item.story.date))
-              .fontSize($r('app.float.p1_secondary_font_size'))
-              .fontColor($r('app.color.secondary_text'))
-          }
-          .width('100%')
           Text(item.story.title)
-            .fontSize($r('app.float.p1_heading_font_size'))
+            .fontSize($r('app.float.p1_body_font_size'))
             .fontWeight(FontWeight.Medium)
             .fontColor($r('app.color.primary_text'))
-            .maxLines(2)
+            .maxLines(4)
             .textOverflow({ overflow: TextOverflow.Ellipsis })
             .width('100%')
           if (item.story.hint.trim().length > 0) {
             Text(item.story.hint)
-              .fontSize($r('app.float.p1_body_font_size'))
+              .fontSize($r('app.float.p1_secondary_font_size'))
               .fontColor($r('app.color.secondary_text'))
               .maxLines(1)
               .textOverflow({ overflow: TextOverflow.Ellipsis })
@@ -445,14 +478,6 @@ export struct ChannelFeedPage {
         }
         .alignItems(HorizontalAlign.Start)
         .layoutWeight(1)
-        if (item.story.imageUrl !== undefined && /^https:\/\/[^\s]+$/i.test(item.story.imageUrl)) {
-          Image(item.story.imageUrl)
-            .width(84)
-            .height(64)
-            .borderRadius($r('app.float.p1_spacing_small'))
-            .objectFit(ImageFit.Cover)
-            .alt('日报缩略图')
-        }
       }
       .alignItems(VerticalAlign.Top)
       .width('100%')
@@ -629,6 +654,16 @@ export struct ChannelFeedPage {
   }
 
   private applyState(state: ChannelFeedViewState): void {
+    const replacedDailyPage = this.source === ChannelFeedSource.DAILY &&
+      (this.phase === ChannelFeedPhase.INITIAL_LOADING || this.refreshing) &&
+      !state.refreshing && (state.phase === ChannelFeedPhase.READY || state.phase === ChannelFeedPhase.EMPTY) &&
+      state.errorMessage === undefined;
+    if (replacedDailyPage) {
+      this.firstVisibleIndex = 0;
+      if (this.refreshing) {
+        this.listScroller.scrollToIndex(0, false, ScrollAlign.START);
+      }
+    }
     this.phase = state.phase;
     this.items = state.items;
     this.refreshing = state.refreshing;
@@ -636,41 +671,17 @@ export struct ChannelFeedPage {
     this.canLoadMore = state.canLoadMore;
     this.requiresLogin = state.requiresLogin;
     this.errorMessage = state.errorMessage ?? '';
+    if (this.source === ChannelFeedSource.DAILY &&
+      (state.phase === ChannelFeedPhase.READY || state.phase === ChannelFeedPhase.EMPTY)) {
+      this.publishDailyViewingDate();
+    }
   }
 
-  private headerTitle(): string {
-    if (this.source !== ChannelFeedSource.DAILY) {
-      return channelFeedTitle(this.source);
+  private publishDailyViewingDate(): void {
+    const date = dailyFeedDateAtIndex(this.items, this.firstVisibleIndex);
+    if (AppStorage.get<string>('dailyViewingDate') !== date) {
+      AppStorage.setOrCreate('dailyViewingDate', date);
     }
-    const first = this.items.find((item: ChannelFeedItem): boolean => item.kind === ChannelFeedItemKind.DAILY_STORY);
-    if (first === undefined || first.kind !== ChannelFeedItemKind.DAILY_STORY) {
-      return '知乎日报';
-    }
-    return `知乎日报 · ${formatDailyDate(first.story.date)}`;
-  }
-
-  private showDailyDatePicker(): void {
-    const selectedDate: Date = this.currentDailyDate();
-    this.getUIContext().showDatePickerDialog({
-      selected: selectedDate,
-      start: new Date(2000, 0, 1),
-      end: new Date(),
-      onDateAccept: (date: Date): void => {
-        const cursor = dailyDateCursor(date);
-        this.controller?.loadDate(cursor);
-      }
-    });
-  }
-
-  private currentDailyDate(): Date {
-    const first = this.items.find((item: ChannelFeedItem): boolean => item.kind === ChannelFeedItemKind.DAILY_STORY);
-    if (first === undefined || first.kind !== ChannelFeedItemKind.DAILY_STORY || !/^\d{8}$/.test(first.story.date)) {
-      return new Date();
-    }
-    const year: number = Number(first.story.date.substring(0, 4));
-    const month: number = Number(first.story.date.substring(4, 6)) - 1;
-    const day: number = Number(first.story.date.substring(6, 8));
-    return new Date(year, month, day);
   }
 }
 
@@ -711,17 +722,4 @@ export function channelActionLabel(item: FeedItem, source: ChannelFeedSource): s
     return '推荐内容';
   }
   return '热榜内容';
-}
-
-export function formatDailyDate(value: string): string {
-  if (!/^\d{8}$/.test(value)) {
-    return value;
-  }
-  return `${value.substring(0, 4)}年${Number(value.substring(4, 6))}月${Number(value.substring(6, 8))}日`;
-}
-
-export function dailyDateCursor(date: Date): string {
-  const month = `${date.getMonth() + 1}`.padStart(2, '0');
-  const day = `${date.getDate()}`.padStart(2, '0');
-  return `${date.getFullYear()}${month}${day}`;
 }

--- a/entry/src/main/ets/pages/ChannelFeedPage.ets
+++ b/entry/src/main/ets/pages/ChannelFeedPage.ets
@@ -1,3 +1,4 @@
+import { FeedContentSummary } from './components/FeedContentSummary';
 import { isSafeDecimalContentId, P1Destination, P1DestinationName } from 'core';
 import {
   BlockedFeedHistoryGateway,
@@ -386,41 +387,7 @@ export struct ChannelFeedPage {
           .accessibilityText('屏蔽作者或关键词')
         }
         .width('100%')
-        // 对齐上游 FeedCard：标题 2 行、摘要 3 行、作者与元信息各 1 行，控制一屏卡片数量。
-        Text(item.feedItem.target.title)
-          .fontSize($r('app.float.p1_heading_font_size'))
-          .fontWeight(FontWeight.Medium)
-          .fontColor($r('app.color.primary_text'))
-          .maxLines(2)
-          .textOverflow({ overflow: TextOverflow.Ellipsis })
-          .width('100%')
-        if (item.feedItem.target.excerpt.trim().length > 0) {
-          Text(item.feedItem.target.excerpt)
-            .fontSize($r('app.float.p1_body_font_size'))
-            .fontColor($r('app.color.secondary_text'))
-            .maxLines(3)
-            .textOverflow({ overflow: TextOverflow.Ellipsis })
-            .width('100%')
-        }
-        Row({ space: $r('app.float.p1_spacing_medium') }) {
-          if (item.feedItem.target.author !== undefined) {
-            Text(item.feedItem.target.author.name)
-              .fontSize($r('app.float.p1_secondary_font_size'))
-              .fontColor($r('app.color.secondary_text'))
-              .maxLines(1)
-              .textOverflow({ overflow: TextOverflow.Ellipsis })
-              .layoutWeight(1)
-          } else {
-            Blank().layoutWeight(1)
-          }
-          Text(`${item.feedItem.target.voteupCount} 赞同`)
-            .fontSize($r('app.float.p1_secondary_font_size'))
-            .fontColor($r('app.color.secondary_text'))
-          Text(`${item.feedItem.target.commentCount} 评论`)
-            .fontSize($r('app.float.p1_secondary_font_size'))
-            .fontColor($r('app.color.secondary_text'))
-        }
-        .width('100%')
+        FeedContentSummary({ target: item.feedItem.target })
       }
       .alignItems(HorizontalAlign.Start)
       .width('100%')

--- a/entry/src/main/ets/pages/ChannelFeedState.ets
+++ b/entry/src/main/ets/pages/ChannelFeedState.ets
@@ -39,7 +39,6 @@ export class ChannelFeedInteractionBridge {
   private hotRefreshAction: (() => void) | undefined = undefined;
   private dailyRefreshAction: (() => void) | undefined = undefined;
   private dailyDateAction: ((date: string) => void) | undefined = undefined;
-  private followingTabAction: ((index: number) => void) | undefined = undefined;
 
   registerHotRefresh(action: () => void): void {
     this.hotRefreshAction = action;
@@ -53,10 +52,6 @@ export class ChannelFeedInteractionBridge {
     this.dailyDateAction = action;
   }
 
-  registerFollowingTab(action: (index: number) => void): void {
-    this.followingTabAction = action;
-  }
-
   refreshHot(): void {
     this.hotRefreshAction?.();
   }
@@ -67,10 +62,6 @@ export class ChannelFeedInteractionBridge {
 
   selectDailyDate(date: string): void {
     this.dailyDateAction?.(date);
-  }
-
-  selectFollowingTab(index: number): void {
-    this.followingTabAction?.(index);
   }
 }
 

--- a/entry/src/main/ets/pages/ChannelFeedState.ets
+++ b/entry/src/main/ets/pages/ChannelFeedState.ets
@@ -91,6 +91,7 @@ export class ChannelFeedController {
   private requiresLogin: boolean = false;
   private restartFirstPageOnActivate: boolean = false;
   private errorMessage?: string;
+  private selectedDailyDate?: string;
 
   constructor(source: ChannelFeedSource, repository: ChannelFeedRepository,
     observer: ChannelFeedStateObserver = (_state: ChannelFeedViewState): void => {
@@ -108,7 +109,7 @@ export class ChannelFeedController {
     if (this.restartFirstPageOnActivate) {
       this.restartFirstPageOnActivate = false;
       this.phase = this.items.length > 0 ? ChannelFeedPhase.READY : ChannelFeedPhase.IDLE;
-      this.refresh();
+      this.loadFirstPage(this.items.length > 0, this.selectedDailyDate, this.selectedDailyDate !== undefined);
       return;
     }
     this.emit();
@@ -171,6 +172,9 @@ export class ChannelFeedController {
     if (this.retryLoadMore) {
       this.paginationBlocked = false;
       return this.loadMore();
+    }
+    if (this.selectedDailyDate !== undefined) {
+      return this.loadDate(this.selectedDailyDate);
     }
     return this.refresh();
   }
@@ -242,6 +246,7 @@ export class ChannelFeedController {
   }
 
   private async loadFirstPage(keepVisibleItems: boolean, cursor?: string, reset: boolean = false): Promise<void> {
+    this.selectedDailyDate = this.source === ChannelFeedSource.DAILY ? cursor : undefined;
     const generation = ++this.generation;
     this.refreshing = keepVisibleItems;
     this.loadingMore = false;

--- a/entry/src/main/ets/pages/CommentLayer.ets
+++ b/entry/src/main/ets/pages/CommentLayer.ets
@@ -1,6 +1,5 @@
 import { P1Destination, P1DestinationName } from 'core';
 import {
-  CommentContentKind,
   CommentItem,
   CommentRepository,
   CommentSortOrder,
@@ -12,9 +11,9 @@ import {
   CommentPhase,
   CommentViewState
 } from './CommentState';
-
-const COMMENT_EXPANDED_IDS_LIMIT = 200;
-
+import { ContentImagePreview } from './NativeContentDocument';
+import { CommentLikeButton } from './CommentLikeButton';
+import { CommentLikeState, CommentLikeStateStore } from './CommentLikeState';
 /**
  * 评论弹层组件：常驻详情页组合树内（以 visibility 切换显隐），
  * 避免关闭弹层时销毁内部状态——与上游 CommentScreenComponent
@@ -30,8 +29,8 @@ export struct CommentLayer {
   navigate: (destination: P1Destination) => void = (_destination: P1Destination): void => {
   };
   @Prop @Watch('onShowCommentsChange') showComments: boolean = false;
-  rootDraft: string = '';
-  replyDraft: string = '';
+  @Prop rootDraft: string = '';
+  @Prop replyDraft: string = '';
   onRootDraftChange: (value: string) => void = (_value: string): void => {
   };
   onReplyDraftChange: (value: string) => void = (_value: string): void => {
@@ -48,12 +47,13 @@ export struct CommentLayer {
   @State private activeRoot?: CommentItem = undefined;
   @State private replyTarget?: CommentItem = undefined;
   @State private submitting: boolean = false;
-  @State private likeBusy: boolean = false;
   @State private deleting: boolean = false;
   @State private actionMessage: string = '';
   @State private actionRequiresLogin: boolean = false;
-  @State private expandedRootIds: Array<string> = [];
+  @State private previewImageUrl: string = '';
+  @State private likeStates: Record<string, CommentLikeState> = {};
   private controller?: CommentController;
+  private readonly likeStateStore: CommentLikeStateStore = new CommentLikeStateStore();
   private rootScroller: Scroller = new Scroller();
   private childScroller: Scroller = new Scroller();
 
@@ -96,7 +96,7 @@ export struct CommentLayer {
     Column()
       .bindSheet(this.showComments, this.commentSheet(), {
         height: SheetSize.LARGE,
-        dragBar: true,
+        dragBar: false,
         showClose: false,
         maskColor: '#66000000',
         backgroundColor: $r('app.color.surface_background'),
@@ -106,6 +106,17 @@ export struct CommentLayer {
           }
         }
       })
+      .bindContentCover(this.previewImageUrl.length > 0, this.imagePreview(), {
+        onDisappear: (): void => { this.previewImageUrl = ''; }
+      })
+  }
+
+  @Builder
+  private imagePreview() {
+    ContentImagePreview({
+      url: this.previewImageUrl,
+      onClose: (): void => { this.previewImageUrl = ''; }
+    })
   }
 
   @Builder
@@ -141,20 +152,19 @@ export struct CommentLayer {
               this.controller?.closeChildComments();
             })
           Text('回复')
-            .fontSize($r('app.float.p1_heading_font_size'))
+            .textAlign(TextAlign.Center)
+            .fontSize(18)
             .fontWeight(FontWeight.Bold)
             .fontColor($r('app.color.primary_text'))
             .layoutWeight(1)
         } else {
+          Blank().width(40)
           Text('评论')
-            .fontSize($r('app.float.p1_heading_font_size'))
+            .textAlign(TextAlign.Center)
+            .fontSize(18)
             .fontWeight(FontWeight.Bold)
             .fontColor($r('app.color.primary_text'))
             .layoutWeight(1)
-          if (this.phase === CommentPhase.READY || this.phase === CommentPhase.EMPTY) {
-            this.sortChip(CommentSortOrder.SCORE, '最热', 'p3_comments_sort_score')
-            this.sortChip(CommentSortOrder.TIME, '最新', 'p3_comments_sort_time')
-          }
         }
         Button({ type: ButtonType.Normal, stateEffect: true }) {
           SymbolGlyph($r('sys.symbol.xmark'))
@@ -174,18 +184,20 @@ export struct CommentLayer {
       .width('100%')
     }
     .width('100%')
-    .padding($r('app.float.p1_card_padding'))
+    .padding({ left: 16, right: 16, top: 8, bottom: 4 })
   }
 
   @Builder
   private sortChip(order: CommentSortOrder, label: string, testId: string) {
-    Button(label, { type: ButtonType.Capsule })
+    Button(label, { type: ButtonType.ROUNDED_RECTANGLE })
       .id(testId)
       .fontSize($r('app.float.p1_secondary_font_size'))
-      .fontColor(this.sortOrder === order ? $r('app.color.on_brand') : $r('app.color.primary_text'))
+      .fontColor(this.sortOrder === order ? $r('app.color.brand_primary') : $r('app.color.secondary_text'))
+      .fontWeight(this.sortOrder === order ? FontWeight.Medium : FontWeight.Normal)
+      .height(32)
+      .padding({ left: 16, right: 16 })
       .backgroundColor(this.sortOrder === order
-        ? $r('app.color.brand_primary')
-        : $r('app.color.control_background'))
+        ? $r('app.color.brand_primary_container') : $r('app.color.control_background'))
       .onClick((): void => {
         this.controller?.changeSortOrder(order);
       })
@@ -223,13 +235,21 @@ export struct CommentLayer {
           .backgroundColor($r('app.color.surface_background'))
         }
 
-        if (this.phase === CommentPhase.EMPTY) {
+        if (this.phase === CommentPhase.EMPTY && this.activeRoot === undefined) {
           this.statusPanel(this.activeRoot === undefined ? '暂无评论，来发表第一条吧' : '暂无回复', false)
         } else {
           if (this.activeRoot !== undefined) {
-            List({ space: 10, scroller: this.childScroller }) {
+            List({ space: 16, scroller: this.childScroller }) {
               ListItem() {
                 this.pinnedRootCard(this.activeRoot)
+              }
+              if (this.items.length === 0) {
+                ListItem() {
+                  Text('暂无回复')
+                    .fontColor($r('app.color.secondary_text'))
+                    .width('100%')
+                    .textAlign(TextAlign.Center)
+                }
               }
               ForEach(this.items, (comment: CommentItem) => {
                 ListItem() {
@@ -248,12 +268,21 @@ export struct CommentLayer {
               }
             }
             .id('p3_comments_children_list')
+            .padding({ left: 16, right: 16, top: 8, bottom: 16 })
             .width('100%')
             .layoutWeight(1)
             .edgeEffect(EdgeEffect.Spring)
             .onReachEnd(() => this.controller?.loadMore())
           } else {
-            List({ space: 10, scroller: this.rootScroller }) {
+            List({ space: 16, scroller: this.rootScroller }) {
+              ListItem() {
+                Row({ space: 12 }) {
+                  this.sortChip(CommentSortOrder.SCORE, '最热', 'p3_comments_sort_score')
+                  this.sortChip(CommentSortOrder.TIME, '最新', 'p3_comments_sort_time')
+                }
+                .width('100%')
+                .justifyContent(FlexAlign.End)
+              }
               ForEach(this.items, (comment: CommentItem) => {
                 ListItem() {
                   this.commentCard(comment, true)
@@ -271,6 +300,7 @@ export struct CommentLayer {
               }
             }
             .id('p3_comments_root_list')
+            .padding({ left: 16, right: 16, top: 8, bottom: 16 })
             .width('100%')
             .scrollBar(BarState.Off)
             .layoutWeight(1)
@@ -287,7 +317,7 @@ export struct CommentLayer {
   @Builder
   private statusPanel(message: string, retry: boolean) {
     Column({ space: $r('app.float.p1_spacing_medium') }) {
-      if (!retry) {
+      if (this.phase === CommentPhase.LOADING || this.phase === CommentPhase.IDLE) {
         LoadingProgress()
           .id('p3_comments_loading_progress')
           .width(40)
@@ -323,93 +353,123 @@ export struct CommentLayer {
 
   @Builder
   private commentCard(comment: CommentItem, showChildSection: boolean) {
-    Column({ space: $r('app.float.p1_spacing_small') }) {
-      this.authorRow(comment)
-      if (comment.replyToAuthor !== undefined) {
-        Text(`回复 ${comment.replyToAuthor.name}`)
-          .fontSize($r('app.float.p1_secondary_font_size'))
-          .fontColor($r('app.color.secondary_text'))
-          .width('100%')
-      }
-      Text(stripCommentHtml(comment.contentHtml))
-        .id(`p3_comments_content_${comment.id}`)
-        .fontSize($r('app.float.p1_body_font_size'))
-        .fontColor($r('app.color.primary_text'))
-        .width('100%')
-      this.commentFooter(comment, true)
+    Column({ space: 8 }) {
+      this.commentRow(comment, true)
       if (showChildSection && comment.childCommentCount > 0) {
         this.childSection(comment)
       }
     }
     .alignItems(HorizontalAlign.Start)
     .width('100%')
-    .padding($r('app.float.p1_card_padding'))
-    .borderRadius($r('app.float.p1_card_radius'))
-    .backgroundColor($r('app.color.card_background'))
   }
 
   @Builder
   private pinnedRootCard(comment: CommentItem) {
-    Column({ space: $r('app.float.p1_spacing_small') }) {
-      this.authorRow(comment)
-      Text(stripCommentHtml(comment.contentHtml))
-        .id(`p3_comments_pinned_${comment.id}`)
-        .fontSize($r('app.float.p1_body_font_size'))
-        .fontColor($r('app.color.primary_text'))
-        .width('100%')
-      this.commentFooter(comment, false)
+    Column({ space: 16 }) {
+      this.commentRow(comment, false)
+      Divider().color($r('app.color.control_background'))
     }
-    .alignItems(HorizontalAlign.Start)
     .width('100%')
-    .padding($r('app.float.p1_card_padding'))
-    .borderRadius($r('app.float.p1_card_radius'))
-    .backgroundColor($r('app.color.surface_background'))
+  }
+
+  @Builder
+  private commentRow(comment: CommentItem, showDelete: boolean) {
+    Row({ space: 8 }) {
+      this.avatar(comment)
+      Column({ space: 4 }) {
+        this.authorRow(comment)
+        Text(stripCommentHtml(comment.contentHtml))
+          .id(`p3_comments_content_${comment.id}`)
+          .fontSize(16)
+          .lineHeight(25.6)
+          .fontColor($r('app.color.primary_text'))
+          .copyOption(CopyOptions.LocalDevice)
+          .width('100%')
+        if (commentImageUrl(comment.contentHtml).length > 0) {
+          Image(commentImageUrl(comment.contentHtml))
+            .id(`p3_comments_image_${comment.id}`)
+            .width(200)
+            .height(100)
+            .constraintSize({ maxWidth: '100%' })
+            .objectFit(ImageFit.Contain)
+            .borderRadius(12)
+            .margin({ top: 4 })
+            .accessibilityText('查看评论图片')
+            .onClick((): void => { this.previewImageUrl = commentImageUrl(comment.contentHtml); })
+        }
+        this.commentFooter(comment, showDelete)
+      }
+      .alignItems(HorizontalAlign.Start)
+      .layoutWeight(1)
+    }
+    .alignItems(VerticalAlign.Top)
+    .width('100%')
+    .gesture(
+      PanGesture({ direction: PanDirection.Left, distance: 60 })
+        .onActionEnd((): void => this.controller?.setReplyTarget(comment))
+    )
+  }
+
+  @Builder
+  private avatar(comment: CommentItem) {
+    Stack({ alignContent: Alignment.Center }) {
+      Text(authorInitial(comment.author.name))
+        .fontSize(16)
+        .fontColor($r('app.color.on_brand'))
+        .textAlign(TextAlign.Center)
+        .width(36)
+        .height(36)
+        .backgroundColor($r('app.color.brand_primary'))
+      if (commentAvatarUrl(comment.author.avatarUrl).length > 0) {
+        Image(commentAvatarUrl(comment.author.avatarUrl))
+          .id(`p3_comments_avatar_${comment.id}`)
+          .width(36)
+          .height(36)
+          .objectFit(ImageFit.Cover)
+      }
+    }
+    .width(36)
+    .height(36)
+    .borderRadius(18)
+    .clip(true)
+    .accessibilityText(comment.author.name)
+    .onClick((): void => this.openAuthor(comment))
   }
 
   @Builder
   private authorRow(comment: CommentItem) {
-    Row({ space: $r('app.float.p1_spacing_small') }) {
-      Stack({ alignContent: Alignment.Center }) {
-        // 底层占位：名字首字，头像缺失或加载失败时可见。
-        Text(authorInitial(comment.author.name))
-          .fontSize($r('app.float.p1_secondary_font_size'))
-          .fontColor($r('app.color.on_brand'))
-          .textAlign(TextAlign.Center)
-          .width(32)
-          .height(32)
-          .borderRadius(16)
-          .backgroundColor($r('app.color.brand_primary'))
-        // 顶层真实头像：加载成功覆盖占位（加载失败保持透明，露出首字）。
-        if (commentAvatarUrl(comment.author.avatarUrl).length > 0) {
-          Image(commentAvatarUrl(comment.author.avatarUrl))
-            .id(`p3_comments_avatar_${comment.id}`)
-            .width(32)
-            .height(32)
-            .borderRadius(16)
-            .objectFit(ImageFit.Cover)
-        }
-      }
-      .width(32)
-      .height(32)
-      .clip(true)
+    Flex({ wrap: FlexWrap.Wrap, alignItems: ItemAlign.Center }) {
       Text(comment.author.name)
         .id(`p3_comments_author_${comment.id}`)
-        .fontSize($r('app.float.p1_body_font_size'))
-        .fontWeight(FontWeight.Medium)
+        .fontSize(16)
+        .fontWeight(FontWeight.Bold)
         .fontColor($r('app.color.primary_text'))
-        .onClick((): void => {
-          this.navigate({
-            name: P1DestinationName.PEOPLE,
-            id: comment.author.urlToken.length > 0 ? comment.author.urlToken : comment.author.id
-          });
-        })
+        .onClick((): void => this.openAuthor(comment))
       if (comment.authorTag !== undefined) {
         Text(comment.authorTag)
-          .fontSize($r('app.float.p1_caption_font_size'))
+          .fontSize(12)
           .fontColor($r('app.color.secondary_text'))
-          .padding({ left: 4, right: 4, top: 1, bottom: 1 })
+          .padding({ left: 3, right: 3 })
+          .margin({ left: 4 })
           .borderRadius(3)
           .border({ width: 0.5, color: $r('app.color.secondary_text') })
+      }
+      if (comment.replyToAuthor !== undefined) {
+        Text('回复')
+          .fontSize(14)
+          .fontColor($r('app.color.secondary_text'))
+          .margin({ left: 4, right: 4 })
+        Text(comment.replyToAuthor.name)
+          .fontSize(16)
+          .fontWeight(FontWeight.Bold)
+          .fontColor($r('app.color.primary_text'))
+          .onClick((): void => {
+            const author = comment.replyToAuthor;
+            if (author !== undefined) {
+              this.navigate({ name: P1DestinationName.PEOPLE,
+                id: author.urlToken.length > 0 ? author.urlToken : author.id });
+            }
+          })
       }
     }
     .width('100%')
@@ -417,112 +477,129 @@ export struct CommentLayer {
 
   @Builder
   private commentFooter(comment: CommentItem, showDelete: boolean) {
-    Row() {
+    Flex({ wrap: FlexWrap.Wrap, alignItems: ItemAlign.Center }) {
       Text(formatCommentTime(comment.createdAt))
-        .fontSize($r('app.float.p1_caption_font_size'))
+        .fontSize(12)
         .fontColor($r('app.color.secondary_text'))
-      Text(this.ipLocation(comment))
-        .fontSize($r('app.float.p1_caption_font_size'))
-        .fontColor($r('app.color.secondary_text'))
-        .margin({ left: $r('app.float.p1_spacing_small') })
-
-      Blank()
-
-      Row({ space: 2 }) {
-        Text('回复')
-          .fontSize($r('app.float.p1_caption_font_size'))
+      if (this.ipLocation(comment).length > 0) {
+        Text(this.ipLocation(comment))
+          .fontSize(12)
           .fontColor($r('app.color.secondary_text'))
-        if (comment.childCommentCount > 0) {
-          Text(`${comment.childCommentCount}`)
-            .fontSize($r('app.float.p1_caption_font_size'))
-            .fontColor($r('app.color.secondary_text'))
+          .margin({ left: 8 })
+      }
+      Blank().layoutWeight(1)
+      if (showDelete && comment.isAuthor) {
+        Button({ type: ButtonType.Normal }) {
+          SymbolGlyph($r('sys.symbol.more'))
+            .fontSize(16)
+            .fontColor([$r('app.color.secondary_text')])
+        }
+        .id(`p3_comments_more_button_${comment.id}`)
+        .width(28)
+        .height(28)
+        .padding(0)
+        .backgroundColor(Color.Transparent)
+        .accessibilityText('更多操作')
+        .bindMenu(this.commentMenu(comment))
+      }
+      Button({ type: ButtonType.Normal }) {
+        Row({ space: 4 }) {
+          SymbolGlyph($r('sys.symbol.message'))
+            .fontSize(16)
+            .fontColor([$r('app.color.secondary_text')])
+          if (comment.childCommentCount > 0) {
+            Text(`${comment.childCommentCount}`)
+              .fontSize(12)
+              .fontColor($r('app.color.secondary_text'))
+          }
         }
       }
       .id(`p3_comments_reply_button_${comment.id}`)
-      .onClick((): void => {
-        this.controller?.setReplyTarget(comment);
+      .height(28)
+      .padding({ left: 4, right: 4 })
+      .backgroundColor(Color.Transparent)
+      .accessibilityText('回复')
+      .onClick((): void => this.openReplies(comment))
+      CommentLikeButton({
+        state: this.likeStates[comment.id],
+        interactionEnabled: !this.submitting && !this.deleting,
+        onToggle: (): void => { this.controller?.toggleLike(comment); }
       })
-
-      Row({ space: 2 }) {
-        Text(comment.liked ? '已赞' : '点赞')
-          .fontSize($r('app.float.p1_caption_font_size'))
-          .fontColor(comment.liked ? $r('app.color.brand_primary') : $r('app.color.secondary_text'))
-        Text(`${comment.likeCount}`)
-          .fontSize($r('app.float.p1_caption_font_size'))
-          .fontColor(comment.liked ? $r('app.color.brand_primary') : $r('app.color.secondary_text'))
-      }
-      .id(`p3_comments_like_button_${comment.id}`)
-      .margin({ left: $r('app.float.p1_spacing_medium') })
-      .onClick((): void => {
-        this.controller?.toggleLike(comment);
-      })
-
-      if (showDelete && comment.isAuthor) {
-        Text('删除')
-          .id(`p3_comments_delete_button_${comment.id}`)
-          .fontSize($r('app.float.p1_caption_font_size'))
-          .fontColor($r('app.color.error_text'))
-          .margin({ left: $r('app.float.p1_spacing_medium') })
-          .onClick((): void => {
-            this.controller?.deleteComment(comment.id);
-          })
-      }
     }
     .width('100%')
   }
 
   @Builder
-  private childSection(comment: CommentItem) {
-    Column({ space: $r('app.float.p1_spacing_small') }) {
-      if (comment.childComments.length > 0 && this.isExpanded(comment.id)) {
-        ForEach(comment.childComments, (child: CommentItem) => {
-          Row({ space: $r('app.float.p1_spacing_small') }) {
-            Text(child.author.name)
-              .fontSize($r('app.float.p1_secondary_font_size'))
-              .fontWeight(FontWeight.Medium)
-              .fontColor($r('app.color.primary_text'))
-              .onClick((): void => {
-                this.navigate({
-                  name: P1DestinationName.PEOPLE,
-                  id: child.author.urlToken.length > 0 ? child.author.urlToken : child.author.id
-                });
-              })
-            Text(stripCommentHtml(child.contentHtml))
-              .fontSize($r('app.float.p1_secondary_font_size'))
-              .fontColor($r('app.color.primary_text'))
-              .layoutWeight(1)
-            Text(`${child.likeCount}`)
-              .fontSize($r('app.float.p1_caption_font_size'))
-              .fontColor($r('app.color.secondary_text'))
-          }
-          .width('100%')
-        }, (child: CommentItem): string => `child_${comment.id}_${child.id}`)
-        Button('收起回复')
-          .id(`p3_comments_collapse_${comment.id}`)
-          .fontSize($r('app.float.p1_caption_font_size'))
-          .onClick((): void => {
-            this.toggleExpanded(comment.id);
-          })
-      } else if (comment.childComments.length > 0) {
-        Button('展开回复')
-          .id(`p3_comments_expand_${comment.id}`)
-          .fontSize($r('app.float.p1_caption_font_size'))
-          .onClick((): void => {
-            this.toggleExpanded(comment.id);
-          })
-      }
-      Button(`查看全部 ${comment.childCommentCount} 条回复`)
-        .id(`p3_comments_child_button_${comment.id}`)
-        .fontSize($r('app.float.p1_caption_font_size'))
-        .enabled(!this.submitting && !this.deleting)
+  private commentMenu(comment: CommentItem) {
+    Menu() {
+      MenuItem(this.deleteMenuLabel())
+        .id(`p3_comments_delete_button_${comment.id}`)
         .onClick((): void => {
-          this.controller?.openChildComments(comment);
+          this.getUIContext().showAlertDialog({
+            title: '删除评论',
+            message: '删除后无法恢复，确认删除这条评论吗？',
+            primaryButton: { value: '取消', action: (): void => {} },
+            secondaryButton: { value: '删除', action: (): void => { this.controller?.deleteComment(comment.id); } }
+          });
         })
+    }
+  }
+
+  @Builder
+  private deleteMenuLabel() {
+    Row({ space: 8 }) {
+      SymbolGlyph($r('sys.symbol.trash'))
+        .fontSize(16)
+        .fontColor([$r('app.color.error_text')])
+      Text('删除').fontColor($r('app.color.error_text'))
+    }
+    .padding(12)
+  }
+
+  @Builder
+  private childSection(comment: CommentItem) {
+    Column({ space: 8 }) {
+      ForEach(comment.childComments, (child: CommentItem) => {
+        this.commentRow(child, false)
+      }, (child: CommentItem): string => `preview_${comment.id}_${child.id}`)
+      Button({ type: ButtonType.Capsule }) {
+        Row({ space: 4 }) {
+          SymbolGlyph($r('sys.symbol.message'))
+            .fontSize(16)
+            .fontColor([$r('app.color.secondary_text')])
+          Text(`查看 ${comment.childCommentCount} 条子评论`)
+            .fontSize(12)
+            .fontColor($r('app.color.primary_text'))
+        }
+      }
+      .id(`p3_comments_child_button_${comment.id}`)
+      .height(28)
+      .padding({ left: 16, right: 16 })
+      .backgroundColor($r('app.color.control_background'))
+      .enabled(!this.submitting && !this.deleting)
+      .onClick((): void => { this.controller?.openChildComments(comment); })
     }
     .alignItems(HorizontalAlign.Start)
     .width('100%')
+    .padding({ left: 40 })
   }
 
+  private openAuthor(comment: CommentItem): void {
+    this.navigate({ name: P1DestinationName.PEOPLE,
+      id: comment.author.urlToken.length > 0 ? comment.author.urlToken : comment.author.id });
+  }
+
+  private openReplies(comment: CommentItem): void {
+    if (this.activeRoot !== undefined) {
+      this.controller?.setReplyTarget(comment);
+      return;
+    }
+    const root = this.items.find((item: CommentItem): boolean =>
+      item.id === comment.id || item.childComments.some((child: CommentItem): boolean => child.id === comment.id));
+    if (root !== undefined) {
+      this.controller?.openChildComments(root);
+    }
+  }
   @Builder
   private inputBar() {
     Column() {
@@ -532,8 +609,17 @@ export struct CommentLayer {
             .fontSize($r('app.float.p1_secondary_font_size'))
             .fontColor($r('app.color.secondary_text'))
             .layoutWeight(1)
-          Button('取消回复')
+          Button({ type: ButtonType.Normal }) {
+            SymbolGlyph($r('sys.symbol.xmark'))
+              .fontSize(16)
+              .fontColor([$r('app.color.secondary_text')])
+          }
             .id('p3_comments_cancel_reply')
+            .width(28)
+            .height(28)
+            .padding(0)
+            .backgroundColor(Color.Transparent)
+            .accessibilityText('取消回复')
             .fontSize($r('app.float.p1_caption_font_size'))
             .onClick((): void => {
               this.controller?.setReplyTarget(undefined);
@@ -578,8 +664,22 @@ export struct CommentLayer {
               this.onRootDraftChange(value);
             }
           })
-        Button(this.submitting ? '发送中…' : '发送')
+        Button({ type: ButtonType.Normal }) {
+          if (this.submitting) {
+            LoadingProgress().width(24).height(24)
+          } else {
+            SymbolGlyph($r('sys.symbol.paperplane'))
+              .fontSize(24)
+              .fontColor([this.currentDraft().trim().length > 0
+                ? $r('app.color.brand_primary') : $r('app.color.secondary_text')])
+          }
+        }
           .id('p3_comments_send_button')
+          .width(40)
+          .height(40)
+          .padding(0)
+          .backgroundColor(Color.Transparent)
+          .accessibilityText(this.submitting ? '发送中' : '发送')
           .fontSize($r('app.float.p1_body_font_size'))
           .enabled(!this.submitting && this.currentDraft().trim().length > 0)
           .onClick((): void => {
@@ -612,21 +712,6 @@ export struct CommentLayer {
     });
   }
 
-  private isExpanded(commentId: string): boolean {
-    return this.expandedRootIds.includes(commentId);
-  }
-
-  private toggleExpanded(commentId: string): void {
-    if (this.expandedRootIds.includes(commentId)) {
-      this.expandedRootIds = this.expandedRootIds.filter((value: string): boolean => value !== commentId);
-    } else {
-      const next = this.expandedRootIds.concat([commentId]);
-      this.expandedRootIds = next.length > COMMENT_EXPANDED_IDS_LIMIT
-        ? next.slice(next.length - COMMENT_EXPANDED_IDS_LIMIT)
-        : next;
-    }
-  }
-
   private ipLocation(comment: CommentItem): string {
     for (const tag of comment.commentTags) {
       if (tag.type === 'ip_info' && tag.text.trim().length > 0) {
@@ -637,6 +722,11 @@ export struct CommentLayer {
   }
 
   private applyState(state: CommentViewState): void {
+    if (state.activeRoot !== undefined) {
+      this.likeStateStore.sync([state.activeRoot]);
+    }
+    this.likeStateStore.sync(state.items);
+    this.likeStates = this.likeStateStore.snapshot();
     this.phase = state.phase;
     this.items = state.items;
     this.loadingMore = state.loadingMore;
@@ -647,7 +737,6 @@ export struct CommentLayer {
     this.activeRoot = state.activeRoot;
     this.replyTarget = state.replyTarget;
     this.submitting = state.submitting;
-    this.likeBusy = state.likeBusy;
     this.deleting = state.deleting;
     this.actionMessage = state.actionMessage ?? '';
     this.actionRequiresLogin = state.actionRequiresLogin;
@@ -669,8 +758,28 @@ function commentAvatarUrl(raw: string): string {
   return url;
 }
 
+function commentImageUrl(html: string): string {
+  const anchors = html.match(/<a\b[^>]*>/gi) ?? [];
+  for (const anchor of anchors) {
+    if (!/\bclass\s*=\s*["'][^"']*\bcomment_(img|gif|sticker)\b/i.test(anchor)) {
+      continue;
+    }
+    const href = anchor.match(/\bhref\s*=\s*["']([^"']+)["']/i);
+    if (href !== null) {
+      const url = commentAvatarUrl(href[1].replace(/&amp;/gi, '&'));
+      if (/^https:\/\/(?:picx?|pic[0-9]+)\.zhimg\.com\//i.test(url)) {
+        return url;
+      }
+    }
+  }
+  return '';
+}
+
 function stripCommentHtml(html: string): string {
-  let text = html
+  const content = commentImageUrl(html).length > 0
+    ? html.replace(/<a\b[^>]*\bclass\s*=\s*["'][^"']*\bcomment_(img|gif|sticker)\b[^"']*["'][^>]*>[\s\S]*?<\/a>/gi, '')
+    : html;
+  let text = content
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/<\/(p|div|h[1-6]|li|blockquote)>/gi, '\n')
     .replace(/<[^>]+>/g, '')

--- a/entry/src/main/ets/pages/CommentLayer.ets
+++ b/entry/src/main/ets/pages/CommentLayer.ets
@@ -11,7 +11,6 @@ import {
   CommentPhase,
   CommentViewState
 } from './CommentState';
-import { ContentImagePreview } from './NativeContentDocument';
 import { CommentLikeButton } from './CommentLikeButton';
 import { CommentLikeState, CommentLikeStateStore } from './CommentLikeState';
 /**
@@ -50,7 +49,6 @@ export struct CommentLayer {
   @State private deleting: boolean = false;
   @State private actionMessage: string = '';
   @State private actionRequiresLogin: boolean = false;
-  @State private previewImageUrl: string = '';
   @State private likeStates: Record<string, CommentLikeState> = {};
   private controller?: CommentController;
   private readonly likeStateStore: CommentLikeStateStore = new CommentLikeStateStore();
@@ -106,17 +104,6 @@ export struct CommentLayer {
           }
         }
       })
-      .bindContentCover(this.previewImageUrl.length > 0, this.imagePreview(), {
-        onDisappear: (): void => { this.previewImageUrl = ''; }
-      })
-  }
-
-  @Builder
-  private imagePreview() {
-    ContentImagePreview({
-      url: this.previewImageUrl,
-      onClose: (): void => { this.previewImageUrl = ''; }
-    })
   }
 
   @Builder
@@ -395,7 +382,9 @@ export struct CommentLayer {
             .borderRadius(12)
             .margin({ top: 4 })
             .accessibilityText('查看评论图片')
-            .onClick((): void => { this.previewImageUrl = commentImageUrl(comment.contentHtml); })
+            .onClick((): void => {
+              AppStorage.setOrCreate('p2ImagePreviewUrl', commentImageUrl(comment.contentHtml));
+            })
         }
         this.commentFooter(comment, showDelete)
       }

--- a/entry/src/main/ets/pages/CommentLikeButton.ets
+++ b/entry/src/main/ets/pages/CommentLikeButton.ets
@@ -1,0 +1,31 @@
+import { CommentLikeState } from './CommentLikeState';
+
+@Component
+export struct CommentLikeButton {
+  @ObjectLink state: CommentLikeState;
+  @Prop interactionEnabled: boolean = true;
+  onToggle: () => void = (): void => {};
+
+  build() {
+    Button({ type: ButtonType.Normal }) {
+      Row({ space: 4 }) {
+        SymbolGlyph(this.state.liked ? $r('sys.symbol.hand_thumbsup_fill') : $r('sys.symbol.hand_thumbsup'))
+          .fontSize(16)
+          .fontColor([this.state.liked ? $r('app.color.brand_primary') : $r('app.color.secondary_text')])
+        Text(`${this.state.count}`)
+          .id(`p3_comments_like_count_${this.state.id}`)
+          .fontSize(12)
+          .fontColor(this.state.liked ? $r('app.color.brand_primary') : $r('app.color.secondary_text'))
+      }
+    }
+    .id(`p3_comments_like_button_${this.state.id}`)
+    .height(28)
+    .padding({ left: 4, right: 4 })
+    .margin({ left: 8 })
+    .backgroundColor(Color.Transparent)
+    // 并发请求由控制器门禁处理，不因点赞请求切换所有按钮的禁用样式。
+    .enabled(this.interactionEnabled)
+    .accessibilityText(this.state.liked ? '取消点赞' : '点赞')
+    .onClick((): void => this.onToggle())
+  }
+}

--- a/entry/src/main/ets/pages/CommentLikeState.ets
+++ b/entry/src/main/ets/pages/CommentLikeState.ets
@@ -1,0 +1,53 @@
+import { CommentItem } from 'data';
+
+/** 每条评论共享一个可观察的点赞状态，更新时保留评论行和头像节点。 */
+@Observed
+export class CommentLikeState {
+  readonly id: string;
+  liked: boolean;
+  count: number;
+
+  constructor(comment: CommentItem) {
+    this.id = comment.id;
+    this.liked = comment.liked;
+    this.count = comment.likeCount;
+  }
+
+  update(comment: CommentItem): void {
+    if (this.liked !== comment.liked) {
+      this.liked = comment.liked;
+    }
+    if (this.count !== comment.likeCount) {
+      this.count = comment.likeCount;
+    }
+  }
+}
+
+export class CommentLikeStateStore {
+  private readonly states: Map<string, CommentLikeState> = new Map<string, CommentLikeState>();
+
+  get(comment: CommentItem): CommentLikeState {
+    const existing = this.states.get(comment.id);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const state = new CommentLikeState(comment);
+    this.states.set(comment.id, state);
+    return state;
+  }
+
+  sync(items: Array<CommentItem>): void {
+    items.forEach((comment: CommentItem): void => {
+      this.get(comment).update(comment);
+      this.sync(comment.childComments);
+    });
+  }
+
+  snapshot(): Record<string, CommentLikeState> {
+    const result: Record<string, CommentLikeState> = {};
+    this.states.forEach((state: CommentLikeState, id: string): void => {
+      result[id] = state;
+    });
+    return result;
+  }
+}

--- a/entry/src/main/ets/pages/CommentState.ets
+++ b/entry/src/main/ets/pages/CommentState.ets
@@ -470,22 +470,17 @@ export class CommentController {
       this.emit();
       return;
     }
-    const isChild = this.activeRoot !== undefined;
-    const targetList = isChild ? this.childItems : this.rootItems;
-    const index = targetList.findIndex((candidate: CommentItem): boolean => candidate.id === comment.id);
-    if (index < 0) {
+    const previous = this.findLikeTarget(comment.id);
+    if (previous === undefined) {
       return;
     }
     const generation = this.generation;
-    const previous = targetList[index];
     const nextLiked = !previous.liked;
     const nextCount = Math.max(0, previous.likeCount + (nextLiked ? 1 : -1));
     this.likeBusy = true;
     this.actionMessage = undefined;
     this.actionRequiresLogin = false;
-    const updated = targetList.slice();
-    updated[index] = copyCommentWithLike(previous, nextLiked, nextCount);
-    this.replaceModeItems(isChild, updated);
+    this.updateLikeEverywhere(previous.id, nextLiked, nextCount);
     this.emit();
     try {
       await this.repository.likeComment(comment.id, nextLiked);
@@ -494,12 +489,7 @@ export class CommentController {
       }
     } catch (error) {
       if (this.isCurrent(generation)) {
-        const reverted = (isChild ? this.childItems : this.rootItems).slice();
-        const revertIndex = reverted.findIndex((candidate: CommentItem): boolean => candidate.id === comment.id);
-        if (revertIndex >= 0) {
-          reverted[revertIndex] = previous;
-        }
-        this.replaceModeItems(isChild, reverted);
+        this.updateLikeEverywhere(previous.id, previous.liked, previous.likeCount);
         this.actionMessage = commentActionError(error, '点赞操作失败，请重试');
         this.actionRequiresLogin = commentActionRequiresLogin(error);
       }
@@ -508,6 +498,31 @@ export class CommentController {
         this.likeBusy = false;
         this.emit();
       }
+    }
+  }
+
+  private findLikeTarget(id: string): CommentItem | undefined {
+    if (this.activeRoot?.id === id) {
+      return this.activeRoot;
+    }
+    for (const item of this.childItems.concat(this.rootItems)) {
+      if (item.id === id) {
+        return item;
+      }
+      const child = item.childComments.find((candidate: CommentItem): boolean => candidate.id === id);
+      if (child !== undefined) {
+        return child;
+      }
+    }
+    return undefined;
+  }
+
+  /** 同步根列表、内嵌回复与回复页，避免返回上一层后赞数恢复旧值。 */
+  private updateLikeEverywhere(id: string, liked: boolean, count: number): void {
+    this.rootItems = updateCommentLikes(this.rootItems, id, liked, count);
+    this.childItems = updateCommentLikes(this.childItems, id, liked, count);
+    if (this.activeRoot !== undefined) {
+      this.activeRoot = updateCommentLikes([this.activeRoot], id, liked, count)[0];
     }
   }
 
@@ -597,6 +612,23 @@ export class CommentController {
       this.observer(this.snapshot());
     }
   }
+}
+
+/** 保持评论内容不变，只替换目标 ID 的点赞状态及其所在的父节点。 */
+function updateCommentLikes(items: Array<CommentItem>, id: string, liked: boolean,
+  count: number): Array<CommentItem> {
+  let changed = false;
+  const updated = items.map((item: CommentItem): CommentItem => {
+    const children = updateCommentLikes(item.childComments, id, liked, count);
+    const likeChanged = item.id === id && (item.liked !== liked || item.likeCount !== count);
+    if (!likeChanged && children === item.childComments) {
+      return item;
+    }
+    changed = true;
+    return copyCommentWithLike(item, likeChanged ? liked : item.liked,
+      likeChanged ? count : item.likeCount, children);
+  });
+  return changed ? updated : items;
 }
 
 /** 按评论 ID 去重合并（保持现有顺序在前，新条目在后）。 */

--- a/entry/src/main/ets/pages/ContentDetailPages.ets
+++ b/entry/src/main/ets/pages/ContentDetailPages.ets
@@ -181,11 +181,6 @@ struct ContentDetailPage {
             }
             .layoutWeight(1)
             .width('100%')
-            // 底部操作栏为占位布局（栏在内容流末尾，占真实布局空间，不叠压正文）；
-            // 悬浮穿透方案在无材质降级与图片场景下会遮挡正文，勿改回。
-            if (!this.immersiveReading) {
-              this.bottomActionBar()
-            }
           }
           .width('100%')
           .layoutWeight(1)
@@ -196,6 +191,18 @@ struct ContentDetailPage {
       .height('100%')
       .padding({ top: 94 })
       .backgroundColor($r('app.color.page_background'))
+
+      // 底部操作栏：全屏悬浮层单实例承载（正文从下方穿透直至物理底边）。
+      // 切勿在布局流内再渲染第二份——两份会完全重叠绘制（06a2ab90 修复的错乱根源）。
+      if (!this.immersiveReading && this.content !== undefined &&
+        this.phase === ContentDetailPhase.READY) {
+        Stack({ alignContent: Alignment.Bottom }) {
+          this.bottomActionBar()
+        }
+        .width('100%')
+        .height('100%')
+        .hitTestBehavior(HitTestMode.Transparent)
+      }
 
       if (this.immersiveReading) {
         this.immersiveExitControl()
@@ -515,7 +522,7 @@ struct ContentDetailPage {
         @Builder
   private bottomActionBar() {
     // 沉浸光感玻璃胶囊：左右两块独立悬浮胶囊（PR 的空 HdsTabs 材质画布方案），
-    // 操作栏整体为占位布局（位于内容流末尾），不叠压正文。
+    // 由全屏悬浮层单实例承载，正文从下方穿透直至物理底边（窗口为全屏布局，无避让空带）。
     Column({ space: $r('app.float.p1_spacing_xsmall') }) {
       if (this.interactionErrorMessage.length > 0) {
         this.interactionStatusRow()

--- a/entry/src/main/ets/pages/ContentDetailPages.ets
+++ b/entry/src/main/ets/pages/ContentDetailPages.ets
@@ -1,4 +1,10 @@
+import { QuestionAnswerDataSource } from './QuestionAnswerDataSource';
+import { QuestionAnswerNavigator, stageQuestionAnswerNavigator, takeQuestionAnswerNavigator } from './QuestionAnswerNavigator';
+import { publishQuestionTitle } from './QuestionTitleBar';
+import { FeedContentSummary } from './components/FeedContentSummary';
+import { AppPageStatusKind, AppPageStatusPanel, FeedPullDownIndicatorOptions, feedPullDownIndicator } from './AppPageChrome';
 import { pasteboard } from '@kit.BasicServicesKit';
+import { ComponentContent, SegmentButton, SegmentButtonOptions } from '@kit.ArkUI';
 import {
   P1Destination,
   P1DestinationName
@@ -7,15 +13,20 @@ import {
   AnswerEndorsementDisplay,
   BlockedFeedHistoryGateway,
   BlockingRuleGateway,
+  ChannelContentItem,
   CollectionRepository,
   CommentRepository,
   ContentDetailKind,
   ContentRepository,
   ContentVoteState,
+  feedItemIdentity,
   FollowMutationResult,
   FollowRepository,
   LoginSessionGateway,
   OpenedContentStore,
+  QuestionAnswerFeedRepository,
+  QuestionAnswerSortOrder,
+  QuestionTopicSummary,
   SessionStatus,
   VoteRepository
 } from 'data';
@@ -25,6 +36,11 @@ import {
   BlockingActionViewState,
   BlockingUserCandidate
 } from './BlockingActionState';
+import {
+  QuestionAnswersController,
+  QuestionAnswersPhase,
+  QuestionAnswersViewState
+} from './QuestionAnswersState';
 import {
   ContentDetailController,
   ContentDetailPhase,
@@ -52,6 +68,18 @@ import { GlassCapsule } from './components/MaterialCanvas';
 struct ContentDetailPage {
   kind: ContentDetailKind = ContentDetailKind.QUESTION;
   contentId: string = '';
+  @State private activeContentId: string = '';
+  @State private refreshingAnswers: boolean = false;
+  @State private navigatorBusy: boolean = false;
+  @State private navigatorRevision: number = 0;
+  @State private navigatorError: string = '';
+  @StorageProp('loginFeedReloadTick') @Watch('onLoginChanged') private loginTick: number = 0;
+  @State private authenticated: boolean = false;
+  private answerNavigator?: QuestionAnswerNavigator;
+  private readonly answerDataSource: QuestionAnswerDataSource = new QuestionAnswerDataSource();
+  private refreshContent?: ComponentContent<FeedPullDownIndicatorOptions>;
+  private questionScrolled: boolean = false;
+  private pageActive: boolean = false;
   repository: ContentRepository | undefined = undefined;
   openedContentStore: OpenedContentStore | undefined = undefined;
   rules: BlockingRuleGateway | undefined = undefined;
@@ -63,6 +91,7 @@ struct ContentDetailPage {
   session: LoginSessionGateway | undefined = undefined;
   navigate: (destination: P1Destination) => void = (_destination: P1Destination): void => {
   };
+  questionAnswerFeedFactory: () => QuestionAnswerFeedRepository | undefined = () => undefined;
   onBack: () => void = (): void => {
   };
   @State private phase: ContentDetailPhase = ContentDetailPhase.IDLE;
@@ -88,8 +117,18 @@ struct ContentDetailPage {
   @State private showComments: boolean = false;
   @State private commentRootDraft: string = '';
   @State private commentReplyDraft: string = '';
-  /** P3-9-B：顶栏折叠状态——false 收起（标题行）、true 展开（作者行），滚动后收为标题行。 */
-  @State private topBarScrolled: boolean = false;
+  /** 问题页回答信息流（P1）：状态由 QuestionAnswersController 推送。 */
+  @State private answersState: QuestionAnswersViewState = {
+    phase: QuestionAnswersPhase.IDLE,
+    items: [],
+    loadingMore: false,
+    canLoadMore: false,
+    sortOrder: QuestionAnswerSortOrder.DEFAULT,
+    errorMessage: '',
+    requiresLogin: false
+  };
+  @State private answersSortIndexes: number[] = [0];
+  private answersController?: QuestionAnswersController;
   /** P3-9-C：底部菜单弹窗可见性。 */
   @State private actionMenuShown: boolean = false;
   /** P3-9-C：菜单操作反馈（复制链接结果等）。 */
@@ -104,6 +143,15 @@ struct ContentDetailPage {
   private followController?: FollowController;
 
   aboutToAppear(): void {
+    this.pageActive = true;
+    if (this.activeContentId.length === 0) { this.activeContentId = this.contentId; }
+    this.authenticated = this.session?.getState().status === SessionStatus.AUTHENTICATED;
+    this.refreshContent = new ComponentContent(this.getUIContext(), wrapBuilder(feedPullDownIndicator),
+      new FeedPullDownIndicatorOptions());
+    if (this.kind === ContentDetailKind.ANSWER && this.answerNavigator === undefined) {
+      this.answerNavigator = takeQuestionAnswerNavigator(this.activeContentId);
+    }
+    this.answerNavigator?.resume();
     try {
       this.immersiveMaterialSupported =
         hdsMaterial.getSystemMaterialTypes().includes(hdsMaterial.MaterialType.IMMERSIVE);
@@ -114,6 +162,11 @@ struct ContentDetailPage {
     // 控制器仍存活时直接复用，避免重建控制器并重载正文导致滚动位置丢失。
     if (this.controller !== undefined) {
       this.controller.activate();
+      this.answersController?.activate();
+      this.ensureAnswers();
+      if (this.phase === ContentDetailPhase.LOADING) {
+        void this.controller.load(this.kind, this.activeContentId);
+      }
       return;
     }
     const repository = this.repository;
@@ -128,26 +181,66 @@ struct ContentDetailPage {
       (state: ContentDetailViewState): void => this.applyState(state)
     );
     this.controller.activate();
-    this.controller.load(this.kind, this.contentId);
+    this.controller.load(this.kind, this.activeContentId);
     this.createBlockingAction();
+    this.ensureAnswers();
+  }
+
+  private ensureAnswers(): void {
+    if (!this.pageActive || this.kind !== ContentDetailKind.QUESTION || !this.authenticated) { return; }
+    if (this.answersController === undefined) {
+      const repository = this.questionAnswerFeedFactory();
+      if (repository === undefined) { return; }
+      this.answersSortIndexes = [0];
+      this.answersController = new QuestionAnswersController(repository, this.activeContentId,
+        (state: QuestionAnswersViewState): void => {
+          this.answersState = state;
+          this.answerDataSource.replace(state.items);
+        });
+    }
+    this.answersController.activate();
+  }
+
+  private onLoginChanged(): void {
+    this.authenticated = this.session?.getState().status === SessionStatus.AUTHENTICATED;
+    if (!this.pageActive) { return; }
+    this.answersController?.deactivate();
+    this.answersController = undefined;
+    this.answerDataSource.replace([]);
+    this.ensureAnswers();
+    this.followController?.deactivate();
+    this.followController = undefined;
+    void this.controller?.load(this.kind, this.activeContentId);
   }
 
   aboutToDisappear(): void {
+    this.pageActive = false;
+    this.refreshContent?.dispose();
+    this.refreshContent = undefined;
+    this.answersController?.deactivate();
     this.controller?.deactivate();
     this.voteController?.deactivate();
     this.followController?.deactivate();
-    this.controller = undefined;
-    this.blockingAction = undefined;
+    this.voteController = undefined;
+    this.followController = undefined;
+    this.answerNavigator?.pause();
     this.pendingUserBlock = undefined;
     this.keywordBlockVisible = false;
     this.keywordBlockInput = '';
-    this.voteController = undefined;
-    this.followController = undefined;
     this.showComments = false;
     this.commentRootDraft = '';
     this.commentReplyDraft = '';
-    this.topBarScrolled = false;
     this.immersiveReading = false;
+  }
+
+  private async refreshQuestion(): Promise<void> {
+    this.refreshingAnswers = true;
+    this.followController?.deactivate();
+    this.followController = undefined;
+    try {
+      await Promise.all([this.controller?.load(this.kind, this.activeContentId) ?? Promise.resolve(),
+        this.answersController?.refresh() ?? Promise.resolve()]);
+    } finally { this.refreshingAnswers = false; }
   }
 
   private createBlockingAction(): void {
@@ -173,11 +266,15 @@ struct ContentDetailPage {
         } else if (this.content !== undefined) {
           Column() {
             // P3-9-B：顶栏作为占位（非覆盖），正文在其下方，避免作者行与标题/统计重叠。
-            if (!this.immersiveReading) {
+            if (!this.immersiveReading && this.kind !== ContentDetailKind.QUESTION) {
               this.detailTopBar(this.content)
             }
             Column() {
-              this.loadedContent(this.content)
+              if (this.kind === ContentDetailKind.QUESTION) {
+                this.questionDocument(this.content)
+              } else {
+                this.loadedContent(this.content)
+              }
             }
             .layoutWeight(1)
             .width('100%')
@@ -208,7 +305,8 @@ struct ContentDetailPage {
         this.immersiveExitControl()
       }
 
-      if (this.collectionRepository !== undefined && this.session !== undefined) {
+      if (this.phase === ContentDetailPhase.READY &&
+        this.collectionRepository !== undefined && this.session !== undefined) {
         Column()
           .bindSheet(this.favoriteDialogShown, this.favoriteDialog(), {
             height: SheetSize.LARGE,
@@ -242,12 +340,13 @@ struct ContentDetailPage {
             }
           }
         })
-      if (this.kind === ContentDetailKind.ANSWER || this.kind === ContentDetailKind.ARTICLE ||
-        this.kind === ContentDetailKind.QUESTION) {
+      // 切换回答期间卸载旧内容的弹层，避免普通入参 contentId 留在前一答。
+      if (this.phase === ContentDetailPhase.READY && (this.kind === ContentDetailKind.ANSWER ||
+        this.kind === ContentDetailKind.ARTICLE || this.kind === ContentDetailKind.QUESTION)) {
         CommentLayer({
           contentType: this.kind === ContentDetailKind.ARTICLE ? 'article'
             : this.kind === ContentDetailKind.QUESTION ? 'question' : 'answer',
-          contentId: this.contentId,
+          contentId: this.activeContentId,
           repository: this.commentRepository,
           session: this.session,
           navigate: this.navigate,
@@ -274,7 +373,7 @@ struct ContentDetailPage {
   private favoriteDialog() {
     CollectionDialogComponent({
       contentType: this.kind === ContentDetailKind.ARTICLE ? 'article' : 'answer',
-      contentId: this.contentId,
+      contentId: this.activeContentId,
       repository: this.collectionRepository,
       session: this.session,
       navigate: this.navigate,
@@ -311,7 +410,7 @@ struct ContentDetailPage {
           Button('重新加载')
             .id(`p2_${this.kind}_detail_retry`)
             .onClick((): void => {
-              this.controller?.load(this.kind, this.contentId);
+              this.controller?.load(this.kind, this.activeContentId);
             })
         }
       }
@@ -350,6 +449,28 @@ struct ContentDetailPage {
   @Builder
   private loadedContent(content: LoadedContentDetail) {
     Column() {
+      this.contentHeader(content)
+      this.answerNavigationControls()
+
+      NativeContentDocument({
+        html: contentHtml(content),
+        emptyMessage: contentEmptyMessage(content),
+        collapsible: this.kind === ContentDetailKind.QUESTION,
+        documentFooter: (): void => {
+          this.answerNavigationControls()
+        },
+        onListReachEnd: (): void => {
+          this.answersController?.loadMore();
+        }
+      })
+        .layoutWeight(1)
+    }
+    .width('100%')
+    .height('100%')
+  }
+
+  @Builder
+  private contentHeader(content: LoadedContentDetail) {
       Column({ space: $r('app.float.p1_spacing_small') }) {
         // 作者信息由顶栏折叠作者条承载（头像+名字），内容区不再重复渲染作者行。
 
@@ -360,16 +481,25 @@ struct ContentDetailPage {
             .fontSize($r('app.float.p1_heading_font_size'))
             .fontWeight(FontWeight.Bold)
             .fontColor($r('app.color.primary_text'))
-            .maxLines(3)
-            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .copyOption(CopyOptions.LocalDevice)
             .width('100%')
         }
 
-        Text(this.displayedContentStatistics(content))
+        if (content.kind === ContentDetailKind.QUESTION) {
+          Row({ space: $r('app.float.p1_spacing_medium') }) {
+            this.questionStatItem($r('sys.symbol.eye'), `${content.value.visitCount ?? 0} 浏览`)
+            this.questionStatItem($r('sys.symbol.heart'), `${this.followController === undefined ? content.value.followerCount : this.followerCount} 关注`)
+            this.questionStatItem($r('sys.symbol.message'), `${content.value.commentCount} 评论`)
+          }
           .id(`p2_${content.kind}_detail_statistics`)
-          .fontSize($r('app.float.p1_secondary_font_size'))
-          .fontColor($r('app.color.secondary_text'))
           .width('100%')
+        } else {
+          Text(this.displayedContentStatistics(content))
+            .id(`p2_${content.kind}_detail_statistics`)
+            .fontSize($r('app.float.p1_secondary_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .width('100%')
+        }
 
         if (contentEndorsements(content).length > 0) {
           this.endorsementFlow(contentEndorsements(content))
@@ -408,19 +538,73 @@ struct ContentDetailPage {
         bottom: $r('app.float.p1_spacing_medium')
       })
       .backgroundColor($r('app.color.surface_background'))
+  }
 
+  @Builder
+  private questionDocument(content: LoadedContentDetail) {
+    Refresh({ refreshing: $$this.refreshingAnswers, refreshingContent: this.refreshContent }) {
       NativeContentDocument({
-        html: contentHtml(content),
-        emptyMessage: contentEmptyMessage(content),
+        html: contentHtml(content), emptyMessage: contentEmptyMessage(content), collapsible: true,
+        documentHeader: (): void => { this.contentHeader(content) },
+        documentBodyFooter: (): void => { this.questionBodyFooter(content) },
+        documentItems: (): void => { this.questionAnswerItems() },
+        documentFooter: (): void => { this.questionAnswersFooter() },
+        onListReachEnd: (): void => { this.answersController?.loadMore(); },
         onScrollOffset: (offset: number): void => {
-          // 像素阈值滞回：视口因顶栏收起而变高时偏移量不变，状态不会振荡。
-          this.topBarScrolled = offset > 20;
+          const scrolled = offset > 160;
+          if (scrolled !== this.questionScrolled) {
+            this.questionScrolled = scrolled;
+            this.getUIContext().animateTo({ duration: 220, curve: Curve.EaseInOut }, (): void => {
+              publishQuestionTitle({ id: this.activeContentId, title: contentTitle(content), scrolled: scrolled });
+            });
+          }
         }
       })
-        .layoutWeight(1)
-    }
-    .width('100%')
-    .height('100%')
+    }.height('100%').width('100%').onRefreshing((): void => { void this.refreshQuestion(); })
+  }
+
+  @Builder
+  private questionBodyFooter(content: LoadedContentDetail) {
+    Column({ space: 12 }) {
+        if (content.kind === ContentDetailKind.QUESTION &&
+          (content.value.topics?.length ?? 0) > 0) {
+          Flex({ wrap: FlexWrap.Wrap }) {
+            ForEach(content.value.topics, (topic: QuestionTopicSummary): void => {
+              Button(`# ${topic.name}`, { type: ButtonType.Normal, stateEffect: true })
+                .id(`p3_question_topic_${topic.id}`)
+                .height(30)
+                .fontSize($r('app.float.p1_caption_font_size'))
+                .fontColor($r('app.color.secondary_text'))
+                .backgroundColor($r('app.color.surface_background'))
+                .borderRadius(15)
+                .margin({ right: 8, bottom: 8 })
+                .onClick((): void => this.navigate({ name: P1DestinationName.SEARCH, query: topic.name }))
+            }, (topic: QuestionTopicSummary): string => topic.id)
+          }
+          .width('100%')
+        }
+
+
+      Button('写回答')
+        .id('question_write_answer').width('100%')
+        .onClick((): void => this.navigate(this.authenticated
+          ? { name: P1DestinationName.WRITE_ANSWER, questionId: this.activeContentId }
+          : { name: P1DestinationName.LOGIN }))
+      Row() {
+        Text(this.questionAnswerCount().toString() + ' 回答').fontWeight(FontWeight.Medium)
+          .fontColor($r('app.color.primary_text')).layoutWeight(1)
+        SegmentButton({ options: this.answersSortOptions, selectedIndexes: $answersSortIndexes,
+          onItemClicked: (index: number): void => this.selectAnswerSort(index) })
+          .id('question_sort').width(168).height(36)
+      }.width('100%')
+    }.width('100%')
+  }
+
+  @Builder
+  private questionAnswerItems() {
+    LazyForEach(this.answerDataSource, (item: ChannelContentItem) => {
+      ListItem() { this.answerFeedCard(item) }
+    }, (item: ChannelContentItem): string => feedItemIdentity(item.feedItem))
   }
 
   @Builder
@@ -679,6 +863,145 @@ struct ContentDetailPage {
     })
   }
 
+  /** 问题页统计项：小图标 + 辅助文字（对齐上游 StatItem）。 */
+  @Builder
+  private questionStatItem(icon: Resource, text: string) {
+    Row({ space: 4 }) {
+      SymbolGlyph(icon)
+        .fontSize(14)
+        .fontColor([$r('app.color.secondary_text')])
+      Text(text)
+        .fontSize($r('app.float.p1_secondary_font_size'))
+        .fontColor($r('app.color.secondary_text'))
+    }
+    .alignItems(VerticalAlign.Center)
+  }
+
+  /**
+   * 问题页回答信息流 footer：挂载在正文文档列表末尾，随同一滚动贯通（对齐上游单列表）。
+   * 注意：@BuilderParam 传入的箭头闭包体内只允许直接调用本 builder（不得再包 if 等非 UI
+   * 语句，否则编译器不转换 builder 调用，运行时静默不渲染）；kind 守卫放在 builder 内部。
+   */
+  @Builder
+  private questionAnswersFooter() {
+    if (this.kind === ContentDetailKind.QUESTION) {
+      Column({ space: 12 }) {
+        if (!this.authenticated) {
+          AppPageStatusPanel({ kind: AppPageStatusKind.EMPTY, message: '登录后即可查看全部回答',
+            testId: 'question_answers_login', actionLabel: '去登录', actionId: 'question_answers_login_button',
+            onAction: (): void => this.navigate({ name: P1DestinationName.LOGIN }) })
+        } else if (this.answersState.phase === QuestionAnswersPhase.INITIAL_LOADING) {
+          AppPageStatusPanel({ message: '正在加载回答…', testId: 'question_answers_loading' })
+        } else if (this.answersState.errorMessage.length > 0) {
+          AppPageStatusPanel({ kind: AppPageStatusKind.ERROR, message: this.answersState.errorMessage,
+            testId: 'question_answers_error', actionLabel: this.answersState.requiresLogin ? '去登录' : '重试',
+            actionId: 'question_answers_retry', onAction: (): void => {
+              if (this.answersState.requiresLogin) { this.navigate({ name: P1DestinationName.LOGIN }); }
+              else if (this.answersState.phase === QuestionAnswersPhase.ERROR) { this.answersController?.refresh(); }
+              else { this.answersController?.loadMore(); }
+            } })
+        } else if (this.answersState.phase === QuestionAnswersPhase.EMPTY) {
+          AppPageStatusPanel({ kind: AppPageStatusKind.EMPTY, message: '暂无可显示的回答', testId: 'question_answers_empty' })
+        } else if (this.answersState.loadingMore) {
+          LoadingProgress().id('p3_question_answers_loading_more').width(40).height(40)
+            .color($r('app.color.brand_primary'))
+        } else if (this.answersState.canLoadMore) {
+          Button('加载更多回答').id('question_answers_more')
+            .onClick((): void => { this.answersController?.loadMore(); })
+        } else {
+          Text('已显示全部回答').fontColor($r('app.color.secondary_text'))
+        }
+      }.width('100%').padding({ top: 12, bottom: 12 })
+    }
+  }
+
+  @Builder
+  private answerFeedCard(item: ChannelContentItem) {
+    Button({ type: ButtonType.Normal, stateEffect: true }) {
+      FeedContentSummary({ target: item.feedItem.target, showTitle: false })
+    }.id('p3_question_answers_card_' + item.feedItem.target.id)
+      .width('100%').padding($r('app.float.p1_card_padding'))
+      .borderRadius($r('app.float.p1_card_radius')).backgroundColor($r('app.color.surface_background'))
+      .accessibilityText('打开回答').onClick((): void => {
+        const repository = this.questionAnswerFeedFactory();
+        const seed = this.answersController?.snapshot();
+        if (repository !== undefined && seed !== undefined) {
+          stageQuestionAnswerNavigator(new QuestionAnswerNavigator(this.activeContentId,
+            item.feedItem.target.id, seed, repository));
+        }
+        this.navigate({ name: P1DestinationName.ANSWER, id: item.feedItem.target.id });
+      })
+  }
+
+  // SegmentButton 的 options 是 @ObjectLink，须放观察状态（内联对象在真机上会丢点击回调）。
+  @State private answersSortOptions: SegmentButtonOptions = SegmentButtonOptions.tab({
+    buttons: [{ text: '默认' }, { text: '最新' }]
+  });
+
+  private questionAnswerCount(): number {
+    const content = this.content;
+    if (content === undefined || content.kind !== ContentDetailKind.QUESTION) {
+      return 0;
+    }
+    return content.value.answerCount;
+  }
+
+  private selectAnswerSort(index: number): void {
+    if (index !== 0 && index !== 1) {
+      return;
+    }
+    if (this.answersSortIndexes[0] !== index) {
+      this.answersSortIndexes = [index];
+    }
+    const order = index === 0 ? QuestionAnswerSortOrder.DEFAULT : QuestionAnswerSortOrder.UPDATED;
+    this.answersController?.setSortOrder(order);
+  }
+
+  @Builder
+  private answerNavigationControls() {
+    if (this.kind === ContentDetailKind.ANSWER && this.answerNavigator !== undefined) {
+      Column() {
+        Row({ space: 12 }) {
+          Button('上一答').id('question_answer_previous')
+            .enabled(!this.navigatorBusy && this.navigatorHasPrevious()).layoutWeight(1)
+            .onClick((): void => { void this.moveAnswer(-1); })
+          Button('下一答').id('question_answer_next')
+            .enabled(!this.navigatorBusy && this.navigatorHasNext()).layoutWeight(1)
+            .onClick((): void => { void this.moveAnswer(1); })
+        }.width('100%')
+        if (this.navigatorError.length > 0) {
+          Text(this.navigatorError).fontColor($r('app.color.error_text'))
+        }
+      }.width('100%').padding(8)
+    }
+  }
+
+  private navigatorHasPrevious(): boolean {
+    return this.navigatorRevision >= 0 && (this.answerNavigator?.hasPrevious() ?? false);
+  }
+  private navigatorHasNext(): boolean {
+    return this.navigatorRevision >= 0 && (this.answerNavigator?.hasNext() ?? false);
+  }
+  private async moveAnswer(direction: number): Promise<void> {
+    if (this.navigatorBusy) { return; }
+    this.navigatorBusy = true;
+    this.navigatorError = '';
+    try {
+      const id = await this.answerNavigator?.move(direction);
+      this.navigatorRevision += 1;
+      if (!this.pageActive) { return; }
+      if (id === undefined) { this.navigatorError = this.answerNavigator?.errorMessage() ?? ''; return; }
+      this.voteController?.deactivate();
+      this.voteController = undefined;
+      this.showComments = false;
+      this.favoriteDialogShown = false;
+      this.commentRootDraft = '';
+      this.commentReplyDraft = '';
+      this.activeContentId = id;
+      await this.controller?.load(ContentDetailKind.ANSWER, id);
+    } finally { this.navigatorBusy = false; }
+  }
+
   private canEditExistingAnswer(): boolean {
     const content = this.content;
     const session = this.session;
@@ -706,54 +1029,75 @@ struct ContentDetailPage {
 
   @Builder
   private detailTopBar(content: LoadedContentDetail) {
-    // P3-9-B：顶部折叠作者栏——未滚动展开显示作者行（头像/名字/简介），滚动后收起为标题行。
-    // 页面返回与类型标题由固定单行标题栏提供，此处只承载内容上下文。
+    // 作者栏常驻（不可随滚动收缩）：收缩会改变布局高度，中长正文在阈值附近反复触发
+    // 视口高度突变，导致作者栏闪烁与滚动顿挫（上游无此问题因其作者条在列表内随内容
+    // 滚走；本侧为固定头部，收缩必然跳动）。无作者时显示单行标题占位。
     Row() {
-      if (!this.topBarScrolled) {
-        if (contentAuthorName(content).length > 0) {
-          Row({ space: $r('app.float.p1_spacing_small') }) {
-            Stack({ alignContent: Alignment.Center }) {
-              // 底层占位：首字圆，头像缺失或加载失败时可见。
-              Circle()
+      if (contentAuthorName(content).length > 0) {
+        Row({ space: $r('app.float.p1_spacing_small') }) {
+          Stack({ alignContent: Alignment.Center }) {
+            // 底层占位：首字圆，头像缺失或加载失败时可见。
+            Circle()
+              .width(36)
+              .height(36)
+              .fill($r('app.color.control_background'))
+            Text(contentAuthorName(content).substring(0, 1))
+              .fontSize($r('app.float.p1_caption_font_size'))
+              .fontColor($r('app.color.secondary_text'))
+            // 顶层真实头像：加载成功覆盖占位（加载失败保持透明，露出首字圆）。
+            if (contentAuthorAvatarUrl(content).length > 0) {
+              Image(contentAuthorAvatarUrl(content))
+                .id(`p3_${content.kind}_detail_top_avatar`)
                 .width(36)
                 .height(36)
-                .fill($r('app.color.control_background'))
-              Text(contentAuthorName(content).substring(0, 1))
+                .borderRadius(18)
+                .objectFit(ImageFit.Cover)
+            }
+          }
+          .width(36)
+          .height(36)
+          .clip(true)
+
+          Column({ space: 2 }) {
+            Text(contentAuthorName(content))
+              .id(`p3_${content.kind}_detail_top_author`)
+              .fontSize($r('app.float.p1_body_font_size'))
+              .fontColor($r('app.color.primary_text'))
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+            if (contentAuthorHeadline(content).length > 0) {
+              Text(contentAuthorHeadline(content))
                 .fontSize($r('app.float.p1_caption_font_size'))
                 .fontColor($r('app.color.secondary_text'))
-              // 顶层真实头像：加载成功覆盖占位（加载失败保持透明，露出首字圆）。
-              if (contentAuthorAvatarUrl(content).length > 0) {
-                Image(contentAuthorAvatarUrl(content))
-                  .id(`p3_${content.kind}_detail_top_avatar`)
-                  .width(36)
-                  .height(36)
-                  .borderRadius(18)
-                  .objectFit(ImageFit.Cover)
-              }
-            }
-            .width(36)
-            .height(36)
-            .clip(true)
-
-            Column({ space: 2 }) {
-              Text(contentAuthorName(content))
-                .id(`p3_${content.kind}_detail_top_author`)
-                .fontSize($r('app.float.p1_body_font_size'))
-                .fontColor($r('app.color.primary_text'))
                 .maxLines(1)
                 .textOverflow({ overflow: TextOverflow.Ellipsis })
-              if (contentAuthorHeadline(content).length > 0) {
-                Text(contentAuthorHeadline(content))
-                  .fontSize($r('app.float.p1_caption_font_size'))
-                  .fontColor($r('app.color.secondary_text'))
-                  .maxLines(1)
-                  .textOverflow({ overflow: TextOverflow.Ellipsis })
-              }
             }
-            .layoutWeight(1)
-            .alignItems(HorizontalAlign.Start)
           }
-          .id(`p3_${content.kind}_detail_top_author_row`)
+          .layoutWeight(1)
+          .alignItems(HorizontalAlign.Start)
+        }
+        .id(`p3_${content.kind}_detail_top_author_row`)
+        .layoutWeight(1)
+        .padding({
+          left: $r('app.float.p1_page_padding'),
+          right: $r('app.float.p1_page_padding'),
+          top: $r('app.float.p1_spacing_small'),
+          bottom: $r('app.float.p1_spacing_small')
+        })
+        .onClick((): void => {
+          const author = content.value.author;
+          if (author !== undefined && author.id.trim().length > 0) {
+            const urlToken = author.urlToken ?? author.id;
+            this.navigate({ name: P1DestinationName.PEOPLE, id: urlToken });
+          }
+        })
+      } else {
+        Text(contentTitle(content))
+          .id(`p3_${content.kind}_detail_top_title`)
+          .fontSize($r('app.float.p1_body_font_size'))
+          .fontColor($r('app.color.primary_text'))
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
           .layoutWeight(1)
           .padding({
             left: $r('app.float.p1_page_padding'),
@@ -761,16 +1105,6 @@ struct ContentDetailPage {
             top: $r('app.float.p1_spacing_small'),
             bottom: $r('app.float.p1_spacing_small')
           })
-          .onClick((): void => {
-            const author = content.value.author;
-            if (author !== undefined && author.id.trim().length > 0) {
-              const urlToken = author.urlToken ?? author.id;
-              this.navigate({ name: P1DestinationName.PEOPLE, id: urlToken });
-            }
-          })
-        }
-        // 无作者与收起态均不再渲染标题行（对齐回答/文章页）：问题标题由下方固定信息头
-        // 常驻展示，条带再渲染同款标题会与之同屏重复。
       }
     }
     .width('100%')
@@ -1064,6 +1398,9 @@ struct ContentDetailPage {
     this.openedRecordPhase = state.openedRecordPhase;
     if (state.phase === ContentDetailPhase.READY && state.content !== undefined) {
       this.activateInteraction(state.content);
+      if (state.content.kind === ContentDetailKind.QUESTION) {
+        publishQuestionTitle({ id: this.activeContentId, title: state.content.value.title, scrolled: this.questionScrolled });
+      }
     }
   }
 
@@ -1074,7 +1411,7 @@ struct ContentDetailPage {
       }
       const repository = this.followRepository;
       const session = this.session;
-      const contentId = this.contentId;
+      const contentId = this.activeContentId;
       this.followController = new FollowController(
         repository,
         session,
@@ -1091,7 +1428,7 @@ struct ContentDetailPage {
         this.voteRepository,
         this.session,
         this.kind,
-        this.contentId,
+        this.activeContentId,
         (state: ContentVoteViewState): void => this.applyVoteState(state)
       );
       this.voteController.activate();
@@ -1127,6 +1464,7 @@ struct ContentDetailPage {
 
 @Component
 export struct QuestionDetailPage {
+  questionAnswerFeedFactory: () => QuestionAnswerFeedRepository | undefined = () => undefined;
   contentId: string = '';
   repository: ContentRepository | undefined = undefined;
   openedContentStore: OpenedContentStore | undefined = undefined;
@@ -1145,6 +1483,7 @@ export struct QuestionDetailPage {
   build() {
     ContentDetailPage({
       kind: ContentDetailKind.QUESTION,
+      questionAnswerFeedFactory: this.questionAnswerFeedFactory,
       contentId: this.contentId,
       repository: this.repository,
       openedContentStore: this.openedContentStore,

--- a/entry/src/main/ets/pages/ContentDetailPages.ets
+++ b/entry/src/main/ets/pages/ContentDetailPages.ets
@@ -1900,11 +1900,13 @@ struct ContentDetailPage {
       this.menuStatus = '暂时无法打开分享面板';
       return;
     }
+    const contextTitle = contentContextTitle(content);
     const payload: ShareTextPayload = {
       kind: SharePayloadKind.TEXT,
-      title: contentDetailPageTitle(content.kind),
-      summary: '来自知乎++的受信内容链接',
-      contentUrl: content.value.url
+      title: contextTitle.length > 0 ? contextTitle : contentDetailPageTitle(content.kind),
+      summary: contentShareSummary(content),
+      contentUrl: content.value.url,
+      thumbnailUrl: contentShareThumbnailUrl(content)
     };
     createSystemShareService(context).share(payload).then((outcome: ShareOutcome): void => {
       this.menuStatus = outcome === ShareOutcome.CANCELLED ? '' : '已打开系统分享面板';
@@ -2276,6 +2278,23 @@ export function contentContextTitle(content: LoadedContentDetail): string {
     return content.value.questionTitle?.trim() ?? '';
   }
   return contentTitle(content).trim();
+}
+
+/** 分享面板摘要：回答/文章用正文摘录，问题与缺失时用固定文案。 */
+export function contentShareSummary(content: LoadedContentDetail): string {
+  if (content.kind === ContentDetailKind.ANSWER || content.kind === ContentDetailKind.ARTICLE) {
+    const excerpt = content.value.excerpt.trim();
+    if (excerpt.length > 0) {
+      return excerpt;
+    }
+  }
+  return '来自知乎++的受信内容链接';
+}
+
+/** 分享卡片缩略图：仅接受受信 zhimg 头像 URL，其余返回 undefined（卡片退回默认图标）。 */
+export function contentShareThumbnailUrl(content: LoadedContentDetail): string | undefined {
+  const url = contentAuthorAvatarUrl(content);
+  return /^https:\/\/(?:pic|pica|picx|pic[0-9]+)\.zhimg\.com\//.test(url) ? url : undefined;
 }
 
 export function contentHtml(content: LoadedContentDetail): string {

--- a/entry/src/main/ets/pages/ContentDetailPages.ets
+++ b/entry/src/main/ets/pages/ContentDetailPages.ets
@@ -1,5 +1,6 @@
 import { QuestionAnswerDataSource } from './QuestionAnswerDataSource';
 import { AnswerNavigationPreview, QuestionAnswerNavigator, stageQuestionAnswerNavigator, takeQuestionAnswerNavigator } from './QuestionAnswerNavigator';
+import { ContentImagePreview } from './NativeContentDocument';
 import { publishQuestionTitle } from './QuestionTitleBar';
 import { publishAnswerTitle } from './AnswerTitleBar';
 import { publishArticleTitle } from './ArticleTitleBar';
@@ -102,6 +103,9 @@ struct ContentDetailPage {
   private answerFabOverlayWidthVp: number = 0;
   private answerFabOverlayHeightVp: number = 0;
   @StorageProp('loginFeedReloadTick') @Watch('onLoginChanged') private loginTick: number = 0;
+  /** 全屏图片查看器：正文/评论图点击后经 AppStorage 广播，在页面根 Stack 叠层渲染
+   *（正文列表惰性树与模态覆盖层树内均无法可靠驱动状态更新，见 NativeContentDocument 注释）。 */
+  @StorageProp('p2ImagePreviewUrl') @Watch('onImagePreviewChanged') private imagePreviewUrl: string = '';
   @State private authenticated: boolean = false;
   private answerNavigator?: QuestionAnswerNavigator;
   private readonly answerDataSource: QuestionAnswerDataSource = new QuestionAnswerDataSource();
@@ -283,6 +287,7 @@ struct ContentDetailPage {
     this.commentReplyDraft = '';
     this.immersiveReading = false;
     AppStorage.setOrCreate('detailImmersiveActive', false);
+    AppStorage.setOrCreate('p2ImagePreviewUrl', '');
     // 对齐上游 LeaveImmersiveModeCleanup：页面销毁时确保状态栏恢复。
     setStatusBarHidden(false);
   }
@@ -291,6 +296,11 @@ struct ContentDetailPage {
     AppStorage.setOrCreate('detailImmersiveActive', this.immersiveReading);
     // 真全屏：沉浸中隐藏状态栏（对齐上游 WindowInsetsController.hide(statusBars)）。
     setStatusBarHidden(this.immersiveReading);
+  }
+
+  /** 全屏图片查看器打开时同步隐藏状态栏（对齐沉浸阅读的真全屏处理），关闭时恢复。 */
+  private onImagePreviewChanged(): void {
+    setStatusBarHidden(this.immersiveReading || this.imagePreviewUrl.length > 0);
   }
 
   private onImmersiveExitSignal(): void {
@@ -460,6 +470,22 @@ struct ContentDetailPage {
             this.showComments = false;
           }
         })
+      }
+
+      // 全屏图片查看器叠层：置于根 Stack 最后一个子节点，盖住正文/底部操作栏；
+      // 标题栏由 P1Shell 监听同一 AppStorage 键隐藏（hideTitleBar）。
+      if (this.imagePreviewUrl.length > 0) {
+        Stack({ alignContent: Alignment.Center }) {
+          ContentImagePreview({
+            url: this.imagePreviewUrl,
+            onClose: (): void => {
+              AppStorage.setOrCreate('p2ImagePreviewUrl', '');
+            }
+          })
+        }
+        .id('p2_image_preview_overlay')
+        .width('100%')
+        .height('100%')
       }
     }
     .width('100%')

--- a/entry/src/main/ets/pages/ContentDetailPages.ets
+++ b/entry/src/main/ets/pages/ContentDetailPages.ets
@@ -2,6 +2,7 @@ import { QuestionAnswerDataSource } from './QuestionAnswerDataSource';
 import { AnswerNavigationPreview, QuestionAnswerNavigator, stageQuestionAnswerNavigator, takeQuestionAnswerNavigator } from './QuestionAnswerNavigator';
 import { publishQuestionTitle } from './QuestionTitleBar';
 import { publishAnswerTitle } from './AnswerTitleBar';
+import { publishArticleTitle } from './ArticleTitleBar';
 import { FeedContentSummary } from './components/FeedContentSummary';
 import { AppPageStatusKind, AppPageStatusPanel, FeedPullDownIndicatorOptions, feedPullDownIndicator } from './AppPageChrome';
 import { pasteboard } from '@kit.BasicServicesKit';
@@ -103,8 +104,10 @@ struct ContentDetailPage {
   private questionScrolled: boolean = false;
   /** 回答页顶栏折叠：问题标题已滚出视口（经 AppStorage 驱动 HDS 标题栏折叠态）。 */
   private answerQuestionScrolled: boolean = false;
-  /** 回答页滚动信息头中问题标题实测高度（vp）：折叠阈值的动态基准；未测得前按单行估算。 */
-  private answerQuestionHeightVp: number = 0;
+  /** 文章页顶栏折叠：文章标题已滚出视口（经 AppStorage 驱动 HDS 标题栏折叠态）。 */
+  private articleTitleScrolled: boolean = false;
+  /** 详情页滚动信息头中主标题实测高度（vp）：折叠阈值的动态基准；未测得前按单行估算。 */
+  private contentTitleHeightVp: number = 0;
   private pageActive: boolean = false;
   repository: ContentRepository | undefined = undefined;
   openedContentStore: OpenedContentStore | undefined = undefined;
@@ -293,11 +296,8 @@ struct ContentDetailPage {
           this.statusPanel(this.errorMessage, true)
         } else if (this.content !== undefined) {
           Column() {
-            // P3-9-B：顶栏作为占位（非覆盖），正文在其下方，避免作者行与标题/统计重叠。
-            // 回答页作者信息随滚动信息头走（对齐上游），不再渲染固定作者条。
-            if (!this.immersiveReading && this.kind === ContentDetailKind.ARTICLE) {
-              this.detailTopBar(this.content)
-            }
+            // P3-9-B：顶栏作为占位（非覆盖），正文在其下方。
+            // 回答/文章页信息头（标题/作者/时间）随正文滚动（对齐上游折叠顶栏），无固定信息条。
             Column() {
               if (this.kind === ContentDetailKind.QUESTION) {
                 this.questionDocument(this.content)
@@ -522,39 +522,28 @@ struct ContentDetailPage {
 
       // 上层：主内容，跟随 overscroll 偏移平移。
       Column() {
-        // 回答页：问题/作者/时间信息头入列随正文滚动（对齐上游折叠顶栏），
-        // 滚过问题标题后经 AppStorage 通知 HDS 标题栏折叠。
-        if (this.kind === ContentDetailKind.ANSWER) {
-          NativeContentDocument({
-            html: contentHtml(content),
-            emptyMessage: contentEmptyMessage(content),
-            disableEdgeSpring: true,
-            documentHeader: (): void => { this.contentHeader(content) },
-            onScrollOffset: (offset: number): void => { this.updateAnswerTitleScrolled(content, offset) },
-            onBottomEdgeChange: (atBottom: boolean): void => {
-              this.contentAtBottom = atBottom;
-            },
-            onTopEdgeChange: (atTop: boolean): void => {
-              this.contentAtTop = atTop;
+        // 回答/文章页：信息头（标题/作者/时间）入列随正文滚动（对齐上游折叠顶栏），
+        // 滚过主标题后经 AppStorage 通知 HDS 标题栏折叠为内容标题。
+        NativeContentDocument({
+          html: contentHtml(content),
+          emptyMessage: contentEmptyMessage(content),
+          disableEdgeSpring: this.kind === ContentDetailKind.ANSWER,
+          documentHeader: (): void => { this.contentHeader(content) },
+          onScrollOffset: (offset: number): void => {
+            if (this.kind === ContentDetailKind.ANSWER) {
+              this.updateAnswerTitleScrolled(content, offset);
+            } else {
+              this.updateArticleTitleScrolled(content, offset);
             }
-          })
-            .layoutWeight(1)
-        } else {
-          // 文章页：信息头固定在正文上方（保持原布局）。
-          this.contentHeader(content)
-
-          NativeContentDocument({
-            html: contentHtml(content),
-            emptyMessage: contentEmptyMessage(content),
-            onBottomEdgeChange: (atBottom: boolean): void => {
-              this.contentAtBottom = atBottom;
-            },
-            onTopEdgeChange: (atTop: boolean): void => {
-              this.contentAtTop = atTop;
-            }
-          })
-            .layoutWeight(1)
-        }
+          },
+          onBottomEdgeChange: (atBottom: boolean): void => {
+            this.contentAtBottom = atBottom;
+          },
+          onTopEdgeChange: (atTop: boolean): void => {
+            this.contentAtTop = atTop;
+          }
+        })
+          .layoutWeight(1)
       }
       .width('100%')
       .height('100%')
@@ -770,8 +759,8 @@ struct ContentDetailPage {
             .width('100%')
             .onAreaChange((_oldArea: Area, newArea: Area): void => {
               const height = Number(newArea.height);
-              if (height > 0 && Math.abs(height - this.answerQuestionHeightVp) > 1) {
-                this.answerQuestionHeightVp = height;
+              if (height > 0 && Math.abs(height - this.contentTitleHeightVp) > 1) {
+                this.contentTitleHeightVp = height;
               }
             })
             .accessibilityDescription(content.kind === ContentDetailKind.ANSWER ? '点击查看问题详情' : '')
@@ -782,20 +771,20 @@ struct ContentDetailPage {
             })
         }
 
-        // 回答页作者信息随信息头滚动（对齐上游展开顶栏）：头像 + 名称 + 一句话简介。
-        if (content.kind === ContentDetailKind.ANSWER) {
-          this.answerHeaderAuthorRow(content)
+        // 回答/文章页作者信息随信息头滚动（对齐上游展开顶栏）：头像 + 名称 + 一句话简介。
+        if (content.kind === ContentDetailKind.ANSWER || content.kind === ContentDetailKind.ARTICLE) {
+          this.contentHeaderAuthorRow(content)
         }
 
-        // 回答页发布/编辑时间（对齐上游 DateTexts：编辑时间与发布不同才显示）。
-        if (content.kind === ContentDetailKind.ANSWER && contentCreatedAtText(content).length > 0) {
+        // 回答/文章页发布/编辑时间（对齐上游 DateTexts：编辑时间与发布不同才显示）。
+        if (contentCreatedAtText(content).length > 0) {
           Text(contentCreatedAtText(content))
             .id(`p2_${content.kind}_detail_created_at`)
             .fontSize($r('app.float.p1_caption_font_size'))
             .fontColor($r('app.color.secondary_text'))
             .width('100%')
         }
-        if (content.kind === ContentDetailKind.ANSWER && contentUpdatedAtText(content).length > 0) {
+        if (contentUpdatedAtText(content).length > 0) {
           Text(contentUpdatedAtText(content))
             .id(`p2_${content.kind}_detail_updated_at`)
             .fontSize($r('app.float.p1_caption_font_size'))
@@ -850,19 +839,21 @@ struct ContentDetailPage {
       .alignItems(HorizontalAlign.Start)
       .width('100%')
       .padding({
-        // 回答页信息头在列表内滚动：左右与顶部留白由 List 统一提供，避免双重内边距。
-        left: content.kind === ContentDetailKind.ANSWER ? 0 : $r('app.float.p1_page_padding'),
-        right: content.kind === ContentDetailKind.ANSWER ? 0 : $r('app.float.p1_page_padding'),
-        top: content.kind === ContentDetailKind.ANSWER ? 0
-          : (this.immersiveReading ? 56 : $r('app.float.p1_spacing_medium')),
+        // 回答/文章页信息头在列表内滚动：左右与顶部留白由 List 统一提供，避免双重内边距。
+        left: content.kind === ContentDetailKind.ANSWER || content.kind === ContentDetailKind.ARTICLE
+          ? 0 : $r('app.float.p1_page_padding'),
+        right: content.kind === ContentDetailKind.ANSWER || content.kind === ContentDetailKind.ARTICLE
+          ? 0 : $r('app.float.p1_page_padding'),
+        top: content.kind === ContentDetailKind.ANSWER || content.kind === ContentDetailKind.ARTICLE
+          ? 0 : $r('app.float.p1_spacing_medium'),
         bottom: $r('app.float.p1_spacing_medium')
       })
       .backgroundColor($r('app.color.surface_background'))
   }
 
-  /** 回答页滚动信息头作者行（对齐上游展开顶栏 subtitle）：头像 + 名称 + 简介，点击进入用户主页。 */
+  /** 回答/文章页滚动信息头作者行（对齐上游展开顶栏 subtitle）：头像 + 名称 + 简介，点击进入用户主页。 */
   @Builder
-  private answerHeaderAuthorRow(content: LoadedContentDetail) {
+  private contentHeaderAuthorRow(content: LoadedContentDetail) {
     if (contentAuthorName(content).length > 0) {
       Row({ space: $r('app.float.p1_spacing_small') }) {
         Stack({ alignContent: Alignment.Center }) {
@@ -927,7 +918,7 @@ struct ContentDetailPage {
     if (content.kind !== ContentDetailKind.ANSWER || content.value.id !== this.content?.value.id) {
       return;
     }
-    const threshold = this.answerQuestionHeightVp > 0 ? this.answerQuestionHeightVp + 8 : 64;
+    const threshold = this.contentTitleHeightVp > 0 ? this.contentTitleHeightVp + 8 : 64;
     const scrolled = offset > threshold;
     if (scrolled !== this.answerQuestionScrolled) {
       this.answerQuestionScrolled = scrolled;
@@ -935,6 +926,29 @@ struct ContentDetailPage {
         publishAnswerTitle({
           id: this.contentId,
           questionTitle: contentContextTitle(content),
+          authorName: contentAuthorName(content),
+          authorAvatarUrl: contentAuthorAvatarUrl(content),
+          scrolled: scrolled
+        });
+      });
+    }
+  }
+
+  /** 文章页顶栏折叠联动：信息头入列随正文滚动，滚过文章主标题（高度经 onAreaChange 实测，
+   * 未测得前用 64vp 兜底）即折叠为顶栏"标题 + 作者"两行，滚回复原；经 AppStorage 广播给
+   * HDS 标题栏（对齐回答页模式，通道键固定用路由 contentId，陈旧回调按内容 id 丢弃）。 */
+  private updateArticleTitleScrolled(content: LoadedContentDetail, offset: number): void {
+    if (content.kind !== ContentDetailKind.ARTICLE || content.value.id !== this.content?.value.id) {
+      return;
+    }
+    const threshold = this.contentTitleHeightVp > 0 ? this.contentTitleHeightVp + 8 : 64;
+    const scrolled = offset > threshold;
+    if (scrolled !== this.articleTitleScrolled) {
+      this.articleTitleScrolled = scrolled;
+      this.getUIContext().animateTo({ duration: 220, curve: Curve.EaseInOut }, (): void => {
+        publishArticleTitle({
+          id: this.contentId,
+          title: contentContextTitle(content),
           authorName: contentAuthorName(content),
           authorAvatarUrl: contentAuthorAvatarUrl(content),
           scrolled: scrolled
@@ -1513,93 +1527,6 @@ struct ContentDetailPage {
   }
 
   @Builder
-  private detailTopBar(content: LoadedContentDetail) {
-    // 作者栏常驻（不可随滚动收缩）：收缩会改变布局高度，中长正文在阈值附近反复触发
-    // 视口高度突变，导致作者栏闪烁与滚动顿挫（上游无此问题因其作者条在列表内随内容
-    // 滚走；本侧为固定头部，收缩必然跳动）。无作者时显示单行标题占位。
-    Row() {
-      if (contentAuthorName(content).length > 0) {
-        Row({ space: $r('app.float.p1_spacing_small') }) {
-          Stack({ alignContent: Alignment.Center }) {
-            // 底层占位：首字圆，头像缺失或加载失败时可见。
-            Circle()
-              .width(36)
-              .height(36)
-              .fill($r('app.color.control_background'))
-            Text(contentAuthorName(content).substring(0, 1))
-              .fontSize($r('app.float.p1_caption_font_size'))
-              .fontColor($r('app.color.secondary_text'))
-            // 顶层真实头像：加载成功覆盖占位（加载失败保持透明，露出首字圆）。
-            if (contentAuthorAvatarUrl(content).length > 0) {
-              Image(contentAuthorAvatarUrl(content))
-                .id(`p3_${content.kind}_detail_top_avatar`)
-                .width(36)
-                .height(36)
-                .borderRadius(18)
-                .objectFit(ImageFit.Cover)
-            }
-          }
-          .width(36)
-          .height(36)
-          .clip(true)
-
-          Column({ space: 2 }) {
-            Text(contentAuthorName(content))
-              .id(`p3_${content.kind}_detail_top_author`)
-              .fontSize($r('app.float.p1_body_font_size'))
-              .fontColor($r('app.color.primary_text'))
-              .maxLines(1)
-              .textOverflow({ overflow: TextOverflow.Ellipsis })
-            if (contentAuthorHeadline(content).length > 0) {
-              Text(contentAuthorHeadline(content))
-                .fontSize($r('app.float.p1_caption_font_size'))
-                .fontColor($r('app.color.secondary_text'))
-                .maxLines(1)
-                .textOverflow({ overflow: TextOverflow.Ellipsis })
-            }
-          }
-          .layoutWeight(1)
-          .alignItems(HorizontalAlign.Start)
-        }
-        .id(`p3_${content.kind}_detail_top_author_row`)
-        .layoutWeight(1)
-        .padding({
-          left: $r('app.float.p1_page_padding'),
-          right: $r('app.float.p1_page_padding'),
-          top: $r('app.float.p1_spacing_small'),
-          bottom: $r('app.float.p1_spacing_small')
-        })
-        .onClick((): void => {
-          const author = content.value.author;
-          if (author !== undefined && author.id.trim().length > 0) {
-            const urlToken = author.urlToken ?? author.id;
-            this.navigate({ name: P1DestinationName.PEOPLE, id: urlToken });
-          }
-        })
-      } else {
-        Text(contentTitle(content))
-          .id(`p3_${content.kind}_detail_top_title`)
-          .fontSize($r('app.float.p1_body_font_size'))
-          .fontColor($r('app.color.primary_text'))
-          .maxLines(1)
-          .textOverflow({ overflow: TextOverflow.Ellipsis })
-          .layoutWeight(1)
-          .padding({
-            left: $r('app.float.p1_page_padding'),
-            right: $r('app.float.p1_page_padding'),
-            top: $r('app.float.p1_spacing_small'),
-            bottom: $r('app.float.p1_spacing_small')
-          })
-      }
-    }
-    .width('100%')
-    .backgroundColor($r('app.color.surface_background'))
-    .border({ width: { bottom: 0.5 }, color: $r('app.color.divider_color') })
-    .zIndex(2)
-    .hitTestBehavior(HitTestMode.Default)
-  }
-
-  @Builder
   private actionMenuSheet() {
     // 分享、复制链接与屏蔽操作放入 API 26 系统半模态；尚未接线的能力不显示占位项。
     Column({ space: $r('app.float.p1_spacing_small') }) {
@@ -1895,6 +1822,15 @@ struct ContentDetailPage {
           scrolled: this.answerQuestionScrolled
         });
       }
+      if (state.content.kind === ContentDetailKind.ARTICLE) {
+        publishArticleTitle({
+          id: this.contentId,
+          title: contentContextTitle(state.content),
+          authorName: contentAuthorName(state.content),
+          authorAvatarUrl: contentAuthorAvatarUrl(state.content),
+          scrolled: this.articleTitleScrolled
+        });
+      }
       if (state.content.kind === ContentDetailKind.ANSWER && this.answerNavigator === undefined) {
         this.ensureAnswerNavigator(state.content.value.questionId);
       }
@@ -2156,18 +2092,18 @@ export function formatContentDateTime(seconds: number): string {
     `${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
-/** 回答发布时间文案：发布于 yyyy-MM-dd HH:mm（对齐上游 DateTexts）。 */
+/** 回答/文章发布时间文案：发布于 yyyy-MM-dd HH:mm（对齐上游 DateTexts）。 */
 export function contentCreatedAtText(content: LoadedContentDetail): string {
-  if (content.kind !== ContentDetailKind.ANSWER) {
+  if (content.kind !== ContentDetailKind.ANSWER && content.kind !== ContentDetailKind.ARTICLE) {
     return '';
   }
   const formatted = formatContentDateTime(content.value.createdAt);
   return formatted.length > 0 ? `发布于 ${formatted}` : '';
 }
 
-/** 回答编辑时间文案：编辑于 yyyy-MM-dd HH:mm；与发布时间相同则不显示（对齐上游）。 */
+/** 回答/文章编辑时间文案：编辑于 yyyy-MM-dd HH:mm；与发布时间相同则不显示（对齐上游）。 */
 export function contentUpdatedAtText(content: LoadedContentDetail): string {
-  if (content.kind !== ContentDetailKind.ANSWER) {
+  if (content.kind !== ContentDetailKind.ANSWER && content.kind !== ContentDetailKind.ARTICLE) {
     return '';
   }
   if (content.value.updatedAt <= 0 || content.value.updatedAt === content.value.createdAt) {

--- a/entry/src/main/ets/pages/ContentDetailPages.ets
+++ b/entry/src/main/ets/pages/ContentDetailPages.ets
@@ -1,6 +1,7 @@
 import { QuestionAnswerDataSource } from './QuestionAnswerDataSource';
 import { AnswerNavigationPreview, QuestionAnswerNavigator, stageQuestionAnswerNavigator, takeQuestionAnswerNavigator } from './QuestionAnswerNavigator';
 import { publishQuestionTitle } from './QuestionTitleBar';
+import { publishAnswerTitle } from './AnswerTitleBar';
 import { FeedContentSummary } from './components/FeedContentSummary';
 import { AppPageStatusKind, AppPageStatusPanel, FeedPullDownIndicatorOptions, feedPullDownIndicator } from './AppPageChrome';
 import { pasteboard } from '@kit.BasicServicesKit';
@@ -100,6 +101,10 @@ struct ContentDetailPage {
   private readonly answerDataSource: QuestionAnswerDataSource = new QuestionAnswerDataSource();
   private refreshContent?: ComponentContent<FeedPullDownIndicatorOptions>;
   private questionScrolled: boolean = false;
+  /** 回答页顶栏折叠：问题标题已滚出视口（经 AppStorage 驱动 HDS 标题栏折叠态）。 */
+  private answerQuestionScrolled: boolean = false;
+  /** 回答页滚动信息头中问题标题实测高度（vp）：折叠阈值的动态基准；未测得前按单行估算。 */
+  private answerQuestionHeightVp: number = 0;
   private pageActive: boolean = false;
   repository: ContentRepository | undefined = undefined;
   openedContentStore: OpenedContentStore | undefined = undefined;
@@ -289,7 +294,8 @@ struct ContentDetailPage {
         } else if (this.content !== undefined) {
           Column() {
             // P3-9-B：顶栏作为占位（非覆盖），正文在其下方，避免作者行与标题/统计重叠。
-            if (!this.immersiveReading && this.kind !== ContentDetailKind.QUESTION) {
+            // 回答页作者信息随滚动信息头走（对齐上游），不再渲染固定作者条。
+            if (!this.immersiveReading && this.kind === ContentDetailKind.ARTICLE) {
               this.detailTopBar(this.content)
             }
             Column() {
@@ -516,24 +522,39 @@ struct ContentDetailPage {
 
       // 上层：主内容，跟随 overscroll 偏移平移。
       Column() {
-        this.contentHeader(content)
+        // 回答页：问题/作者/时间信息头入列随正文滚动（对齐上游折叠顶栏），
+        // 滚过问题标题后经 AppStorage 通知 HDS 标题栏折叠。
+        if (this.kind === ContentDetailKind.ANSWER) {
+          NativeContentDocument({
+            html: contentHtml(content),
+            emptyMessage: contentEmptyMessage(content),
+            disableEdgeSpring: true,
+            documentHeader: (): void => { this.contentHeader(content) },
+            onScrollOffset: (offset: number): void => { this.updateAnswerTitleScrolled(content, offset) },
+            onBottomEdgeChange: (atBottom: boolean): void => {
+              this.contentAtBottom = atBottom;
+            },
+            onTopEdgeChange: (atTop: boolean): void => {
+              this.contentAtTop = atTop;
+            }
+          })
+            .layoutWeight(1)
+        } else {
+          // 文章页：信息头固定在正文上方（保持原布局）。
+          this.contentHeader(content)
 
-        NativeContentDocument({
-          html: contentHtml(content),
-          emptyMessage: contentEmptyMessage(content),
-          collapsible: this.kind === ContentDetailKind.QUESTION,
-          disableEdgeSpring: this.kind === ContentDetailKind.ANSWER,
-          onBottomEdgeChange: (atBottom: boolean): void => {
-            this.contentAtBottom = atBottom;
-          },
-          onTopEdgeChange: (atTop: boolean): void => {
-            this.contentAtTop = atTop;
-          },
-          onListReachEnd: (): void => {
-            this.answersController?.loadMore();
-          }
-        })
-          .layoutWeight(1)
+          NativeContentDocument({
+            html: contentHtml(content),
+            emptyMessage: contentEmptyMessage(content),
+            onBottomEdgeChange: (atBottom: boolean): void => {
+              this.contentAtBottom = atBottom;
+            },
+            onTopEdgeChange: (atTop: boolean): void => {
+              this.contentAtTop = atTop;
+            }
+          })
+            .layoutWeight(1)
+        }
       }
       .width('100%')
       .height('100%')
@@ -738,8 +759,6 @@ struct ContentDetailPage {
   @Builder
   private contentHeader(content: LoadedContentDetail) {
       Column({ space: $r('app.float.p1_spacing_small') }) {
-        // 作者信息由顶栏折叠作者条承载（头像+名字），内容区不再重复渲染作者行。
-
         // 主标题保留在正文信息头：回答显示所属问题，文章显示文章标题，避免仅依赖通用路由标题。
         if (contentContextTitle(content).length > 0) {
           Text(contentContextTitle(content))
@@ -749,12 +768,39 @@ struct ContentDetailPage {
             .fontColor($r('app.color.primary_text'))
             .copyOption(CopyOptions.LocalDevice)
             .width('100%')
+            .onAreaChange((_oldArea: Area, newArea: Area): void => {
+              const height = Number(newArea.height);
+              if (height > 0 && Math.abs(height - this.answerQuestionHeightVp) > 1) {
+                this.answerQuestionHeightVp = height;
+              }
+            })
             .accessibilityDescription(content.kind === ContentDetailKind.ANSWER ? '点击查看问题详情' : '')
             .onClick((): void => {
               if (content.kind === ContentDetailKind.ANSWER) {
                 this.navigate({ name: P1DestinationName.QUESTION, id: content.value.questionId });
               }
             })
+        }
+
+        // 回答页作者信息随信息头滚动（对齐上游展开顶栏）：头像 + 名称 + 一句话简介。
+        if (content.kind === ContentDetailKind.ANSWER) {
+          this.answerHeaderAuthorRow(content)
+        }
+
+        // 回答页发布/编辑时间（对齐上游 DateTexts：编辑时间与发布不同才显示）。
+        if (content.kind === ContentDetailKind.ANSWER && contentCreatedAtText(content).length > 0) {
+          Text(contentCreatedAtText(content))
+            .id(`p2_${content.kind}_detail_created_at`)
+            .fontSize($r('app.float.p1_caption_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .width('100%')
+        }
+        if (content.kind === ContentDetailKind.ANSWER && contentUpdatedAtText(content).length > 0) {
+          Text(contentUpdatedAtText(content))
+            .id(`p2_${content.kind}_detail_updated_at`)
+            .fontSize($r('app.float.p1_caption_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .width('100%')
         }
 
         if (content.kind === ContentDetailKind.QUESTION) {
@@ -804,12 +850,97 @@ struct ContentDetailPage {
       .alignItems(HorizontalAlign.Start)
       .width('100%')
       .padding({
-        left: $r('app.float.p1_page_padding'),
-        right: $r('app.float.p1_page_padding'),
-        top: this.immersiveReading ? 56 : $r('app.float.p1_spacing_medium'),
+        // 回答页信息头在列表内滚动：左右与顶部留白由 List 统一提供，避免双重内边距。
+        left: content.kind === ContentDetailKind.ANSWER ? 0 : $r('app.float.p1_page_padding'),
+        right: content.kind === ContentDetailKind.ANSWER ? 0 : $r('app.float.p1_page_padding'),
+        top: content.kind === ContentDetailKind.ANSWER ? 0
+          : (this.immersiveReading ? 56 : $r('app.float.p1_spacing_medium')),
         bottom: $r('app.float.p1_spacing_medium')
       })
       .backgroundColor($r('app.color.surface_background'))
+  }
+
+  /** 回答页滚动信息头作者行（对齐上游展开顶栏 subtitle）：头像 + 名称 + 简介，点击进入用户主页。 */
+  @Builder
+  private answerHeaderAuthorRow(content: LoadedContentDetail) {
+    if (contentAuthorName(content).length > 0) {
+      Row({ space: $r('app.float.p1_spacing_small') }) {
+        Stack({ alignContent: Alignment.Center }) {
+          Circle()
+            .width(40)
+            .height(40)
+            .fill($r('app.color.control_background'))
+          Text(contentAuthorName(content).substring(0, 1))
+            .fontSize($r('app.float.p1_body_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+          if (contentAuthorAvatarUrl(content).length > 0) {
+            Image(contentAuthorAvatarUrl(content))
+              .id(`p3_${content.kind}_detail_header_avatar`)
+              .width(40)
+              .height(40)
+              .borderRadius(20)
+              .objectFit(ImageFit.Cover)
+          }
+        }
+          .width(40)
+          .height(40)
+          .clip(true)
+
+        Column({ space: 2 }) {
+          Text(contentAuthorName(content))
+            .id(`p3_${content.kind}_detail_header_author`)
+            .fontSize($r('app.float.p1_body_font_size'))
+            .fontWeight(FontWeight.Medium)
+            .fontColor($r('app.color.primary_text'))
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+          if (contentAuthorHeadline(content).length > 0) {
+            Text(contentAuthorHeadline(content))
+              .fontSize($r('app.float.p1_caption_font_size'))
+              .fontColor($r('app.color.secondary_text'))
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+          }
+        }
+          .layoutWeight(1)
+          .alignItems(HorizontalAlign.Start)
+      }
+      .id(`p3_${content.kind}_detail_header_author_row`)
+      .width('100%')
+      .onClick((): void => {
+        const author = content.value.author;
+        if (author !== undefined && author.id.trim().length > 0) {
+          const urlToken = author.urlToken ?? author.id;
+          this.navigate({ name: P1DestinationName.PEOPLE, id: urlToken });
+        }
+      })
+    }
+  }
+
+  /** 回答页顶栏折叠联动：正文滚过问题标题（高度经 onAreaChange 实测，未测得前用 64vp 兜底）
+   * 即折叠，滚回复原；经 AppStorage 广播给 HDS 标题栏（同问题页 160px 阈值模式）。
+   * 通道键固定用路由 contentId（标题栏按 destination.id 查找，过滑切换回答不改路由，
+   * activeContentId 会随切换漂移导致顶栏读到陈旧条目）；闭包捕获的 content 是构造时
+   * 的克隆（@Builder 传值不更新已挂载子组件属性，且控制器每次 emit 都换新克隆），
+   * 陈旧判定只能按内容 id 比较——id 不同才说明是切换期间的陈旧回调，直接丢弃。 */
+  private updateAnswerTitleScrolled(content: LoadedContentDetail, offset: number): void {
+    if (content.kind !== ContentDetailKind.ANSWER || content.value.id !== this.content?.value.id) {
+      return;
+    }
+    const threshold = this.answerQuestionHeightVp > 0 ? this.answerQuestionHeightVp + 8 : 64;
+    const scrolled = offset > threshold;
+    if (scrolled !== this.answerQuestionScrolled) {
+      this.answerQuestionScrolled = scrolled;
+      this.getUIContext().animateTo({ duration: 220, curve: Curve.EaseInOut }, (): void => {
+        publishAnswerTitle({
+          id: this.contentId,
+          questionTitle: contentContextTitle(content),
+          authorName: contentAuthorName(content),
+          authorAvatarUrl: contentAuthorAvatarUrl(content),
+          scrolled: scrolled
+        });
+      });
+    }
   }
 
   @Builder
@@ -1242,6 +1373,8 @@ struct ContentDetailPage {
     // 新内容从顶部渲染：边界状态归位，避免沿用上一答的贴底状态误触发底部过滑。
     this.contentAtBottom = false;
     this.contentAtTop = true;
+    // 顶栏折叠态随新答复位：新内容从顶部渲染，问题标题回到视口内。
+    this.answerQuestionScrolled = false;
     try {
       const id = await this.answerNavigator?.move(direction);
       this.navigatorRevision += 1;
@@ -1753,6 +1886,15 @@ struct ContentDetailPage {
       if (state.content.kind === ContentDetailKind.QUESTION) {
         publishQuestionTitle({ id: this.activeContentId, title: state.content.value.title, scrolled: this.questionScrolled });
       }
+      if (state.content.kind === ContentDetailKind.ANSWER) {
+        publishAnswerTitle({
+          id: this.contentId,
+          questionTitle: contentContextTitle(state.content),
+          authorName: contentAuthorName(state.content),
+          authorAvatarUrl: contentAuthorAvatarUrl(state.content),
+          scrolled: this.answerQuestionScrolled
+        });
+      }
       if (state.content.kind === ContentDetailKind.ANSWER && this.answerNavigator === undefined) {
         this.ensureAnswerNavigator(state.content.value.questionId);
       }
@@ -2001,6 +2143,38 @@ export function contentAuthorAvatarUrl(content: LoadedContentDetail): string {
     return '';
   }
   return url;
+}
+
+/** 详情时间戳（unix 秒）转本地 yyyy-MM-dd HH:mm；对齐上游 formatArticleDateTime，非法值返回空串。 */
+export function formatContentDateTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return '';
+  }
+  const date = new Date(seconds * 1000);
+  const pad = (value: number): string => value < 10 ? `0${value}` : `${value}`;
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ` +
+    `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+/** 回答发布时间文案：发布于 yyyy-MM-dd HH:mm（对齐上游 DateTexts）。 */
+export function contentCreatedAtText(content: LoadedContentDetail): string {
+  if (content.kind !== ContentDetailKind.ANSWER) {
+    return '';
+  }
+  const formatted = formatContentDateTime(content.value.createdAt);
+  return formatted.length > 0 ? `发布于 ${formatted}` : '';
+}
+
+/** 回答编辑时间文案：编辑于 yyyy-MM-dd HH:mm；与发布时间相同则不显示（对齐上游）。 */
+export function contentUpdatedAtText(content: LoadedContentDetail): string {
+  if (content.kind !== ContentDetailKind.ANSWER) {
+    return '';
+  }
+  if (content.value.updatedAt <= 0 || content.value.updatedAt === content.value.createdAt) {
+    return '';
+  }
+  const formatted = formatContentDateTime(content.value.updatedAt);
+  return formatted.length > 0 ? `编辑于 ${formatted}` : '';
 }
 
 /** P3-9-D1：回答/文章的认可徽章流（仅 ANSWER/ARTICLE 有）。 */

--- a/entry/src/main/ets/pages/ContentDetailPages.ets
+++ b/entry/src/main/ets/pages/ContentDetailPages.ets
@@ -12,7 +12,10 @@ import {
   P1DestinationName
 } from 'core';
 import {
+  AnswerDoubleTapAction,
+  answerDoubleTapActionLabel,
   AnswerEndorsementDisplay,
+  AppPreferencesStore,
   BlockedFeedHistoryGateway,
   BlockingRuleGateway,
   ChannelContentItem,
@@ -62,6 +65,7 @@ import { NativeContentDocument } from './NativeContentDocument';
 import { stageAnswerEditSeed } from './AnswerEditSeedStore';
 import { getAbilityContext } from '../entryability/AbilityContextHolder';
 import { createSystemShareService } from '../platform/SystemShareService';
+import { performConfirmHaptic } from '../platform/HapticFeedback';
 import { ShareOutcome, SharePayloadKind, ShareTextPayload } from '../platform/ShareContracts';
 import { hdsMaterial } from '@kit.UIDesignKit';
 import { GlassCapsule } from './components/MaterialCanvas';
@@ -143,6 +147,12 @@ struct ContentDetailPage {
   @State private interactionErrorMessage: string = '';
   @State private interactionRequiresLogin: boolean = false;
   @State private favoriteDialogShown: boolean = false;
+  /** 回答页双击正文动作（对齐上游 answerDoubleTapAction）：AppStorage 广播跨页同步
+   * （详情页 Ask 面板与设置页改动互见），默认询问并记住。 */
+  @StorageProp('answerDoubleTapAction') private answerDoubleTapAction: AnswerDoubleTapAction =
+    AnswerDoubleTapAction.ASK;
+  /** 双击动作询问面板（Ask 动作）可见性。 */
+  @State private doubleTapAskSheetShown: boolean = false;
   @State private showComments: boolean = false;
   @State private commentRootDraft: string = '';
   @State private commentReplyDraft: string = '';
@@ -175,6 +185,8 @@ struct ContentDetailPage {
     this.pageActive = true;
     if (this.activeContentId.length === 0) { this.activeContentId = this.contentId; }
     this.authenticated = this.session?.getState().status === SessionStatus.AUTHENTICATED;
+    // 双击动作偏好全局生效，返回栈重显时也刷新（可能刚在设置页改过）。
+    void this.restoreAnswerDoubleTapAction();
     this.refreshContent = new ComponentContent(this.getUIContext(), wrapBuilder(feedPullDownIndicator),
       new FeedPullDownIndicatorOptions());
     if (this.kind === ContentDetailKind.ANSWER && this.answerNavigator === undefined) {
@@ -392,6 +404,19 @@ struct ContentDetailPage {
             }
           }
         })
+      Column()
+        .bindSheet(this.doubleTapAskSheetShown, this.doubleTapAskSheet(), {
+          height: SheetSize.FIT_CONTENT,
+          dragBar: true,
+          showClose: false,
+          maskColor: '#66000000',
+          backgroundColor: $r('app.color.surface_background'),
+          onDisappear: (): void => {
+            if (this.doubleTapAskSheetShown) {
+              this.doubleTapAskSheetShown = false;
+            }
+          }
+        })
       // 切换回答期间卸载旧内容的弹层，避免普通入参 contentId 留在前一答。
       if (this.phase === ContentDetailPhase.READY && (this.kind === ContentDetailKind.ANSWER ||
         this.kind === ContentDetailKind.ARTICLE || this.kind === ContentDetailKind.QUESTION)) {
@@ -564,6 +589,14 @@ struct ContentDetailPage {
         })
         .onActionEnd((): void => {
           this.onAnswerOverscrollPanEnd();
+        })
+    )
+    // 双击正文赞同一键：互斥手势默认子组件优先，图片/链接等可点区域不触发；
+    // 与上方 parallelGesture 过滑 PanGesture 并存（tap 与 pan 不互斥）。
+    .gesture(
+      TapGesture({ count: 2 })
+        .onAction((): void => {
+          this.onAnswerDoubleTap();
         })
     )
   }
@@ -1380,6 +1413,60 @@ struct ContentDetailPage {
   private navigatorHasNext(): boolean {
     return this.navigatorRevision >= 0 && (this.answerNavigator?.hasNext() ?? false);
   }
+  /** 双击正文动作分发（对齐上游 performAnswerDoubleTapAction）：仅回答页生效；
+   * 震感仅点赞与打开评论区有；Ask 弹询问面板，选择后记住。 */
+  private onAnswerDoubleTap(): void {
+    if (this.kind !== ContentDetailKind.ANSWER) {
+      return;
+    }
+    const action = this.answerDoubleTapAction;
+    if (action === AnswerDoubleTapAction.NONE) {
+      return;
+    }
+    if (action === AnswerDoubleTapAction.OPEN_COMMENTS) {
+      performConfirmHaptic();
+      this.showComments = true;
+      return;
+    }
+    if (action === AnswerDoubleTapAction.TOGGLE_IMMERSIVE) {
+      this.immersiveReading = !this.immersiveReading;
+      return;
+    }
+    if (action === AnswerDoubleTapAction.VOTE_UP) {
+      performConfirmHaptic();
+      void this.voteController?.voteUpFromDoubleTap();
+      return;
+    }
+    this.doubleTapAskSheetShown = true;
+  }
+
+  /** 读取双击动作偏好；失败保持默认 Ask，不影响双击可用性。 */
+  private async restoreAnswerDoubleTapAction(): Promise<void> {
+    const context = getAbilityContext();
+    if (context === undefined) {
+      return;
+    }
+    try {
+      const action = await new AppPreferencesStore(context).loadAnswerDoubleTapAction();
+      if (this.pageActive) {
+        AppStorage.setOrCreate('answerDoubleTapAction', action);
+      }
+    } catch (_error) {
+    }
+  }
+
+  /** 保存双击动作（询问面板与设置页共用）：先广播 AppStorage 再落盘，提示文案对齐上游。 */
+  private saveAnswerDoubleTapAction(action: AnswerDoubleTapAction): void {
+    AppStorage.setOrCreate('answerDoubleTapAction', action);
+    const context = getAbilityContext();
+    if (context !== undefined) {
+      void new AppPreferencesStore(context).saveAnswerDoubleTapAction(action).catch((_error: Object): void => {
+      });
+    }
+    this.getUIContext().getPromptAction()
+      .showToast({ message: `已将双击回答动作设为：${answerDoubleTapActionLabel(action)}` });
+  }
+
   private async moveAnswer(direction: number): Promise<void> {
     if (this.navigatorBusy) { return; }
     this.navigatorBusy = true;
@@ -1634,6 +1721,74 @@ struct ContentDetailPage {
 
     }
     .id('p3_detail_menu_sheet')
+    .width('100%')
+    .padding($r('app.float.p1_spacing_medium'))
+  }
+
+  /** 双击动作询问面板（对齐上游 showDoubleTapActionDialog）：每项保存偏好并立即执行该动作。 */
+  @Builder
+  private doubleTapAskSheet() {
+    Column({ space: $r('app.float.p1_spacing_small') }) {
+      Text('设置双击回答动作')
+        .fontSize($r('app.float.p1_heading_font_size'))
+        .fontWeight(FontWeight.Bold)
+        .fontColor($r('app.color.primary_text'))
+        .width('100%')
+      Text('选择以后双击回答时默认执行的动作。选择后会立即保存到设置，你也可以稍后在设置中修改。')
+        .fontSize($r('app.float.p1_secondary_font_size'))
+        .fontColor($r('app.color.secondary_text'))
+        .width('100%')
+      Button('设为无操作', { type: ButtonType.Normal, stateEffect: true })
+        .id('p3_answer_double_tap_none')
+        .width('100%')
+        .fontSize($r('app.float.p1_body_font_size'))
+        .fontColor($r('app.color.primary_text'))
+        .backgroundColor($r('app.color.control_background'))
+        .borderRadius($r('app.float.p1_card_radius'))
+        .onClick((): void => {
+          this.doubleTapAskSheetShown = false;
+          this.saveAnswerDoubleTapAction(AnswerDoubleTapAction.NONE);
+        })
+      Button('设为点赞', { type: ButtonType.Normal, stateEffect: true })
+        .id('p3_answer_double_tap_vote_up')
+        .width('100%')
+        .fontSize($r('app.float.p1_body_font_size'))
+        .fontColor($r('app.color.primary_text'))
+        .backgroundColor($r('app.color.control_background'))
+        .borderRadius($r('app.float.p1_card_radius'))
+        .onClick((): void => {
+          this.doubleTapAskSheetShown = false;
+          this.saveAnswerDoubleTapAction(AnswerDoubleTapAction.VOTE_UP);
+          performConfirmHaptic();
+          void this.voteController?.voteUpFromDoubleTap();
+        })
+      Button('设为打开评论区', { type: ButtonType.Normal, stateEffect: true })
+        .id('p3_answer_double_tap_open_comments')
+        .width('100%')
+        .fontSize($r('app.float.p1_body_font_size'))
+        .fontColor($r('app.color.primary_text'))
+        .backgroundColor($r('app.color.control_background'))
+        .borderRadius($r('app.float.p1_card_radius'))
+        .onClick((): void => {
+          this.doubleTapAskSheetShown = false;
+          this.saveAnswerDoubleTapAction(AnswerDoubleTapAction.OPEN_COMMENTS);
+          performConfirmHaptic();
+          this.showComments = true;
+        })
+      Button('设为开关沉浸式', { type: ButtonType.Normal, stateEffect: true })
+        .id('p3_answer_double_tap_toggle_immersive')
+        .width('100%')
+        .fontSize($r('app.float.p1_body_font_size'))
+        .fontColor($r('app.color.primary_text'))
+        .backgroundColor($r('app.color.control_background'))
+        .borderRadius($r('app.float.p1_card_radius'))
+        .onClick((): void => {
+          this.doubleTapAskSheetShown = false;
+          this.saveAnswerDoubleTapAction(AnswerDoubleTapAction.TOGGLE_IMMERSIVE);
+          this.immersiveReading = !this.immersiveReading;
+        })
+    }
+    .id('p3_answer_double_tap_sheet')
     .width('100%')
     .padding($r('app.float.p1_spacing_medium'))
   }

--- a/entry/src/main/ets/pages/ContentDetailPages.ets
+++ b/entry/src/main/ets/pages/ContentDetailPages.ets
@@ -65,6 +65,7 @@ import { NativeContentDocument } from './NativeContentDocument';
 import { stageAnswerEditSeed } from './AnswerEditSeedStore';
 import { getAbilityContext } from '../entryability/AbilityContextHolder';
 import { createSystemShareService } from '../platform/SystemShareService';
+import { setStatusBarHidden } from '../platform/SystemBars';
 import { performConfirmHaptic } from '../platform/HapticFeedback';
 import { ShareOutcome, SharePayloadKind, ShareTextPayload } from '../platform/ShareContracts';
 import { hdsMaterial } from '@kit.UIDesignKit';
@@ -172,8 +173,13 @@ struct ContentDetailPage {
   @State private actionMenuShown: boolean = false;
   /** P3-9-C：菜单操作反馈（复制链接结果等）。 */
   @State private menuStatus: string = '';
-  /** 沉浸式阅读仅收起页面 Chrome，不改变正文、互动或滚动状态。 */
-  @State private immersiveReading: boolean = false;
+  /** 沉浸式阅读仅收起页面 Chrome，不改变正文、互动或滚动状态。
+   * 变化经 AppStorage 广播给 P1Shell 隐藏/恢复 NavDestination 顶栏（对齐上游 topBar={}）。 */
+  @State @Watch('onImmersiveReadingChanged') private immersiveReading: boolean = false;
+  /** P1Shell Back 拦截发出的"先退沉浸式"信号（跨页面信号必须走 AppStorage 广播）。 */
+  @StorageProp('detailImmersiveExitTick') @Watch('onImmersiveExitSignal') private immersiveExitTick: number = 0;
+  /** 状态栏高度（vp，EntryAbility 广播）：沉浸式隐藏顶栏后正文的顶部留空。 */
+  @StorageProp('statusBarHeight') private statusBarHeightVp: number = 0;
   /** 设备支持沉浸材质：玻璃胶囊走 HDS 画布，否则回落组件模糊。 */
   private immersiveMaterialSupported: boolean = false;
   private controller?: ContentDetailController;
@@ -187,6 +193,8 @@ struct ContentDetailPage {
     this.authenticated = this.session?.getState().status === SessionStatus.AUTHENTICATED;
     // 双击动作偏好全局生效，返回栈重显时也刷新（可能刚在设置页改过）。
     void this.restoreAnswerDoubleTapAction();
+    // 同步沉浸式初始/保留态给 P1Shell（返回栈重显时实例与状态均保留）。
+    AppStorage.setOrCreate('detailImmersiveActive', this.immersiveReading);
     this.refreshContent = new ComponentContent(this.getUIContext(), wrapBuilder(feedPullDownIndicator),
       new FeedPullDownIndicatorOptions());
     if (this.kind === ContentDetailKind.ANSWER && this.answerNavigator === undefined) {
@@ -274,6 +282,21 @@ struct ContentDetailPage {
     this.commentRootDraft = '';
     this.commentReplyDraft = '';
     this.immersiveReading = false;
+    AppStorage.setOrCreate('detailImmersiveActive', false);
+    // 对齐上游 LeaveImmersiveModeCleanup：页面销毁时确保状态栏恢复。
+    setStatusBarHidden(false);
+  }
+
+  private onImmersiveReadingChanged(): void {
+    AppStorage.setOrCreate('detailImmersiveActive', this.immersiveReading);
+    // 真全屏：沉浸中隐藏状态栏（对齐上游 WindowInsetsController.hide(statusBars)）。
+    setStatusBarHidden(this.immersiveReading);
+  }
+
+  private onImmersiveExitSignal(): void {
+    if (this.immersiveReading) {
+      this.immersiveReading = false;
+    }
   }
 
   private async refreshQuestion(): Promise<void> {
@@ -327,7 +350,8 @@ struct ContentDetailPage {
       .id(`p2_${this.kind}_detail_page`)
       .width('100%')
       .height('100%')
-      .padding({ top: 94 })
+      // 94vp 为顶栏叠加预留；沉浸式隐藏顶栏后仅保留状态栏高度（对齐上游 topBar={}）。
+      .padding({ top: this.immersiveReading ? Math.max(this.statusBarHeightVp, 0) : 94 })
       .backgroundColor($r('app.color.page_background'))
 
       // 底部操作栏：全屏悬浮层单实例承载（正文从下方穿透直至物理底边）。
@@ -363,10 +387,6 @@ struct ContentDetailPage {
             this.answerFabOverlayHeightVp = height;
           }
         })
-      }
-
-      if (this.immersiveReading) {
-        this.immersiveExitControl()
       }
 
       if (this.phase === ContentDetailPhase.READY &&
@@ -497,30 +517,6 @@ struct ContentDetailPage {
     .width('100%')
     .layoutWeight(1)
     .padding($r('app.float.p1_page_padding'))
-  }
-
-  @Builder
-  private immersiveExitControl() {
-    Button({ type: ButtonType.Normal, stateEffect: true }) {
-      SymbolGlyph($r('sys.symbol.xmark'))
-        .fontSize(20)
-        .fontColor([$r('app.color.primary_text')])
-    }
-      .id(`p3_${this.kind}_detail_exit_immersive`)
-      .width(40)
-      .height(40)
-      .padding(0)
-      .backgroundColor($r('app.color.surface_background'))
-      .borderRadius(20)
-      .accessibilityText('退出沉浸式阅读')
-      .align(Alignment.TopStart)
-      .margin({
-        left: $r('app.float.p1_page_padding'),
-        top: $r('app.float.p1_spacing_medium')
-      })
-      .onClick((): void => {
-        this.immersiveReading = false;
-      })
   }
 
   @Builder
@@ -780,6 +776,11 @@ struct ContentDetailPage {
 
   @Builder
   private contentHeader(content: LoadedContentDetail) {
+    if ((content.kind === ContentDetailKind.ANSWER || content.kind === ContentDetailKind.ARTICLE) &&
+      this.immersiveReading) {
+      // 沉浸式：收起问题标题/时间/统计等完整信息头，仅留窄作者行（对齐上游 isImmersiveMode 分支）。
+      this.immersiveAuthorRow(content)
+    } else {
       Column({ space: $r('app.float.p1_spacing_small') }) {
         // 主标题保留在正文信息头：回答显示所属问题，文章显示文章标题，避免仅依赖通用路由标题。
         if (contentContextTitle(content).length > 0) {
@@ -882,6 +883,54 @@ struct ContentDetailPage {
         bottom: $r('app.float.p1_spacing_medium')
       })
       .backgroundColor($r('app.color.surface_background'))
+    }
+  }
+
+  /** 沉浸式窄作者行（对齐上游 isImmersiveMode 分支）：24vp 头像 + 名称，点击进作者主页。 */
+  @Builder
+  private immersiveAuthorRow(content: LoadedContentDetail) {
+    if (contentAuthorName(content).length > 0) {
+      Row({ space: 6 }) {
+        Stack({ alignContent: Alignment.Center }) {
+          Circle()
+            .width(24)
+            .height(24)
+            .fill($r('app.color.control_background'))
+          Text(contentAuthorName(content).substring(0, 1))
+            .fontSize($r('app.float.p1_caption_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+          if (contentAuthorAvatarUrl(content).length > 0) {
+            Image(contentAuthorAvatarUrl(content))
+              .id(`p3_${content.kind}_immersive_author_avatar`)
+              .width(24)
+              .height(24)
+              .borderRadius(12)
+              .objectFit(ImageFit.Cover)
+          }
+        }
+          .width(24)
+          .height(24)
+          .clip(true)
+
+        Text(contentAuthorName(content))
+          .id(`p3_${content.kind}_immersive_author_name`)
+          .fontSize($r('app.float.p1_body_font_size'))
+          .fontColor($r('app.color.primary_text'))
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .layoutWeight(1)
+      }
+      .id(`p3_${content.kind}_immersive_author_row`)
+      .width('100%')
+      .padding({ top: 8, bottom: 8 })
+      .onClick((): void => {
+        const author = content.value.author;
+        if (author !== undefined && author.id.trim().length > 0) {
+          const urlToken = author.urlToken ?? author.id;
+          this.navigate({ name: P1DestinationName.PEOPLE, id: urlToken });
+        }
+      })
+    }
   }
 
   /** 回答/文章页滚动信息头作者行（对齐上游展开顶栏 subtitle）：头像 + 名称 + 简介，点击进入用户主页。 */
@@ -1683,6 +1732,9 @@ struct ContentDetailPage {
           .onClick((): void => {
             this.actionMenuShown = false;
             this.immersiveReading = true;
+            // 对齐上游菜单提示：沉浸式下返回键优先退出沉浸式而非退出回答。
+            this.getUIContext().getPromptAction()
+              .showToast({ message: '已进入沉浸式，按返回键即可退出' });
           })
       }
 

--- a/entry/src/main/ets/pages/ContentDetailPages.ets
+++ b/entry/src/main/ets/pages/ContentDetailPages.ets
@@ -483,6 +483,12 @@ struct ContentDetailPage {
             .fontColor($r('app.color.primary_text'))
             .copyOption(CopyOptions.LocalDevice)
             .width('100%')
+            .accessibilityDescription(content.kind === ContentDetailKind.ANSWER ? '点击查看问题详情' : '')
+            .onClick((): void => {
+              if (content.kind === ContentDetailKind.ANSWER) {
+                this.navigate({ name: P1DestinationName.QUESTION, id: content.value.questionId });
+              }
+            })
         }
 
         if (content.kind === ContentDetailKind.QUESTION) {

--- a/entry/src/main/ets/pages/ContentDetailPages.ets
+++ b/entry/src/main/ets/pages/ContentDetailPages.ets
@@ -1,10 +1,10 @@
 import { QuestionAnswerDataSource } from './QuestionAnswerDataSource';
-import { QuestionAnswerNavigator, stageQuestionAnswerNavigator, takeQuestionAnswerNavigator } from './QuestionAnswerNavigator';
+import { AnswerNavigationPreview, QuestionAnswerNavigator, stageQuestionAnswerNavigator, takeQuestionAnswerNavigator } from './QuestionAnswerNavigator';
 import { publishQuestionTitle } from './QuestionTitleBar';
 import { FeedContentSummary } from './components/FeedContentSummary';
 import { AppPageStatusKind, AppPageStatusPanel, FeedPullDownIndicatorOptions, feedPullDownIndicator } from './AppPageChrome';
 import { pasteboard } from '@kit.BasicServicesKit';
-import { ComponentContent, SegmentButton, SegmentButtonOptions } from '@kit.ArkUI';
+import { ComponentContent, SegmentButton, SegmentButtonOptions, curves } from '@kit.ArkUI';
 import {
   P1Destination,
   P1DestinationName
@@ -72,7 +72,28 @@ struct ContentDetailPage {
   @State private refreshingAnswers: boolean = false;
   @State private navigatorBusy: boolean = false;
   @State private navigatorRevision: number = 0;
-  @State private navigatorError: string = '';
+  /** 回答页过滑切换：主内容 overscroll 偏移（<0 上移露底部"下一答"预览卡，>0 下移露顶部"上一答"预览卡）。 */
+  @State private answerOverscrollOffset: number = 0;
+  /** 正文是否贴在列表底边（NativeContentDocument 回推）。 */
+  @State private contentAtBottom: boolean = false;
+  /** 正文是否贴在列表顶边（NativeContentDocument 回推）。 */
+  @State private contentAtTop: boolean = true;
+  /** overscroll 原始拖动累计量（阻尼换算前）。 */
+  private overscrollRawDrag: number = 0;
+  /** 上一次 pan 手势 offsetY（换算单帧 delta）。 */
+  private overscrollPanPrevY: number = 0;
+  /** 悬浮"下一个回答"按钮拖动偏移（相对右下角默认位，负值向左/向上），松手后保留。 */
+  @State private answerFabOffsetX: number = 0;
+  @State private answerFabOffsetY: number = 0;
+  /** 上一次按钮拖动 pan 手势 offset（换算单帧 delta）。 */
+  private answerFabPanPrevX: number = 0;
+  private answerFabPanPrevY: number = 0;
+  /** 悬浮按钮拖动进行中：冻结正文过滑手势（同指不得同时驱动按钮与预览卡）。 */
+  private answerFabDragging: boolean = false;
+  /** 悬浮按钮实测宽度（vp）与所在悬浮层尺寸（vp）：拖动越界钳制用。 */
+  private answerFabWidthVp: number = 0;
+  private answerFabOverlayWidthVp: number = 0;
+  private answerFabOverlayHeightVp: number = 0;
   @StorageProp('loginFeedReloadTick') @Watch('onLoginChanged') private loginTick: number = 0;
   @State private authenticated: boolean = false;
   private answerNavigator?: QuestionAnswerNavigator;
@@ -224,6 +245,8 @@ struct ContentDetailPage {
     this.voteController = undefined;
     this.followController = undefined;
     this.answerNavigator?.pause();
+    this.resetAnswerOverscroll(false);
+    this.contentAtBottom = false;
     this.pendingUserBlock = undefined;
     this.keywordBlockVisible = false;
     this.keywordBlockInput = '';
@@ -299,6 +322,29 @@ struct ContentDetailPage {
         .width('100%')
         .height('100%')
         .hitTestBehavior(HitTestMode.Transparent)
+      }
+
+      // 悬浮"下一个回答"按钮（对齐上游 SkipNext FAB）：右下角、底部操作栏上方，可拖动避让正文；
+      // 底部"下一答"预览卡展开时隐藏，避免盖住预览卡。
+      if (this.kind === ContentDetailKind.ANSWER && !this.immersiveReading &&
+        this.content !== undefined && this.phase === ContentDetailPhase.READY &&
+        this.answerOverscrollOffset >= 0 && this.navigatorHasNext()) {
+        Stack({ alignContent: Alignment.BottomEnd }) {
+          this.answerNextFloatingButton()
+        }
+        .width('100%')
+        .height('100%')
+        .hitTestBehavior(HitTestMode.Transparent)
+        .onAreaChange((_oldArea: Area, newArea: Area): void => {
+          const width = Number(newArea.width);
+          const height = Number(newArea.height);
+          if (width > 0 && Math.abs(width - this.answerFabOverlayWidthVp) > 1) {
+            this.answerFabOverlayWidthVp = width;
+          }
+          if (height > 0 && Math.abs(height - this.answerFabOverlayHeightVp) > 1) {
+            this.answerFabOverlayHeightVp = height;
+          }
+        })
       }
 
       if (this.immersiveReading) {
@@ -448,25 +494,245 @@ struct ContentDetailPage {
 
   @Builder
   private loadedContent(content: LoadedContentDetail) {
-    Column() {
-      this.contentHeader(content)
-      this.answerNavigationControls()
-
-      NativeContentDocument({
-        html: contentHtml(content),
-        emptyMessage: contentEmptyMessage(content),
-        collapsible: this.kind === ContentDetailKind.QUESTION,
-        documentFooter: (): void => {
-          this.answerNavigationControls()
-        },
-        onListReachEnd: (): void => {
-          this.answersController?.loadMore();
+    Stack({ alignContent: Alignment.Bottom }) {
+      // 底层：顶部"上一个回答"预览卡（对齐上游 AnswerVerticalOverscroll 顶部卡，
+      // 标签行在上、作者行在下）；主内容随 overscroll 下移露出；只在有上一答时渲染。
+      if (this.kind === ContentDetailKind.ANSWER && this.answerOverscrollOffset > 0 &&
+        this.answerNavigator !== undefined && this.navigatorHasPrevious()) {
+        Stack({ alignContent: Alignment.Top }) {
+          this.answerPreviewCard(true)
         }
-      })
-        .layoutWeight(1)
+        .width('100%')
+        .height('100%')
+        .hitTestBehavior(HitTestMode.None)
+      }
+
+      // 底层：底部"下一个回答"预览卡（对齐上游 AnswerVerticalOverscroll 底部卡，
+      // 作者行在上、标签行在下）；主内容随 overscroll 上移露出；只在有下一答时渲染。
+      if (this.kind === ContentDetailKind.ANSWER && this.answerOverscrollOffset < 0 &&
+        this.answerNavigator !== undefined && this.navigatorHasNext()) {
+        this.answerPreviewCard(false)
+      }
+
+      // 上层：主内容，跟随 overscroll 偏移平移。
+      Column() {
+        this.contentHeader(content)
+
+        NativeContentDocument({
+          html: contentHtml(content),
+          emptyMessage: contentEmptyMessage(content),
+          collapsible: this.kind === ContentDetailKind.QUESTION,
+          disableEdgeSpring: this.kind === ContentDetailKind.ANSWER,
+          onBottomEdgeChange: (atBottom: boolean): void => {
+            this.contentAtBottom = atBottom;
+          },
+          onTopEdgeChange: (atTop: boolean): void => {
+            this.contentAtTop = atTop;
+          },
+          onListReachEnd: (): void => {
+            this.answersController?.loadMore();
+          }
+        })
+          .layoutWeight(1)
+      }
+      .width('100%')
+      .height('100%')
+      .translate({ y: this.answerOverscrollOffset })
     }
     .width('100%')
     .height('100%')
+    .clip(true)
+    // 并行手势：与正文 List 滚动同时识别，贴边后的继续滑动量由本容器转为 overscroll
+    // （List 的 edgeEffect 已在回答页关闭，不会自身回弹）。
+    .parallelGesture(
+      PanGesture({ fingers: 1, direction: PanDirection.Vertical })
+        .onActionStart((event: GestureEvent): void => {
+          this.overscrollPanPrevY = event.offsetY;
+        })
+        .onActionUpdate((event: GestureEvent): void => {
+          this.onAnswerOverscrollPanUpdate(event);
+        })
+        .onActionEnd((): void => {
+          this.onAnswerOverscrollPanEnd();
+        })
+    )
+  }
+
+  /** 过滑预览卡（对齐上游 AnswerPreviewCard）：上一答卡标签行在上、作者行在下；
+   * 下一答卡 reverseLayout：作者行在上、标签行在下。 */
+  @Builder
+  private answerPreviewCard(previous: boolean) {
+    Column({ space: 8 }) {
+      if (previous) {
+        this.answerPreviewLabelRow(previous)
+        this.answerPreviewAuthorRow(previous)
+      } else {
+        this.answerPreviewAuthorRow(previous)
+        this.answerPreviewLabelRow(previous)
+      }
+    }
+    .id(previous ? 'p2_answer_prev_preview_card' : 'p2_answer_next_preview_card')
+    .width('100%')
+    .padding(12)
+    .borderRadius($r('app.float.p1_card_radius'))
+    .margin({
+      left: $r('app.float.p1_page_padding'),
+      right: $r('app.float.p1_page_padding'),
+      // 上一答卡贴顶部（页顶栏下方留 8vp）；下一答卡预留在底部悬浮操作栏（约 44vp 高 + 12vp 底距）上方。
+      top: previous ? 8 : 0,
+      bottom: previous ? 0 : 72
+    })
+    .backgroundColor(this.answerOverscrollTriggered()
+      ? $r('app.color.brand_primary_container') : $r('app.color.surface_background'))
+    .opacity(this.answerOverscrollProgress())
+  }
+
+  /** 预览卡标签行：方向图标 + 文案（触发后高亮为"松手切换"）。 */
+  @Builder
+  private answerPreviewLabelRow(previous: boolean) {
+    Row({ space: 6 }) {
+      SymbolGlyph(previous ? $r('sys.symbol.arrow_up') : $r('sys.symbol.arrow_down'))
+        .fontSize(16)
+        .fontColor([this.answerOverscrollTriggered()
+          ? $r('app.color.brand_primary') : $r('app.color.secondary_text')])
+      Text(this.answerOverscrollTriggered() ? '松手切换' : (previous ? '上一个回答' : '下一个回答'))
+        .fontSize($r('app.float.p1_caption_font_size'))
+        .fontWeight(this.answerOverscrollTriggered() ? FontWeight.Bold : FontWeight.Normal)
+        .fontColor(this.answerOverscrollTriggered()
+          ? $r('app.color.brand_primary') : $r('app.color.secondary_text'))
+    }
+    .width('100%')
+  }
+
+  /** 预览卡作者行：头像 + 姓名/摘要。 */
+  @Builder
+  private answerPreviewAuthorRow(previous: boolean) {
+    Row({ space: 8 }) {
+      Stack({ alignContent: Alignment.Center }) {
+        Circle()
+          .width(28)
+          .height(28)
+          .fill($r('app.color.control_background'))
+        if (this.answerPreviewAvatarUrl(previous).length > 0) {
+          Image(this.answerPreviewAvatarUrl(previous))
+            .id(previous ? 'p2_answer_prev_preview_avatar' : 'p2_answer_next_preview_avatar')
+            .width(28)
+            .height(28)
+            .borderRadius(14)
+            .objectFit(ImageFit.Cover)
+        } else if (this.answerPreviewAuthorName(previous).length > 0) {
+          Text(this.answerPreviewAuthorName(previous).substring(0, 1))
+            .fontSize($r('app.float.p1_caption_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+        }
+      }
+      .width(28)
+      .height(28)
+      .clip(true)
+
+      Column({ space: 2 }) {
+        if (this.answerPreviewAuthorName(previous).length > 0) {
+          Text(this.answerPreviewAuthorName(previous))
+            .id(previous ? 'p2_answer_prev_preview_author' : 'p2_answer_next_preview_author')
+            .fontSize($r('app.float.p1_body_font_size'))
+            .fontWeight(FontWeight.Medium)
+            .fontColor($r('app.color.primary_text'))
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+        }
+        if (this.answerPreviewExcerpt(previous).length > 0) {
+          Text(this.answerPreviewExcerpt(previous))
+            .id(previous ? 'p2_answer_prev_preview_excerpt' : 'p2_answer_next_preview_excerpt')
+            .fontSize($r('app.float.p1_caption_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .maxLines(2)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+        }
+      }
+      .layoutWeight(1)
+      .alignItems(HorizontalAlign.Start)
+    }
+    .width('100%')
+  }
+
+  /** 悬浮"下一个回答"按钮：品牌色胶囊 + 官方符号图标，点击切换下一答；可拖动避让正文。 */
+  @Builder
+  private answerNextFloatingButton() {
+    Button({ type: ButtonType.Normal, stateEffect: true }) {
+      Row({ space: 6 }) {
+        SymbolGlyph($r('sys.symbol.arrow_down'))
+          .fontSize(20)
+          .fontColor([$r('app.color.on_brand')])
+        Text('下一个回答')
+          .fontSize($r('app.float.p1_secondary_font_size'))
+          .fontWeight(FontWeight.Medium)
+          .fontColor($r('app.color.on_brand'))
+      }
+      .padding({ left: 16, right: 16, top: 10, bottom: 10 })
+    }
+    .id('p2_answer_next_floating')
+    .height(44)
+    .borderRadius(22)
+    .backgroundColor($r('app.color.brand_primary'))
+    .shadow({ radius: 12, color: '#33000000', offsetY: 4 })
+    .margin({
+      right: $r('app.float.p1_page_padding'),
+      // 底部操作栏高约 44vp + 12vp 底距，再加少量间隔。
+      bottom: 76
+    })
+    .offset({ x: this.answerFabOffsetX, y: this.answerFabOffsetY })
+    .onAreaChange((_oldArea: Area, newArea: Area): void => {
+      const width = Number(newArea.width);
+      if (width > 0 && Math.abs(width - this.answerFabWidthVp) > 1) {
+        this.answerFabWidthVp = width;
+      }
+    })
+    .enabled(!this.navigatorBusy)
+    .accessibilityText('下一个回答')
+    .gesture(
+      PanGesture({ fingers: 1 })
+        .onActionStart((event: GestureEvent): void => {
+          this.answerFabPanPrevX = event.offsetX;
+          this.answerFabPanPrevY = event.offsetY;
+          this.answerFabDragging = true;
+        })
+        .onActionUpdate((event: GestureEvent): void => {
+          this.onAnswerFabPanUpdate(event);
+        })
+        .onActionEnd((): void => {
+          this.answerFabPanPrevX = 0;
+          this.answerFabPanPrevY = 0;
+          this.answerFabDragging = false;
+        })
+        .onActionCancel((): void => {
+          this.answerFabPanPrevX = 0;
+          this.answerFabPanPrevY = 0;
+          this.answerFabDragging = false;
+        })
+    )
+    .onClick((): void => {
+      void this.moveAnswer(1);
+    })
+  }
+
+  /** 悬浮"下一个回答"按钮拖动：累计偏移并钳制在页面可视域内
+   * （左/上不越过页边距与页头区，右/下不越过默认位——再低会压住底部操作栏）。 */
+  private onAnswerFabPanUpdate(event: GestureEvent): void {
+    const deltaX = event.offsetX - this.answerFabPanPrevX;
+    const deltaY = event.offsetY - this.answerFabPanPrevY;
+    this.answerFabPanPrevX = event.offsetX;
+    this.answerFabPanPrevY = event.offsetY;
+    if (deltaX === 0 && deltaY === 0) {
+      return;
+    }
+    // 与 p1_page_padding（12vp）保持一致；悬浮层尺寸未就绪（=0）时钳制退化为仅禁越右侧/下侧。
+    const pagePadding = 12;
+    const fabHeight = 44;
+    const minX = this.answerFabWidthVp + pagePadding * 2 - this.answerFabOverlayWidthVp;
+    // 页头（返回 + 标题）区高约 94vp，按钮顶边不得低于其下沿。
+    const minY = 94 + pagePadding + fabHeight + 76 - this.answerFabOverlayHeightVp;
+    this.answerFabOffsetX = Math.min(0, Math.max(minX, this.answerFabOffsetX + deltaX));
+    this.answerFabOffsetY = Math.min(0, Math.max(minY, this.answerFabOffsetY + deltaY));
   }
 
   @Builder
@@ -963,25 +1229,6 @@ struct ContentDetailPage {
     this.answersController?.setSortOrder(order);
   }
 
-  @Builder
-  private answerNavigationControls() {
-    if (this.kind === ContentDetailKind.ANSWER && this.answerNavigator !== undefined) {
-      Column() {
-        Row({ space: 12 }) {
-          Button('上一答').id('question_answer_previous')
-            .enabled(!this.navigatorBusy && this.navigatorHasPrevious()).layoutWeight(1)
-            .onClick((): void => { void this.moveAnswer(-1); })
-          Button('下一答').id('question_answer_next')
-            .enabled(!this.navigatorBusy && this.navigatorHasNext()).layoutWeight(1)
-            .onClick((): void => { void this.moveAnswer(1); })
-        }.width('100%')
-        if (this.navigatorError.length > 0) {
-          Text(this.navigatorError).fontColor($r('app.color.error_text'))
-        }
-      }.width('100%').padding(8)
-    }
-  }
-
   private navigatorHasPrevious(): boolean {
     return this.navigatorRevision >= 0 && (this.answerNavigator?.hasPrevious() ?? false);
   }
@@ -991,12 +1238,20 @@ struct ContentDetailPage {
   private async moveAnswer(direction: number): Promise<void> {
     if (this.navigatorBusy) { return; }
     this.navigatorBusy = true;
-    this.navigatorError = '';
+    this.resetAnswerOverscroll(false);
+    // 新内容从顶部渲染：边界状态归位，避免沿用上一答的贴底状态误触发底部过滑。
+    this.contentAtBottom = false;
+    this.contentAtTop = true;
     try {
       const id = await this.answerNavigator?.move(direction);
       this.navigatorRevision += 1;
       if (!this.pageActive) { return; }
-      if (id === undefined) { this.navigatorError = this.answerNavigator?.errorMessage() ?? ''; return; }
+      if (id === undefined) {
+        const message = this.answerNavigator?.errorMessage() ?? '';
+        this.getUIContext().getPromptAction()
+          .showToast({ message: message.length > 0 ? message : '暂时无法切换回答' });
+        return;
+      }
       this.voteController?.deactivate();
       this.voteController = undefined;
       this.showComments = false;
@@ -1006,6 +1261,97 @@ struct ContentDetailPage {
       this.activeContentId = id;
       await this.controller?.load(ContentDetailKind.ANSWER, id);
     } finally { this.navigatorBusy = false; }
+  }
+
+  /** 贴边后的继续滑动量按 tanh 阻尼转为 overscroll 偏移：贴顶下拉为正（上一答卡），
+   * 贴底上滑为负（下一答卡）；反向回拉等量削减。 */
+  private onAnswerOverscrollPanUpdate(event: GestureEvent): void {
+    if (this.kind !== ContentDetailKind.ANSWER || this.answerFabDragging) { return; }
+    const delta = event.offsetY - this.overscrollPanPrevY;
+    this.overscrollPanPrevY = event.offsetY;
+    if (delta < 0) {
+      // 手指上移：贴底加深"下一答"过滑，或回拉已展开的"上一答"过滑。
+      if (this.contentAtBottom && this.navigatorHasNext() && !this.navigatorBusy) {
+        this.overscrollRawDrag += delta;
+      } else if (this.answerOverscrollOffset > 0) {
+        this.overscrollRawDrag = Math.max(0, this.overscrollRawDrag + delta);
+      } else {
+        return;
+      }
+    } else if (delta > 0) {
+      // 手指下移：贴顶加深"上一答"过滑，或回拉已展开的"下一答"过滑。
+      if (this.contentAtTop && this.navigatorHasPrevious() && !this.navigatorBusy) {
+        this.overscrollRawDrag += delta;
+      } else if (this.answerOverscrollOffset < 0) {
+        this.overscrollRawDrag = Math.min(0, this.overscrollRawDrag + delta);
+      } else {
+        return;
+      }
+    } else {
+      return;
+    }
+    this.answerOverscrollOffset = dampedOverscrollOffset(this.overscrollRawDrag,
+      ANSWER_OVERSCROLL_MAX_OFFSET, ANSWER_OVERSCROLL_DAMPING_FACTOR);
+  }
+
+  /** 松手：达到阈值切换回答（顶部过滑切上一答、底部过滑切下一答，无回弹）；否则弹簧回位。 */
+  private onAnswerOverscrollPanEnd(): void {
+    if (this.kind !== ContentDetailKind.ANSWER || this.answerOverscrollOffset === 0) {
+      this.overscrollRawDrag = 0;
+      return;
+    }
+    const previous = this.answerOverscrollOffset > 0;
+    const triggered = this.answerOverscrollTriggered() && !this.navigatorBusy &&
+      (previous ? this.navigatorHasPrevious() : this.navigatorHasNext());
+    this.overscrollRawDrag = 0;
+    if (triggered) {
+      this.resetAnswerOverscroll(false);
+      void this.moveAnswer(previous ? -1 : 1);
+      return;
+    }
+    this.getUIContext().animateTo({ curve: curves.springMotion(0.32, 0.78) }, (): void => {
+      this.answerOverscrollOffset = 0;
+    });
+  }
+
+  /** 切换回答/页面离开时归零 overscroll（animated=false 跳过回弹动画）。 */
+  private resetAnswerOverscroll(animated: boolean): void {
+    if (this.answerOverscrollOffset === 0 && this.overscrollRawDrag === 0) { return; }
+    this.overscrollRawDrag = 0;
+    if (animated) {
+      this.getUIContext().animateTo({ curve: curves.springMotion(0.32, 0.78) }, (): void => {
+        this.answerOverscrollOffset = 0;
+      });
+    } else {
+      this.answerOverscrollOffset = 0;
+    }
+  }
+
+  private answerOverscrollTriggered(): boolean {
+    return Math.abs(this.answerOverscrollOffset) >= ANSWER_OVERSCROLL_TRIGGER_THRESHOLD;
+  }
+
+  private answerOverscrollProgress(): number {
+    return Math.min(1, Math.abs(this.answerOverscrollOffset) / ANSWER_OVERSCROLL_TRIGGER_THRESHOLD);
+  }
+
+  /** 过滑方向对应的预览数据：previous=true 取上一答，否则取下一答。 */
+  private answerPreviewData(previous: boolean): AnswerNavigationPreview | undefined {
+    return previous ? this.answerNavigator?.previousAnswerPreview() : this.answerNavigator?.nextAnswerPreview();
+  }
+
+  private answerPreviewAuthorName(previous: boolean): string {
+    return this.answerPreviewData(previous)?.authorName ?? '';
+  }
+
+  private answerPreviewAvatarUrl(previous: boolean): string {
+    return this.answerPreviewData(previous)?.authorAvatarUrl ?? '';
+  }
+
+  private answerPreviewExcerpt(previous: boolean): string {
+    const preview = this.answerPreviewData(previous);
+    if (preview === undefined || !preview.detailLoaded) { return ''; }
+    return preview.excerpt;
   }
 
   private canEditExistingAnswer(): boolean {
@@ -1407,7 +1753,18 @@ struct ContentDetailPage {
       if (state.content.kind === ContentDetailKind.QUESTION) {
         publishQuestionTitle({ id: this.activeContentId, title: state.content.value.title, scrolled: this.questionScrolled });
       }
+      if (state.content.kind === ContentDetailKind.ANSWER && this.answerNavigator === undefined) {
+        this.ensureAnswerNavigator(state.content.value.questionId);
+      }
     }
+  }
+
+  /** 信息流直达的回答页没有暂存导航器：按回答归属问题自建（对齐上游 ArticleViewModel）。 */
+  private ensureAnswerNavigator(questionId: string): void {
+    const repository = this.questionAnswerFeedFactory();
+    if (repository === undefined) { return; }
+    this.answerNavigator = new QuestionAnswerNavigator(questionId, this.activeContentId, undefined, repository,
+      (): void => { this.navigatorRevision += 1; });
   }
 
   private activateInteraction(content: LoadedContentDetail): void {
@@ -1508,6 +1865,7 @@ export struct QuestionDetailPage {
 
 @Component
 export struct AnswerDetailPage {
+  questionAnswerFeedFactory: () => QuestionAnswerFeedRepository | undefined = () => undefined;
   contentId: string = '';
   repository: ContentRepository | undefined = undefined;
   openedContentStore: OpenedContentStore | undefined = undefined;
@@ -1526,6 +1884,7 @@ export struct AnswerDetailPage {
   build() {
     ContentDetailPage({
       kind: ContentDetailKind.ANSWER,
+      questionAnswerFeedFactory: this.questionAnswerFeedFactory,
       contentId: this.contentId,
       repository: this.repository,
       openedContentStore: this.openedContentStore,
@@ -1735,4 +2094,17 @@ export function contentStatistics(content: LoadedContentDetail, voteupCount?: nu
     case ContentDetailKind.ARTICLE:
       return `${voteupCount ?? content.value.voteupCount} 赞同 · ${content.value.commentCount} 条评论`;
   }
+}
+
+/** 回答下滑切换：overscroll 最大偏移（vp），对齐上游 MAX_OVERSCROLL_DP。 */
+const ANSWER_OVERSCROLL_MAX_OFFSET: number = 200;
+/** 回答下滑切换：松手触发阈值（vp），对齐上游 TRIGGER_THRESHOLD_DP。 */
+const ANSWER_OVERSCROLL_TRIGGER_THRESHOLD: number = 80;
+/** 回答下滑切换：阻尼系数，对齐上游 DAMPING_FACTOR。 */
+const ANSWER_OVERSCROLL_DAMPING_FACTOR: number = 1.2;
+
+/** tanh 阻尼（对齐上游 dampedOverscrollOffset）：位移趋近上限时增益渐减。 */
+function dampedOverscrollOffset(rawDelta: number, maxOverscroll: number, dampingFactor: number): number {
+  const sign = rawDelta >= 0 ? 1 : -1;
+  return sign * maxOverscroll * Math.tanh(Math.abs(rawDelta) / (maxOverscroll * dampingFactor));
 }

--- a/entry/src/main/ets/pages/ContentDetailState.ets
+++ b/entry/src/main/ets/pages/ContentDetailState.ets
@@ -10,6 +10,7 @@ import {
   HttpFailureKind,
   OpenedContentStore,
   Question,
+  QuestionTopicSummary,
   UserProfile
 } from 'data';
 
@@ -262,6 +263,15 @@ function cloneAuthor(author?: UserProfile): UserProfile | undefined {
   };
 }
 
+function cloneQuestionTopics(topics?: QuestionTopicSummary[]): QuestionTopicSummary[] | undefined {
+  if (topics === undefined) {
+    return undefined;
+  }
+  return topics.map((topic: QuestionTopicSummary): QuestionTopicSummary => {
+    return { id: topic.id, name: topic.name };
+  });
+}
+
 function cloneLoadedContent(content: LoadedContentDetail): LoadedContentDetail {
   switch (content.kind) {
     case ContentDetailKind.QUESTION:
@@ -275,10 +285,12 @@ function cloneLoadedContent(content: LoadedContentDetail): LoadedContentDetail {
           answerCount: content.value.answerCount,
           commentCount: content.value.commentCount,
           followerCount: content.value.followerCount,
+          visitCount: content.value.visitCount,
           createdAt: content.value.createdAt,
           updatedAt: content.value.updatedAt,
           author: cloneAuthor(content.value.author),
-          isFollowing: content.value.isFollowing
+          isFollowing: content.value.isFollowing,
+          topics: cloneQuestionTopics(content.value.topics)
         }
       };
     case ContentDetailKind.ANSWER:

--- a/entry/src/main/ets/pages/ContentInteractionState.ets
+++ b/entry/src/main/ets/pages/ContentInteractionState.ets
@@ -108,6 +108,14 @@ export class ContentVoteController {
     this.emit();
   }
 
+  /** 双击正文赞同一键（对齐上游 upVoteFromDoubleTap）：已赞时静默幂等，不取消赞。 */
+  async voteUpFromDoubleTap(): Promise<void> {
+    if (this.voteState === ContentVoteState.UP) {
+      return;
+    }
+    await this.toggleVote(true);
+  }
+
   async toggleVote(up: boolean): Promise<void> {
     if (!this.active || this.pending) {
       return;

--- a/entry/src/main/ets/pages/DailyFeedDates.ets
+++ b/entry/src/main/ets/pages/DailyFeedDates.ets
@@ -1,0 +1,31 @@
+import { ChannelFeedItem, ChannelFeedItemKind, isDailyFeedDateCursor } from 'data';
+
+export function dailyFeedDateAtIndex(items: Array<ChannelFeedItem>, index: number): string {
+  if (items.length === 0 || index < 0) {
+    return '';
+  }
+  // 底部加载指示器不属于内容，继续显示最后一张卡片的日期。
+  const item = items[Math.min(index, items.length - 1)];
+  return item.kind === ChannelFeedItemKind.DAILY_STORY ? item.story.date : '';
+}
+
+export function formatDailyDate(value: string): string {
+  if (!isDailyFeedDateCursor(value)) {
+    return value;
+  }
+  return `${value.substring(0, 4)}年${Number(value.substring(4, 6))}月${Number(value.substring(6, 8))}日`;
+}
+
+export function dailyDateCursor(date: Date): string {
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${date.getFullYear()}${month}${day}`;
+}
+
+export function dailyPickerDate(value: string): Date {
+  if (!isDailyFeedDateCursor(value)) {
+    return new Date();
+  }
+  return new Date(Number(value.substring(0, 4)), Number(value.substring(4, 6)) - 1,
+    Number(value.substring(6, 8)));
+}

--- a/entry/src/main/ets/pages/FollowingFeedPage.ets
+++ b/entry/src/main/ets/pages/FollowingFeedPage.ets
@@ -3,68 +3,98 @@ import {
   BlockedFeedHistoryGateway,
   BlockingRuleGateway,
   ChannelFeedRepository,
-  ChannelFeedSource
+  ChannelFeedSource,
+  RecentFollowingUsersRepository
 } from 'data';
 import { ChannelFeedPage } from './ChannelFeedPage';
-import { ChannelFeedInteractionBridge } from './ChannelFeedState';
+import { FollowingUsersRow } from './components/FollowingUsersRow';
 
 /**
- * 与上游 FollowScreen 一致：关注顶层页内继续区分推荐与动态。
- * 两个页签各自持有仓储和 ChannelFeedPage，切换时不会串用分页游标或已加载内容。
+ * 与上游 FollowScreen 一致：关注顶层页内用横向 Swiper 承载“推荐”与“动态”两个子页，
+ * 支持左右滑动切换；两个页签各自持有仓储和 ChannelFeedPage，不会串用分页游标。
+ * 标题栏页签选择经 AppStorage 广播（@Consume 在 HdsTabs 树下实测不链接）。
  */
 @Component
 export struct FollowingFeedPage {
   recommendRepository: ChannelFeedRepository | undefined = undefined;
   dynamicRepository: ChannelFeedRepository | undefined = undefined;
+  usersRepository: RecentFollowingUsersRepository | undefined = undefined;
   rules: BlockingRuleGateway | undefined = undefined;
   history: BlockedFeedHistoryGateway | undefined = undefined;
   @Prop reloadToken: number = 0;
   @Prop selectedTabIndex: number = 0;
-  @Consume('channelFeedInteractionBridge') private interactionBridge: ChannelFeedInteractionBridge =
-    new ChannelFeedInteractionBridge();
-  @State private activeTabIndex: number = 0;
   navigate: (destination: P1Destination) => void = (_destination: P1Destination): void => {
   };
+  @State private activeTabIndex: number = 0;
+  private readonly swiperController: SwiperController = new SwiperController();
+  @StorageProp('followingSelectedTabIndex') followingSelectedTabIndex: number = 0;
+  @StorageProp('followingTabSelectionTick') @Watch('onFollowingTabSelectionTick') followingTabSelectionTick: number = 0;
 
   aboutToAppear(): void {
-    this.activeTabIndex = this.selectedTabIndex;
-    this.interactionBridge.registerFollowingTab((index: number): void => {
-      if (index === 0 || index === 1) {
-        this.activeTabIndex = index;
-      }
-    });
+    const initial = this.selectedTabIndex === 1 ? 1 : 0;
+    this.activeTabIndex = initial;
+    if (AppStorage.get<number>('followingSelectedTabIndex') !== initial) {
+      AppStorage.setOrCreate('followingSelectedTabIndex', initial);
+    }
+  }
+
+  private onFollowingTabSelectionTick(): void {
+    const target = this.followingSelectedTabIndex;
+    if ((target === 0 || target === 1) && target !== this.activeTabIndex) {
+      this.swiperController.changeIndex(target, true);
+    }
+  }
+
+  @Builder
+  private recommendTopContent() {
+    FollowingUsersRow({
+      repository: this.usersRepository,
+      navigate: this.navigate
+    })
   }
 
   build() {
-    Column({ space: $r('app.float.p1_spacing_small') }) {
-      if (this.activeTabIndex === 0) {
-        ChannelFeedPage({
-          source: ChannelFeedSource.FOLLOWING_RECOMMEND,
-          showHeader: false,
-          repository: this.recommendRepository,
-          reloadToken: this.reloadToken,
-          navigate: this.navigate,
-          rules: this.rules,
-          history: this.history
-        })
-          .id('p2_following_recommend_content')
-          .layoutWeight(1)
-      } else {
-        ChannelFeedPage({
-          source: ChannelFeedSource.FOLLOWING,
-          showHeader: false,
-          repository: this.dynamicRepository,
-          reloadToken: this.reloadToken,
-          navigate: this.navigate,
-          rules: this.rules,
-          history: this.history
-        })
-          .id('p2_following_dynamic_content')
-          .layoutWeight(1)
-      }
+    Swiper(this.swiperController) {
+      ChannelFeedPage({
+        source: ChannelFeedSource.FOLLOWING_RECOMMEND,
+        showHeader: false,
+        topContent: (): void => {
+          this.recommendTopContent()
+        },
+        topContentVisible: true,
+        repository: this.recommendRepository,
+        reloadToken: this.reloadToken,
+        navigate: this.navigate,
+        rules: this.rules,
+        history: this.history
+      })
+        .id('p2_following_recommend_content')
+
+      ChannelFeedPage({
+        source: ChannelFeedSource.FOLLOWING,
+        showHeader: false,
+        repository: this.dynamicRepository,
+        reloadToken: this.reloadToken,
+        navigate: this.navigate,
+        rules: this.rules,
+        history: this.history
+      })
+        .id('p2_following_dynamic_content')
     }
+    .id('p2_following_pager')
+    .index(this.activeTabIndex)
+    .loop(false)
+    .indicator(false)
+    .cachedCount(1)
+    .onChange((index: number): void => {
+      if (index === this.activeTabIndex) {
+        return;
+      }
+      this.activeTabIndex = index;
+      AppStorage.setOrCreate('followingSelectedTabIndex', index);
+    })
     .width('100%')
-    .height('100%')
+    .layoutWeight(1)
     .backgroundColor($r('app.color.page_background'))
   }
 

--- a/entry/src/main/ets/pages/HistoryTitleBar.ets
+++ b/entry/src/main/ets/pages/HistoryTitleBar.ets
@@ -1,0 +1,65 @@
+/**
+ * 历史记录页 HDS 标题栏注入内容：标题 + 右上角溢出菜单（查看本地历史记录/清除历史记录）。
+ * 与 ReadHistoryPage 分属 HdsNavDestination 的 stackBuilder 与内容两棵子树，经 AppStorage 键通信
+ * （同 SearchTitleBar 模式）；菜单动作只发 tick，确认弹窗与跳转由内容页承接。
+ */
+export const READ_HISTORY_OPEN_LOCAL_TICK_KEY = 'readHistoryOpenLocalTick';
+export const READ_HISTORY_CLEAR_TICK_KEY = 'readHistoryClearTick';
+
+export function publishReadHistoryOpenLocal(): void {
+  AppStorage.setOrCreate(READ_HISTORY_OPEN_LOCAL_TICK_KEY,
+    (AppStorage.get<number>(READ_HISTORY_OPEN_LOCAL_TICK_KEY) ?? 0) + 1);
+}
+
+export function publishReadHistoryClear(): void {
+  AppStorage.setOrCreate(READ_HISTORY_CLEAR_TICK_KEY,
+    (AppStorage.get<number>(READ_HISTORY_CLEAR_TICK_KEY) ?? 0) + 1);
+}
+
+interface HistoryMenuAction {
+  readonly value: string;
+  readonly action: () => void;
+}
+
+@Component
+export struct HistoryTitleBar {
+  title: string = '历史记录';
+
+  build() {
+    Row({ space: 8 }) {
+      // 返回键由 HDS 标题栏默认 backIcon 承载（P1Shell 传入 action），这里从其右侧起排。
+      Text(this.title)
+        .id('p2_history_title')
+        .fontSize($r('app.float.p1_heading_font_size'))
+        .fontWeight(FontWeight.Bold)
+        .fontColor($r('app.color.primary_text'))
+        .maxLines(1)
+        .textOverflow({ overflow: TextOverflow.Ellipsis })
+        .layoutWeight(1)
+      Button({ type: ButtonType.Normal, stateEffect: true }) {
+        SymbolGlyph($r('sys.symbol.ellipsis_circle'))
+          .fontSize(20)
+          .fontColor([$r('app.color.primary_text')])
+      }
+      .id('p2_history_overflow')
+      .width(40)
+      .height(40)
+      .padding(0)
+      .backgroundColor(Color.Transparent)
+      .accessibilityText('历史记录选项')
+      .bindMenu(this.historyMenu())
+    }
+    .width('100%')
+    .height(48)
+    // 左侧 64vp 让出 HDS 默认返回键的区域（实测不 pad 会压到其触摸区，同 SearchTitleBar）。
+    .padding({ left: 64, right: 8 })
+    .alignItems(VerticalAlign.Center)
+  }
+
+  private historyMenu(): Array<HistoryMenuAction> {
+    return [
+      { value: '查看本地历史记录', action: (): void => publishReadHistoryOpenLocal() },
+      { value: '清除历史记录', action: (): void => publishReadHistoryClear() }
+    ];
+  }
+}

--- a/entry/src/main/ets/pages/HomeFeedPage.ets
+++ b/entry/src/main/ets/pages/HomeFeedPage.ets
@@ -6,8 +6,12 @@ import {
   feedItemIdentity,
   FeedItem,
   FeedRepository,
-  FeedTargetKind
+  FeedTargetKind,
+  isUpdateAnnouncementVisible
 } from 'data';
+import { Want } from '@kit.AbilityKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { getAbilityContext } from '../entryability/AbilityContextHolder';
 import {
   BlockingActionContext,
   BlockingActionController,
@@ -24,6 +28,8 @@ import {
 } from './AppPageChrome';
 import { HomeFeedController, HomeFeedPhase, HomeFeedViewState } from './HomeFeedState';
 
+const PROJECT_RELEASES_URI: string = 'https://github.com/zhuoyi233/zhihu-plus-plus-HMOS/releases/latest';
+
 @Component
 export struct HomeFeedPage {
   repository: FeedRepository | undefined = new DefaultFeedRepository();
@@ -36,6 +42,11 @@ export struct HomeFeedPage {
   // 双击底栏“首页”页签刷新：复用下拉刷新链路
   @StorageProp('tabRefreshTick') @Watch('onTabRefreshRequested') tabRefreshTick: number = 0;
   @StorageProp('tabRefreshTabIndex') tabRefreshTabIndex: number = -1;
+  // 首页更新卡片（对齐上游 HomeScreen 顶部 AnnouncementCard）：P1Shell 启动检查到新版本后经
+  // AppStorage 广播（HdsTabs 树下跨页面信号唯一可靠通道）。“以后”仅本次会话内忽略，对齐上游。
+  @StorageProp('homeUpdateAnnouncementVersion') private pendingUpdateVersion: string = '';
+  @StorageProp('homeUpdateAnnouncementUrl') private pendingUpdateUrl: string = '';
+  @State private dismissedUpdateVersion: string = '';
   // 下拉刷新自定义加载圆圈（refreshingContent 需 ComponentContent，随页面销毁释放）
   private refreshContent?: ComponentContent<FeedPullDownIndicatorOptions> = undefined;
   navigate: (destination: P1Destination) => void = (_destination: P1Destination): void => {
@@ -148,6 +159,13 @@ export struct HomeFeedPage {
             friction: 100
           }) {
             List() {
+              if (isUpdateAnnouncementVisible(this.pendingUpdateVersion, this.dismissedUpdateVersion)) {
+                ListItem() {
+                  this.updateAnnouncementCard()
+                }
+                .margin({ bottom: $r('app.float.p1_spacing_medium') })
+              }
+
               ForEach(this.items, (item: FeedItem) => {
                 ListItem() {
                   this.feedCard(item);
@@ -210,6 +228,84 @@ export struct HomeFeedPage {
     .height('100%')
     .alignContent(Alignment.TopStart)
     .backgroundColor($r('app.color.page_background'))
+  }
+
+  @Builder
+  private updateAnnouncementCard() {
+    // 对齐上游 AnnouncementCard colorsImportant：主色底、圆形图标位、右侧“以后/查看更新”操作区。
+    Column({ space: $r('app.float.p1_spacing_small') }) {
+      Row({ space: $r('app.float.p1_spacing_small') }) {
+        Row() {
+          SymbolGlyph($r('sys.symbol.arrow_up'))
+            .fontSize(16)
+            .fontColor([Color.White])
+        }
+          .width(28)
+          .height(28)
+          .borderRadius(14)
+          .backgroundColor('#33FFFFFF')
+          .justifyContent(FlexAlign.Center)
+          .alignItems(VerticalAlign.Center)
+        Text(`发现新版本：${this.pendingUpdateVersion}`)
+          .id('p2_home_update_card_title')
+          .fontSize($r('app.float.p1_heading_font_size'))
+          .fontWeight(FontWeight.Medium)
+          .fontColor(Color.White)
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .layoutWeight(1)
+      }
+        .width('100%')
+        .alignItems(VerticalAlign.Center)
+
+      Row({ space: $r('app.float.p1_spacing_small') }) {
+        Button('以后', { type: ButtonType.ROUNDED_RECTANGLE, stateEffect: true })
+          .id('p2_home_update_card_dismiss')
+          .fontSize($r('app.float.p1_body_font_size'))
+          .fontColor(Color.White)
+          .backgroundColor(Color.Transparent)
+          .borderRadius(12)
+          .onClick((): void => {
+            this.dismissedUpdateVersion = this.pendingUpdateVersion;
+          })
+        Button('查看更新', { type: ButtonType.ROUNDED_RECTANGLE, stateEffect: true })
+          .id('p2_home_update_card_open')
+          .fontSize($r('app.float.p1_body_font_size'))
+          .fontColor($r('app.color.brand_primary'))
+          .backgroundColor(Color.White)
+          .borderRadius(12)
+          .onClick((): void => this.openUpdateReleasePage())
+      }
+        .width('100%')
+        .justifyContent(FlexAlign.End)
+    }
+      .width('100%')
+      .padding($r('app.float.p1_card_padding'))
+      .borderRadius($r('app.float.p1_card_radius'))
+      .backgroundColor($r('app.color.brand_primary'))
+      .accessibilityText('发现新版本，可查看更新或稍后忽略')
+  }
+
+  private openUpdateReleasePage(): void {
+    const url = this.pendingUpdateUrl.length > 0 ? this.pendingUpdateUrl : PROJECT_RELEASES_URI;
+    const context = getAbilityContext();
+    if (context === undefined) {
+      hilog.warn(0x0000, 'AppUpdate', 'cannot open release page: no ability context');
+      return;
+    }
+    const want: Want = {
+      action: 'ohos.want.action.viewData',
+      uri: url
+    };
+    try {
+      void context.startAbility(want).then((): void => {}, (error: Object): void => {
+        const detail = error instanceof Error ? error.message : '';
+        hilog.warn(0x0000, 'AppUpdate', 'failed to open release page %{public}s', detail);
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : '';
+      hilog.warn(0x0000, 'AppUpdate', 'failed to open release page %{public}s', detail);
+    }
   }
 
   @Builder

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -109,6 +109,7 @@ struct Index {
   @State private followingRepository?: ChannelFeedRepository = undefined;
   @State private followingRecommendRepository?: ChannelFeedRepository = undefined;
   @State private hotRepository?: ChannelFeedRepository = undefined;
+  private hotQuestionRepositoryFactory: () => ContentRepository | undefined = () => undefined;
   @State private dailyRepository?: ChannelFeedRepository = undefined;
   @State private dailyStoryRepository?: DailyStoryRepository = undefined;
   @State private questionRepository?: ContentRepository = undefined;
@@ -160,6 +161,7 @@ struct Index {
       this.followingRepository = new DefaultChannelFeedRepository(new ZhihuHttpClient(session), blockingMatcher);
       this.followingRecommendRepository = new DefaultChannelFeedRepository(new ZhihuHttpClient(session), blockingMatcher);
       this.hotRepository = new DefaultChannelFeedRepository(new ZhihuHttpClient(session), blockingMatcher);
+      this.hotQuestionRepositoryFactory = (): ContentRepository => new DefaultContentRepository(new ZhihuHttpClient(session));
       this.dailyRepository = new DefaultChannelFeedRepository(new ZhihuHttpClient(), blockingMatcher);
       this.dailyStoryRepository = new DefaultDailyStoryRepository(new ZhihuHttpClient());
       this.questionRepository = new DefaultContentRepository(new ZhihuHttpClient(session));
@@ -292,6 +294,7 @@ struct Index {
     ChannelFeedPage({
       source: ChannelFeedSource.HOT,
       repository: this.hotRepository,
+      questionRepositoryFactory: this.hotQuestionRepositoryFactory,
       reloadToken: reloadToken,
       navigate: navigate,
       rules: this.blockingRuleStore,

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -89,6 +89,7 @@ import { PeopleDetailPage, PinDetailPage } from './PeoplePinDetailPages';
 import { BlockingRulesPage } from './BlockingRulesPage';
 import { BlockedFeedHistoryPage } from './BlockedFeedHistoryPage';
 import { ReadHistoryPage } from './ReadHistoryPage';
+import { LocalHistoryPage } from './LocalHistoryPage';
 import { CollectionPage } from './CollectionPage';
 import { CollectionContentPage } from './CollectionContentPage';
 import { NotificationPage } from './NotificationPage';
@@ -247,6 +248,8 @@ struct Index {
           blockedFeedHistoryContent: (onBack: () => void): void => this.blockedFeedHistoryContent(onBack),
           readHistoryContent: (navigate: (destination: P1Destination) => void, onBack: () => void): void =>
             this.readHistoryContent(navigate, onBack),
+          localHistoryContent: (navigate: (destination: P1Destination) => void, onBack: () => void): void =>
+            this.localHistoryContent(navigate, onBack),
           loginContent: (onBack: () => void, onAuthenticated: () => void, onScanDesktopLogin: () => void): void =>
             this.loginContent(onBack, onAuthenticated, onScanDesktopLogin),
           technicalLabContent: (navigate: (destination: P1Destination) => void): void =>
@@ -527,27 +530,44 @@ struct Index {
   }
 
   @Builder
-  readHistoryContent(navigate: (destination: P1Destination) => void, onBack: () => void) {
+  readHistoryContent(navigate: (destination: P1Destination) => void, _onBack: () => void) {
     ReadHistoryPage({
       history: this.openedContentStore,
       onlineHistory: this.onlineHistoryRepository,
       session: this.session,
       onOpen: (target: ReadHistoryOpenTarget): void => {
-        if (target.kind === ReadHistoryContentKind.QUESTION) {
-          navigate({ name: P1DestinationName.QUESTION, id: target.id });
-        } else if (target.kind === ReadHistoryContentKind.ANSWER) {
-          navigate({ name: P1DestinationName.ANSWER, id: target.id });
-        } else if (target.kind === ReadHistoryContentKind.ARTICLE) {
-          navigate({ name: P1DestinationName.ARTICLE, id: target.id });
-        } else {
-          navigate({ name: P1DestinationName.PIN, id: target.id });
-        }
+        this.navigateReadHistoryTarget(navigate, target);
       },
       onGoLogin: (): void => {
         navigate({ name: P1DestinationName.LOGIN });
       },
-      onBack: onBack
+      onNavigateLocal: (): void => {
+        navigate({ name: P1DestinationName.LOCAL_HISTORY });
+      }
     });
+  }
+
+  @Builder
+  localHistoryContent(navigate: (destination: P1Destination) => void, _onBack: () => void) {
+    LocalHistoryPage({
+      history: this.openedContentStore,
+      onOpen: (target: ReadHistoryOpenTarget): void => {
+        this.navigateReadHistoryTarget(navigate, target);
+      }
+    });
+  }
+
+  private navigateReadHistoryTarget(navigate: (destination: P1Destination) => void,
+    target: ReadHistoryOpenTarget): void {
+    if (target.kind === ReadHistoryContentKind.QUESTION) {
+      navigate({ name: P1DestinationName.QUESTION, id: target.id });
+    } else if (target.kind === ReadHistoryContentKind.ANSWER) {
+      navigate({ name: P1DestinationName.ANSWER, id: target.id });
+    } else if (target.kind === ReadHistoryContentKind.ARTICLE) {
+      navigate({ name: P1DestinationName.ARTICLE, id: target.id });
+    } else {
+      navigate({ name: P1DestinationName.PIN, id: target.id });
+    }
   }
 
   @Builder

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -327,6 +327,7 @@ struct Index {
     SearchPage({
       initialQuery: query,
       repository: this.searchRepository,
+      preferences: this.preferencesStore,
       navigate: navigate,
       onBack: onBack
     });

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -22,6 +22,7 @@ import {
   DefaultPeopleRepository,
   DefaultPinRepository,
   DefaultPinPublishRepository,
+  DefaultQuestionAnswerFeedRepository,
   DefaultSearchRepository,
   DefaultOnlineHistoryRepository,
   DefaultNotificationRepository,
@@ -46,6 +47,7 @@ import {
   ImageUploadSource,
   AnswerPublishRepository,
   PinPublishRepository,
+  QuestionAnswerFeedRepository,
   VoteRepository,
   ZhihuHttpClient
 } from 'data';
@@ -110,6 +112,7 @@ struct Index {
   @State private dailyRepository?: ChannelFeedRepository = undefined;
   @State private dailyStoryRepository?: DailyStoryRepository = undefined;
   @State private questionRepository?: ContentRepository = undefined;
+  private questionAnswerFeedFactory: () => QuestionAnswerFeedRepository | undefined = () => undefined;
   @State private answerRepository?: ContentRepository = undefined;
   @State private articleRepository?: ContentRepository = undefined;
   @State private peopleRepository?: PeopleDetailRepository = undefined;
@@ -160,6 +163,8 @@ struct Index {
       this.dailyRepository = new DefaultChannelFeedRepository(new ZhihuHttpClient(), blockingMatcher);
       this.dailyStoryRepository = new DefaultDailyStoryRepository(new ZhihuHttpClient());
       this.questionRepository = new DefaultContentRepository(new ZhihuHttpClient(session));
+      this.questionAnswerFeedFactory = (): QuestionAnswerFeedRepository =>
+        new DefaultQuestionAnswerFeedRepository(new ZhihuHttpClient(session), blockingMatcher);
       this.answerRepository = new DefaultContentRepository(new ZhihuHttpClient(session));
       this.articleRepository = new DefaultContentRepository(new ZhihuHttpClient(session));
       this.peopleRepository = new DefaultPeopleRepository(new ZhihuHttpClient(session));
@@ -337,6 +342,7 @@ struct Index {
       followRepository: this.followRepository,
       collectionRepository: this.collectionRepository,
       commentRepository: this.commentRepository,
+      questionAnswerFeedFactory: this.questionAnswerFeedFactory,
       session: this.session,
       onBack: onBack
     });

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -23,6 +23,7 @@ import {
   DefaultPinRepository,
   DefaultPinPublishRepository,
   DefaultQuestionAnswerFeedRepository,
+  DefaultRecentFollowingUsersRepository,
   DefaultSearchRepository,
   DefaultOnlineHistoryRepository,
   DefaultNotificationRepository,
@@ -37,6 +38,7 @@ import {
   OnlineHistoryRepository,
   PeopleContentRepository,
   PeopleDetailRepository,
+  RecentFollowingUsersRepository,
   PinRepository,
   SearchRepository,
   SessionRepository,
@@ -108,6 +110,7 @@ struct Index {
   @State private searchRepository?: SearchRepository = undefined;
   @State private followingRepository?: ChannelFeedRepository = undefined;
   @State private followingRecommendRepository?: ChannelFeedRepository = undefined;
+  @State private followingUsersRepository?: RecentFollowingUsersRepository = undefined;
   @State private hotRepository?: ChannelFeedRepository = undefined;
   private hotQuestionRepositoryFactory: () => ContentRepository | undefined = () => undefined;
   @State private dailyRepository?: ChannelFeedRepository = undefined;
@@ -160,6 +163,7 @@ struct Index {
       this.searchRepository = new DefaultSearchRepository(new ZhihuHttpClient(session), blockingMatcher);
       this.followingRepository = new DefaultChannelFeedRepository(new ZhihuHttpClient(session), blockingMatcher);
       this.followingRecommendRepository = new DefaultChannelFeedRepository(new ZhihuHttpClient(session), blockingMatcher);
+      this.followingUsersRepository = new DefaultRecentFollowingUsersRepository(new ZhihuHttpClient(session));
       this.hotRepository = new DefaultChannelFeedRepository(new ZhihuHttpClient(session), blockingMatcher);
       this.hotQuestionRepositoryFactory = (): ContentRepository => new DefaultContentRepository(new ZhihuHttpClient(session));
       this.dailyRepository = new DefaultChannelFeedRepository(new ZhihuHttpClient(), blockingMatcher);
@@ -280,6 +284,7 @@ struct Index {
     selectedTabIndex: number) {
     FollowingFeedPage({
       recommendRepository: this.followingRecommendRepository,
+      usersRepository: this.followingUsersRepository,
       dynamicRepository: this.followingRepository,
       reloadToken: reloadToken,
       selectedTabIndex: selectedTabIndex,

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -364,6 +364,7 @@ struct Index {
       followRepository: this.followRepository,
       collectionRepository: this.collectionRepository,
       commentRepository: this.commentRepository,
+      questionAnswerFeedFactory: this.questionAnswerFeedFactory,
       session: this.session,
       onBack: onBack
     });

--- a/entry/src/main/ets/pages/LocalHistoryPage.ets
+++ b/entry/src/main/ets/pages/LocalHistoryPage.ets
@@ -1,0 +1,198 @@
+import { ReadHistoryGateway } from 'data';
+import { feedPullDownIndicator, FeedPullDownIndicatorOptions } from './AppPageChrome';
+import { ComponentContent } from '@kit.ArkUI';
+import {
+  LocalHistoryController,
+  ReadHistoryItem,
+  readHistoryKindLabel,
+  ReadHistoryOpenTarget,
+  ReadHistoryPhase,
+  readHistoryTimeLabel,
+  ReadHistoryViewState
+} from './ReadHistoryState';
+
+/** 本地历史记录页：对齐上游 LegacyLocalHistoryScreen，一次性读取本机已读记录的卡片列表。 */
+@Component
+export struct LocalHistoryPage {
+  history: ReadHistoryGateway | undefined = undefined;
+  onOpen: (target: ReadHistoryOpenTarget) => void = (_target: ReadHistoryOpenTarget): void => {};
+  @State private viewState: ReadHistoryViewState = {
+    phase: ReadHistoryPhase.LOADING,
+    items: [],
+    busy: false,
+    message: '正在读取本地历史记录',
+    requiresLogin: false,
+    loadingMore: false,
+    canLoadMore: false
+  };
+  private controller?: LocalHistoryController;
+  private refreshContent?: ComponentContent<FeedPullDownIndicatorOptions> = undefined;
+
+  aboutToAppear(): void {
+    if (this.controller !== undefined) {
+      this.controller.activate();
+      return;
+    }
+    const history = this.history;
+    if (history === undefined) {
+      this.viewState = {
+        phase: ReadHistoryPhase.ERROR,
+        items: [],
+        busy: false,
+        message: '本地历史记录数据源未配置',
+        requiresLogin: false,
+        loadingMore: false,
+        canLoadMore: false
+      };
+      return;
+    }
+    this.controller = new LocalHistoryController(history, (state: ReadHistoryViewState): void => {
+      this.viewState = state;
+    });
+    this.refreshContent = new ComponentContent(this.getUIContext(), wrapBuilder(feedPullDownIndicator),
+      new FeedPullDownIndicatorOptions());
+    this.controller.activate();
+  }
+
+  aboutToDisappear(): void {
+    this.controller?.deactivate();
+    this.controller = undefined;
+    this.refreshContent?.dispose();
+    this.refreshContent = undefined;
+  }
+
+  build() {
+    Stack({ alignContent: Alignment.TopStart }) {
+      Column({ space: $r('app.float.p1_spacing_medium') }) {
+        Text('只保存在本机；不保存正文、Cookie、搜索词或账号信息。')
+          .id('p2_read_history_privacy')
+          .fontSize($r('app.float.p1_caption_font_size'))
+          .fontColor($r('app.color.secondary_text'))
+          .width('100%')
+        if (this.viewState.phase === ReadHistoryPhase.LOADING && this.viewState.items.length === 0) {
+          LoadingProgress()
+            .id('p2_local_history_loading')
+            .width(40)
+            .height(40)
+            .color($r('app.color.brand_primary'))
+        } else if (this.viewState.items.length === 0) {
+          Column({ space: $r('app.float.p1_spacing_medium') }) {
+            Text(this.viewState.message)
+              .id('p2_local_history_empty')
+              .fontSize($r('app.float.p1_body_font_size'))
+              .fontColor($r('app.color.secondary_text'))
+              .textAlign(TextAlign.Center)
+              .width('100%')
+            if (this.viewState.phase === ReadHistoryPhase.ERROR) {
+              Button('重新读取')
+                .id('p2_local_history_retry')
+                .enabled(!this.viewState.busy)
+                .onClick((): void => {
+                  void this.controller?.reload();
+                })
+            }
+          }
+          .justifyContent(FlexAlign.Center)
+          .layoutWeight(1)
+          .width('100%')
+        } else {
+          Refresh({
+            refreshing: false,
+            refreshingContent: this.refreshContent,
+            offset: 80,
+            friction: 100
+          }) {
+            List({ space: 12 }) {
+              ForEach(this.viewState.items, (item: ReadHistoryItem) => {
+                ListItem() {
+                  this.localHistoryCard(item)
+                }
+                .width('100%')
+              }, (item: ReadHistoryItem): string => item.contentKey)
+            }
+            .id('p2_local_history_list')
+            .width('100%')
+            .scrollBar(BarState.Off)
+            .edgeEffect(EdgeEffect.Spring)
+          }
+          .id('p2_local_history_pull_refresh')
+          .width('100%')
+          .layoutWeight(1)
+          .onRefreshing((): void => {
+            void this.controller?.reload();
+          })
+        }
+      }
+      .width('100%')
+      .height('100%')
+      .padding({ left: $r('app.float.p1_page_padding'), right: $r('app.float.p1_page_padding'),
+        top: 94, bottom: $r('app.float.p1_page_padding') })
+      .backgroundColor($r('app.color.page_background'))
+    }
+    .id('p2_local_history_page')
+    .width('100%')
+    .height('100%')
+    .backgroundColor($r('app.color.page_background'))
+  }
+
+  @Builder
+  private localHistoryCard(item: ReadHistoryItem) {
+    Button({ type: ButtonType.Normal, stateEffect: true }) {
+      Column({ space: $r('app.float.p1_spacing_small') }) {
+        Row({ space: $r('app.float.p1_spacing_xsmall') }) {
+          Text(`${readHistoryKindLabel(item.kind)} · ${readHistoryTimeLabel(item.openedAt)}`)
+            .fontSize($r('app.float.p1_secondary_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .layoutWeight(1)
+          Button({ type: ButtonType.Normal, stateEffect: true }) {
+            SymbolGlyph($r('sys.symbol.ellipsis_circle'))
+              .fontSize(18)
+              .fontColor([$r('app.color.secondary_text')])
+          }
+          .id(`p3_local_history_item_menu_${item.contentKey}`)
+          .width(32)
+          .height(32)
+          .padding(0)
+          .backgroundColor(Color.Transparent)
+          .enabled(!this.viewState.busy)
+          .bindMenu(this.itemMenu(item))
+          .accessibilityText('该条本地记录操作')
+        }
+        .width('100%')
+
+        Text(this.itemTitle(item))
+          .fontSize($r('app.float.p1_heading_font_size'))
+          .fontWeight(FontWeight.Medium)
+          .fontColor($r('app.color.primary_text'))
+          .maxLines(2)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .width('100%')
+      }
+      .alignItems(HorizontalAlign.Start)
+      .width('100%')
+    }
+    .id(`p2_local_history_card_${item.contentKey}`)
+    .width('100%')
+    .padding($r('app.float.p1_card_padding'))
+    .borderRadius($r('app.float.p1_card_radius'))
+    .backgroundColor($r('app.color.surface_background'))
+    .accessibilityText(`打开${readHistoryKindLabel(item.kind)}：${this.itemTitle(item)}`)
+    .onClick((): void => this.onOpen({ kind: item.kind, id: item.id }))
+  }
+
+  private itemMenu(item: ReadHistoryItem): Array<MenuElement> {
+    return [{
+      value: '删除该条本地记录',
+      action: (): void => {
+        void this.controller?.delete(item.contentKey);
+      }
+    }];
+  }
+
+  private itemTitle(item: ReadHistoryItem): string {
+    const title = item.title.trim();
+    return title.length > 0 ? title : `${readHistoryKindLabel(item.kind)} #${item.id}`;
+  }
+}

--- a/entry/src/main/ets/pages/NativeContentDocument.ets
+++ b/entry/src/main/ets/pages/NativeContentDocument.ets
@@ -403,15 +403,120 @@ export struct NativeContentDocument {
   emptyMessage: string = '正文为空';
   /** P3-9-B：正文滚动像素偏移回调（用于详情页顶栏折叠联动）。 */
   onScrollOffset?: (offset: number) => void;
+  /** 问题详情页在正文末尾追加的 section（回答信息流）；未传入时渲染空。 */
+  @BuilderParam documentHeader: () => void = this.emptyFooter;
+  @BuilderParam documentBodyFooter: () => void = this.emptyFooter;
+  @BuilderParam documentItems: () => void = this.emptyFooter;
+  @BuilderParam documentFooter: () => void = this.emptyFooter;
+  /** 列表触底回调：问题详情页用于回答信息流分页加载。 */
+  onListReachEnd?: () => void;
+  /** 问题页正文折叠预览：正文超阈值（纯文本≥100 字或含图）时收起为 180vp 视口。 */
+  collapsible: boolean = false;
+  @State private detailExpanded: boolean = false;
+  @State private collapsibleActive: boolean = false;
+  /** 正文自然高度（vp）：由内层 onAreaChange 单调更新；视口高度据此派生，勿存快照——
+   * 首帧测量偏小若被存死，内容长高后视口将永久被压小（正文整块消失）。 */
+  @State private naturalHeightVp: number = 0;
+  private blocks: ReaderBlock[] = [];
   @State private previewUrl: string = '';
   @State private empty: boolean = true;
   private readonly dataSource: ReaderBlockDataSource = new ReaderBlockDataSource();
   private readonly scroller: Scroller = new Scroller();
 
+  @Builder
+  private emptyFooter(): void {
+  }
+
+  /**
+   * 问题正文折叠视口（对齐上游 QuestionAnimatedBodyHeader）：收起 180vp + 底部渐变遮罩 +
+   * 右下角展开/收起开关，420ms FastOutSlowIn 动画。内层 Scroll 让子列不受视口高度约束、
+   * 始终按自然高度测量（onAreaChange 回填展开目标高度），规避"父锁高→子测量被压缩"死锁。
+   */
+  @Builder
+  private collapsibleBodyViewport() {
+    Stack({ alignContent: Alignment.Bottom }) {
+      Scroll() {
+        Column({ space: 12 }) {
+          ForEach(this.blocks, (item: ReaderBlock) => {
+            this.readerBlock(item)
+          }, (item: ReaderBlock): string => item.id)
+        }
+        .width('100%')
+        .onAreaChange((_oldArea: Area, newArea: Area): void => {
+          const height = Number(newArea.height);
+          if (height > 0 && Math.abs(height - this.naturalHeightVp) > 1) {
+            this.naturalHeightVp = height;
+          }
+        })
+      }
+      .scrollBar(BarState.Off)
+      .align(Alignment.Top)
+      .width('100%')
+      // 该 Scroll 仅用于让子列按自然高度测量（无约束约束），自身永不滚动；
+      // 不禁用滚动交互会抢占全部滑动手势，外层列表（回答流）将无法滚动。
+      .enableScrollInteraction(false)
+
+      Column()
+          .linearGradient({
+            angle: 180,
+            colors: [['rgba(0,0,0,0)', 0], [$r('app.color.page_background'), 1]]
+          })
+          .width('100%')
+          .height(88)
+          .opacity(this.detailExpanded ? 0 : 1)
+          .hitTestBehavior(HitTestMode.None)
+
+      Row() {
+        Blank()
+        Row({ space: 4 }) {
+          SymbolGlyph(this.detailExpanded ? $r('sys.symbol.chevron_up') : $r('sys.symbol.chevron_down'))
+            .fontSize(16)
+            .fontColor([$r('app.color.brand_primary')])
+          Text(this.detailExpanded ? '收起详情' : '展开详情')
+            .fontSize($r('app.float.p1_secondary_font_size'))
+            .fontColor($r('app.color.brand_primary'))
+        }
+        .padding({ left: 12, right: 12 }).height(56)
+        .borderRadius(16)
+        .backgroundColor($r('app.color.surface_background'))
+        .onClick((): void => this.toggleDetailExpanded())
+        .accessibilityText(this.detailExpanded ? '收起问题详情' : '展开问题详情')
+      }
+      .id('p3_question_detail_toggle')
+      .width('100%')
+      .padding({ left: 12, right: 12, bottom: 8 })
+    }
+    .id('p3_question_detail_content')
+    .height(this.detailExpanded ? this.expandedViewportHeight() : this.collapsedViewportHeight())
+    .clip(true)
+    .width('100%')
+  }
+
+  /** 收起态视口高：未测得自然高前用 180，测得后取 min(自然高,180) 兜底短正文。 */
+  private collapsedViewportHeight(): number {
+    return this.naturalHeightVp > 0 ? Math.min(this.naturalHeightVp, 180) : 180;
+  }
+
+  private expandedViewportHeight(): number {
+    return Math.max(this.naturalHeightVp, 1) + 64;
+  }
+
+  private toggleDetailExpanded(): void {
+    this.getUIContext().animateTo({
+      duration: 420,
+      curve: Curve.FastOutSlowIn
+    }, (): void => {
+      this.detailExpanded = !this.detailExpanded;
+    });
+  }
+
   aboutToAppear(): void {
     const blocks = parseZhihuHtml(this.html);
     this.empty = blocks.length === 0;
+    this.blocks = blocks;
     this.dataSource.replace(blocks);
+    const plainLength = this.html.replace(/<[^>]*>/g, '').trim().length;
+    this.collapsibleActive = this.collapsible && (plainLength >= 100 || this.html.includes('<img'));
   }
 
   aboutToDisappear(): void {
@@ -420,21 +525,32 @@ export struct NativeContentDocument {
 
   build() {
     Stack({ alignContent: Alignment.Center }) {
-      if (this.empty) {
-        Text(this.emptyMessage)
-          .id('p2_content_document_empty')
-          .fontSize($r('app.float.p1_body_font_size'))
-          .fontColor($r('app.color.secondary_text'))
-          .textAlign(TextAlign.Center)
-          .width('100%')
-          .padding($r('app.float.p1_page_padding'))
-      } else {
-        List({ space: 12, scroller: this.scroller }) {
-          LazyForEach(this.dataSource, (item: ReaderBlock) => {
+      List({ space: 12, scroller: this.scroller }) {
+          ListItem() { this.documentHeader() }
+          if (this.empty) {
             ListItem() {
-              this.readerBlock(item)
+              Text(this.emptyMessage).id('p2_content_document_empty')
+                .fontColor($r('app.color.secondary_text')).padding(12)
             }
-          }, (item: ReaderBlock): string => item.id)
+          }
+          if (this.collapsibleActive) {
+            ListItem() {
+              this.collapsibleBodyViewport()
+            }
+            .width('100%')
+          } else {
+            LazyForEach(this.dataSource, (item: ReaderBlock) => {
+              ListItem() {
+                this.readerBlock(item)
+              }
+            }, (item: ReaderBlock): string => item.id)
+          }
+          ListItem() { this.documentBodyFooter() }
+          this.documentItems()
+          ListItem() {
+            this.documentFooter()
+          }
+          .width('100%')
         }
         .id('p2_content_document_list')
         .width('100%')
@@ -444,10 +560,17 @@ export struct NativeContentDocument {
           left: $r('app.float.p1_page_padding'),
           right: $r('app.float.p1_page_padding'),
           top: $r('app.float.p1_spacing_medium'),
-          bottom: $r('app.float.p1_page_padding')
+          bottom: 100
         })
         .cachedCount(6)
         .edgeEffect(EdgeEffect.Spring)
+        // 触底回调：问题详情页据此加载回答信息流下一页。
+        .onReachEnd((): void => {
+          const callback = this.onListReachEnd;
+          if (callback !== undefined) {
+            callback();
+          }
+        })
         // 用像素偏移而非 onScrollIndex 驱动顶栏折叠：索引会随视口高度变化回弹造成振荡闪烁，
         // 像素偏移在顶栏收起（视口变高）时保持不变，状态稳定。
         .onDidScroll((): void => {
@@ -456,7 +579,6 @@ export struct NativeContentDocument {
             callback(this.scroller.currentOffset().yOffset);
           }
         })
-      }
 
       if (this.previewUrl.length > 0) {
         ContentImagePreview({

--- a/entry/src/main/ets/pages/NativeContentDocument.ets
+++ b/entry/src/main/ets/pages/NativeContentDocument.ets
@@ -49,7 +49,7 @@ function previewImageExtension(value: string): string {
 }
 
 @Component
-struct ContentImagePreview {
+export struct ContentImagePreview {
   url: string = '';
   onClose: () => void = () => {};
   @State private previewScale: number = 1;

--- a/entry/src/main/ets/pages/NativeContentDocument.ets
+++ b/entry/src/main/ets/pages/NativeContentDocument.ets
@@ -559,9 +559,10 @@ export struct NativeContentDocument {
         .padding({
           left: $r('app.float.p1_page_padding'),
           right: $r('app.float.p1_page_padding'),
-          top: $r('app.float.p1_spacing_medium'),
-          bottom: 100
+          top: $r('app.float.p1_spacing_medium')
         })
+        // 末尾避让随正文滚动，避免底部 padding 压缩视口、在悬浮操作栏下方形成固定留白。
+        .contentEndOffset(100)
         .cachedCount(6)
         .edgeEffect(EdgeEffect.Spring)
         // 触底回调：问题详情页据此加载回答信息流下一页。

--- a/entry/src/main/ets/pages/NativeContentDocument.ets
+++ b/entry/src/main/ets/pages/NativeContentDocument.ets
@@ -1,7 +1,7 @@
 import { image } from '@kit.ImageKit';
 import { http } from '@kit.NetworkKit';
 import { photoAccessHelper } from '@kit.MediaLibraryKit';
-import { abilityAccessCtrl } from '@kit.AbilityKit';
+import { abilityAccessCtrl, Want } from '@kit.AbilityKit';
 import { getAbilityContext } from '../entryability/AbilityContextHolder';
 import {
   createSystemShareService
@@ -29,8 +29,18 @@ function inlineFormulaWidth(tex: string): number {
   return Math.min(220, Math.max(20, tex.length * 9));
 }
 
+/** 对齐上游 telephoto 默认 ZoomSpec(maxZoomFactor = 2f)。 */
+const IMAGE_PREVIEW_MAX_SCALE = 2;
+
 function clampPreviewScale(value: number): number {
-  return Math.min(4, Math.max(1, value));
+  return Math.min(IMAGE_PREVIEW_MAX_SCALE, Math.max(1, value));
+}
+
+function clampValue(value: number, limit: number): number {
+  if (limit <= 0) {
+    return 0;
+  }
+  return Math.min(limit, Math.max(-limit, value));
 }
 
 function isTrustedPreviewImageUrl(value: string): boolean {
@@ -50,21 +60,35 @@ function previewImageExtension(value: string): string {
 
 @Component
 export struct ContentImagePreview {
-  url: string = '';
+  @Prop url: string = '';
   onClose: () => void = () => {};
   @State private previewScale: number = 1;
+  @State private previewOffsetX: number = 0;
+  @State private previewOffsetY: number = 0;
   @State private actionStatus: string = '';
   private saveInFlight: boolean = false;
   private pinchStartScale: number = 1;
+  /** 源图宽高比与容器尺寸：用于计算放大后允许的平移范围。 */
+  private imageRatio: number = 0;
+  private containerWidth: number = 0;
+  private containerHeight: number = 0;
+  private panStartX: number = 0;
+  private panStartY: number = 0;
 
   build() {
-    Stack({ alignContent: Alignment.TopEnd }) {
+    Stack({ alignContent: Alignment.Center }) {
       Image(this.url)
         .id('p2_content_image_preview')
         .width('100%')
         .height('100%')
         .objectFit(ImageFit.Contain)
+        .onComplete((event) => {
+          if (event !== undefined && event.width > 0 && event.height > 0) {
+            this.imageRatio = event.width / event.height;
+          }
+        })
         .scale({ x: this.previewScale, y: this.previewScale, z: 1 })
+        .translate({ x: this.previewOffsetX, y: this.previewOffsetY })
         .gesture(
           PinchGesture({ fingers: 2 })
             .onActionStart((): void => {
@@ -72,53 +96,121 @@ export struct ContentImagePreview {
             })
             .onActionUpdate((event: GestureEvent): void => {
               this.previewScale = clampPreviewScale(this.pinchStartScale * event.scale);
+              this.clampPreviewOffset();
             })
         )
-        .parallelGesture(
-          TapGesture({ count: 2 })
-            .onAction((): void => {
-              this.previewScale = 1;
-              this.actionStatus = '已恢复原始大小';
+        .gesture(
+          PanGesture({ fingers: 1 })
+            .onActionStart((): void => {
+              this.panStartX = this.previewOffsetX;
+              this.panStartY = this.previewOffsetY;
+            })
+            .onActionUpdate((event: GestureEvent): void => {
+              const maxX = this.maxPreviewOffsetX();
+              const maxY = this.maxPreviewOffsetY();
+              this.previewOffsetX = clampValue(this.panStartX + event.offsetX, maxX);
+              this.previewOffsetY = clampValue(this.panStartY + event.offsetY, maxY);
             })
         )
-        .parallelGesture(
-          LongPressGesture({ duration: 600 })
-            .onAction((): void => {
-              this.saveImage();
-            })
+        .gesture(
+          GestureGroup(GestureMode.Exclusive,
+            TapGesture({ count: 2 })
+              .onAction((): void => {
+                // 对齐上游 telephoto 双击：在适配屏幕与最大倍数间切换，缩放回 1 时复位平移。
+                this.previewScale = this.previewScale > 1 ? 1 : IMAGE_PREVIEW_MAX_SCALE;
+                this.clampPreviewOffset();
+              }),
+            TapGesture({ count: 1 })
+              .onAction((): void => {
+                this.onClose();
+              })
+          )
         )
+        // 对齐上游 OpenImageDialog：长按在按压点弹出操作菜单（无顶栏按钮）。
+        .bindContextMenu(this.imageContextMenu, ResponseType.LongPress)
 
-      Column({ space: $r('app.float.p1_spacing_small') }) {
-        Row({ space: $r('app.float.p1_spacing_small') }) {
-          Button('保存')
-            .id('p2_content_image_preview_save')
-            .onClick((): void => {
-              this.saveImage();
-            })
-          Button('分享')
-            .id('p2_content_image_preview_share')
-            .onClick((): void => {
-              this.shareImage();
-            })
-          Button('关闭')
-            .id('p2_content_image_preview_close')
-            .onClick((): void => {
-              this.onClose();
-            })
-        }
-        if (this.actionStatus.length > 0) {
+      if (this.actionStatus.length > 0) {
+        Column() {
+          Blank()
           Text(this.actionStatus)
             .id('p2_content_image_preview_status')
             .fontSize($r('app.float.p1_secondary_font_size'))
             .fontColor(Color.White)
+            .margin({ bottom: 64 })
         }
+        .width('100%')
+        .height('100%')
+        .hitTestBehavior(HitTestMode.None)
       }
-      .margin($r('app.float.p1_page_padding'))
-      .alignItems(HorizontalAlign.End)
     }
     .width('100%')
     .height('100%')
     .backgroundColor('#EE000000')
+    .onAreaChange((_oldArea: Area, newArea: Area): void => {
+      this.containerWidth = Number(newArea.width);
+      this.containerHeight = Number(newArea.height);
+    })
+  }
+
+  /** 放大后单指平移的最大位移：超出适配尺寸的部分才允许拖动（对齐 telephoto 平移边界）。 */
+  private maxPreviewOffsetX(): number {
+    if (this.containerWidth <= 0 || this.containerHeight <= 0 || this.imageRatio <= 0) {
+      return 0;
+    }
+    const ratio = this.containerWidth / this.containerHeight;
+    const baseWidth = this.imageRatio > ratio ? this.containerWidth : this.containerHeight * this.imageRatio;
+    return Math.max(0, (baseWidth * this.previewScale - this.containerWidth) / 2);
+  }
+
+  private maxPreviewOffsetY(): number {
+    if (this.containerWidth <= 0 || this.containerHeight <= 0 || this.imageRatio <= 0) {
+      return 0;
+    }
+    const ratio = this.containerWidth / this.containerHeight;
+    const baseHeight = this.imageRatio > ratio ? this.containerWidth / this.imageRatio : this.containerHeight;
+    return Math.max(0, (baseHeight * this.previewScale - this.containerHeight) / 2);
+  }
+
+  private clampPreviewOffset(): void {
+    this.previewOffsetX = clampValue(this.previewOffsetX, this.maxPreviewOffsetX());
+    this.previewOffsetY = clampValue(this.previewOffsetY, this.maxPreviewOffsetY());
+  }
+
+  @Builder
+  private imageContextMenu() {
+    Menu() {
+      MenuItem({ content: '保存图片' })
+        .id('p2_content_image_preview_menu_save')
+        .onClick((): void => {
+          this.saveImage();
+        })
+      MenuItem({ content: '分享图片' })
+        .id('p2_content_image_preview_menu_share')
+        .onClick((): void => {
+          this.shareImage();
+        })
+      MenuItem({ content: '在浏览器中打开' })
+        .id('p2_content_image_preview_menu_browser')
+        .onClick((): void => {
+          this.openInBrowser();
+        })
+    }
+  }
+
+  private async openInBrowser(): Promise<void> {
+    const context = getAbilityContext();
+    if (context === undefined || !isTrustedPreviewImageUrl(this.url)) {
+      return;
+    }
+    const want: Want = {
+      action: 'ohos.want.action.viewData',
+      uri: this.url
+    };
+    try {
+      await context.startAbility(want);
+    } catch (_error) {
+      this.getUIContext().getPromptAction().showToast({ message: '暂时无法在浏览器中打开' });
+    }
   }
 
   private async saveImage(): Promise<void> {
@@ -424,7 +516,6 @@ export struct NativeContentDocument {
    * 首帧测量偏小若被存死，内容长高后视口将永久被压小（正文整块消失）。 */
   @State private naturalHeightVp: number = 0;
   private blocks: ReaderBlock[] = [];
-  @State private previewUrl: string = '';
   @State private empty: boolean = true;
   /** 正文是否贴在列表底边：onReachEnd 置位；出现任何实际滚动（回滚/内容增高后续滚）即复位。 */
   private atBottomEdge: boolean = false;
@@ -601,16 +692,6 @@ export struct NativeContentDocument {
           }
         })
 
-      if (this.previewUrl.length > 0) {
-        ContentImagePreview({
-          url: this.previewUrl,
-          onClose: (): void => {
-            this.previewUrl = '';
-          }
-        })
-        .width('100%')
-        .height('100%')
-      }
     }
     .width('100%')
     .height('100%')
@@ -654,7 +735,9 @@ export struct NativeContentDocument {
         item: item,
         secondaryTextColor: $r('app.color.secondary_text'),
         onPreview: (url: string): void => {
-          this.previewUrl = url;
+          // 全屏查看器由详情页根 Stack 叠层渲染（AppStorage 广播）：正文组件处于列表
+          // 惰性树内，本地渲染全屏层会受标题栏约束，且模态覆盖层树不响应状态更新。
+          AppStorage.setOrCreate('p2ImagePreviewUrl', url);
         }
       })
     } else if (item.inlineRuns.length > 0) {

--- a/entry/src/main/ets/pages/NativeContentDocument.ets
+++ b/entry/src/main/ets/pages/NativeContentDocument.ets
@@ -410,6 +410,12 @@ export struct NativeContentDocument {
   @BuilderParam documentFooter: () => void = this.emptyFooter;
   /** 列表触底回调：问题详情页用于回答信息流分页加载。 */
   onListReachEnd?: () => void;
+  /** 回答详情页切换：正文是否贴在列表底边（用于自定义 overscroll 手势）。 */
+  onBottomEdgeChange?: (atBottom: boolean) => void;
+  /** 回答详情页切换：正文是否贴在列表顶边（顶部过滑切上一答依赖此信号）。 */
+  onTopEdgeChange?: (atTop: boolean) => void;
+  /** 回答详情页关闭 Spring 边缘效果：自定义 overscroll 需要独占边界拖动量。 */
+  disableEdgeSpring: boolean = false;
   /** 问题页正文折叠预览：正文超阈值（纯文本≥100 字或含图）时收起为 180vp 视口。 */
   collapsible: boolean = false;
   @State private detailExpanded: boolean = false;
@@ -420,6 +426,11 @@ export struct NativeContentDocument {
   private blocks: ReaderBlock[] = [];
   @State private previewUrl: string = '';
   @State private empty: boolean = true;
+  /** 正文是否贴在列表底边：onReachEnd 置位；出现任何实际滚动（回滚/内容增高后续滚）即复位。 */
+  private atBottomEdge: boolean = false;
+  /** 正文是否贴在列表顶边：初始即顶；滚动进正文（yOffset 越过容差）即复位，滚回顶部再置位。 */
+  private atTopEdge: boolean = true;
+  private lastYOffset: number = 0;
   private readonly dataSource: ReaderBlockDataSource = new ReaderBlockDataSource();
   private readonly scroller: Scroller = new Scroller();
 
@@ -564,9 +575,10 @@ export struct NativeContentDocument {
         // 末尾避让随正文滚动，避免底部 padding 压缩视口、在悬浮操作栏下方形成固定留白。
         .contentEndOffset(100)
         .cachedCount(6)
-        .edgeEffect(EdgeEffect.Spring)
+        .edgeEffect(this.disableEdgeSpring ? EdgeEffect.None : EdgeEffect.Spring)
         // 触底回调：问题详情页据此加载回答信息流下一页。
         .onReachEnd((): void => {
+          this.updateBottomEdge(true);
           const callback = this.onListReachEnd;
           if (callback !== undefined) {
             callback();
@@ -574,10 +586,18 @@ export struct NativeContentDocument {
         })
         // 用像素偏移而非 onScrollIndex 驱动顶栏折叠：索引会随视口高度变化回弹造成振荡闪烁，
         // 像素偏移在顶栏收起（视口变高）时保持不变，状态稳定。
+        // 同时维护底部边界状态：贴底后回滚（y 减小）即离开底边；y 反向增大只可能是
+        // 内容增高后继续上滚（onReachEnd 提前触发的残余滚动在 2px 容差内不复位）。
         .onDidScroll((): void => {
+          const yOffset = this.scroller.currentOffset().yOffset;
+          if (yOffset < this.lastYOffset - 0.5 || yOffset > this.lastYOffset + 2) {
+            this.updateBottomEdge(false);
+          }
+          this.updateTopEdge(yOffset <= 2);
+          this.lastYOffset = yOffset;
           const callback = this.onScrollOffset;
           if (callback !== undefined) {
-            callback(this.scroller.currentOffset().yOffset);
+            callback(yOffset);
           }
         })
 
@@ -594,6 +614,27 @@ export struct NativeContentDocument {
     }
     .width('100%')
     .height('100%')
+  }
+
+  /** 触底/离底状态变化时通知页面侧（下滑切换回答依赖此信号）。 */
+  private updateBottomEdge(atBottom: boolean): void {
+    this.lastYOffset = this.scroller.currentOffset().yOffset;
+    if (this.atBottomEdge === atBottom) { return; }
+    this.atBottomEdge = atBottom;
+    const callback = this.onBottomEdgeChange;
+    if (callback !== undefined) {
+      callback(atBottom);
+    }
+  }
+
+  /** 贴顶/离顶状态变化时通知页面侧（顶部过滑切上一答依赖此信号）。 */
+  private updateTopEdge(atTop: boolean): void {
+    if (this.atTopEdge === atTop) { return; }
+    this.atTopEdge = atTop;
+    const callback = this.onTopEdgeChange;
+    if (callback !== undefined) {
+      callback(atTop);
+    }
   }
 
   @Builder

--- a/entry/src/main/ets/pages/P1Shell.ets
+++ b/entry/src/main/ets/pages/P1Shell.ets
@@ -42,6 +42,7 @@ import { getImmersiveTitleBarStyle } from '../common/style/NavStyles';
 import { ZhihuHdsTabs } from './components/ZhihuHdsTabs';
 import { materialCanvas } from './components/MaterialCanvas';
 import { ChannelFeedInteractionBridge } from './ChannelFeedState';
+import { dailyDateCursor, dailyPickerDate, formatDailyDate } from './DailyFeedDates';
 
 const PROJECT_HOME_URI: string = 'https://github.com/zhuoyi233/zhihu-plus-plus-HMOS';
 
@@ -130,8 +131,8 @@ export struct P1Shell {
   // the options in observed state instead of passing an inline object, which
   // otherwise renders the control but drops its tap callback on device.
   @State private followingSegmentOptions: SegmentButtonOptions = this.createFollowingSegmentOptions();
-  @Provide('dailyDatePickerRequest') private dailyDatePickerRequest: number = 0;
-  @Provide('dailyDateCursor') private dailyDateCursor: string = '';
+  @StorageProp('dailyViewingDate') private dailyViewingDate: string = '';
+  @State private dailyDateCursor: string = '';
   @Provide('channelFeedInteractionBridge') private channelFeedInteractionBridge: ChannelFeedInteractionBridge =
     new ChannelFeedInteractionBridge();
   @State @Watch('onTopLevelTabIndexChanged') private topLevelTabIndex: number = P1TopLevelTab.HOME;
@@ -876,6 +877,21 @@ export struct P1Shell {
       .hitTestBehavior(HitTestMode.Transparent)
     } else if (this.topLevelTabIndex === P1TopLevelTab.DAILY) {
       Row() {
+        Column({ space: 2 }) {
+          Text('知乎日报')
+            .fontSize($r('app.float.p1_heading_font_size'))
+            .fontWeight(FontWeight.Bold)
+            .fontColor($r('app.color.primary_text'))
+          if (this.dailyViewingDate.length > 0) {
+            Text(formatDailyDate(this.dailyViewingDate))
+              .id('p2_daily_titlebar_current_date')
+              .fontSize($r('app.float.p1_secondary_font_size'))
+              .fontColor($r('app.color.secondary_text'))
+              .maxLines(1)
+          }
+        }
+        .alignItems(HorizontalAlign.Start)
+        .layoutWeight(1)
         Button({ type: ButtonType.Circle, stateEffect: true }) {
           SymbolGlyph($r('sys.symbol.calendar'))
             .fontSize(20)
@@ -893,8 +909,7 @@ export struct P1Shell {
         })
       }
       .width('100%')
-      .justifyContent(FlexAlign.End)
-      .padding({ right: 12 })
+      .padding({ left: $r('app.float.p1_page_padding'), right: 12 })
       .hitTestBehavior(HitTestMode.Transparent)
     }
     }
@@ -926,23 +941,18 @@ export struct P1Shell {
   }
 
   private openDailyDatePicker(): void {
-    const selectedDate: Date = new Date();
     this.getUIContext().showDatePickerDialog({
-      selected: selectedDate,
+      selected: dailyPickerDate(this.dailyViewingDate),
       start: new Date(2000, 0, 1),
       end: new Date(),
       onDateAccept: (date: Date): void => {
-        this.dailyDateCursor = this.formatDailyDateCursor(date);
-        this.dailyReloadToken += 1;
-        this.channelFeedInteractionBridge.selectDailyDate(this.dailyDateCursor);
+        // HdsTabs 下使用 AppStorage 先写日期再广播，重复选择同一天也能重新加载。
+        this.dailyDateCursor = dailyDateCursor(date);
+        AppStorage.setOrCreate('dailySelectedDate', this.dailyDateCursor);
+        AppStorage.setOrCreate('dailyDateSelectionTick',
+          (AppStorage.get<number>('dailyDateSelectionTick') ?? 0) + 1);
       }
     });
-  }
-
-  private formatDailyDateCursor(date: Date): string {
-    const month: string = `${date.getMonth() + 1}`.padStart(2, '0');
-    const day: string = `${date.getDate()}`.padStart(2, '0');
-    return `${date.getFullYear()}${month}${day}`;
   }
 
   @Builder

--- a/entry/src/main/ets/pages/P1Shell.ets
+++ b/entry/src/main/ets/pages/P1Shell.ets
@@ -20,8 +20,6 @@ import ConfigurationConstant from '@ohos.app.ability.ConfigurationConstant';
 import bundleManager from '@ohos.bundle.bundleManager';
 import { Want } from '@kit.AbilityKit';
 import {
-  SegmentButton,
-  SegmentButtonOptions,
   SymbolGlyphModifier
 } from '@kit.ArkUI';
 import { hilog } from '@kit.PerformanceAnalysisKit';
@@ -140,10 +138,9 @@ export struct P1Shell {
   @State private followingReloadToken: number = 0;
   @State private hotReloadToken: number = 0;
   @State private dailyReloadToken: number = 0;
-  // SegmentButtonOptions is an @ObjectLink in the framework component. Keep
-  // the options in observed state instead of passing an inline object, which
-  // otherwise renders the control but drops its tap callback on device.
-  @State private followingSegmentOptions: SegmentButtonOptions = this.createFollowingSegmentOptions();
+  // 关注页子页签（推荐/动态）当前选中项：经 AppStorage 与关注页 Swiper 双向同步
+  // （标题栏点选写 tick，关注页滑动写 index），@Consume 在 HdsTabs 树下实测不链接。
+  @StorageProp('followingSelectedTabIndex') private followingTitleSelectedIndex: number = 0;
   @StorageProp('dailyViewingDate') private dailyViewingDate: string = '';
   @State private dailyDateCursor: string = '';
   @Provide('channelFeedInteractionBridge') private channelFeedInteractionBridge: ChannelFeedInteractionBridge =
@@ -363,7 +360,7 @@ export struct P1Shell {
       HdsNavDestination() {
         this.followingContent(this.followingReloadToken,
           (destination: P1Destination): void => this.navigate(destination),
-          this.followingTitleBarIndexes[0]);
+          this.followingTitleSelectedIndex);
       }
       .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { title: { mainTitle: '关注' }, divider: { showType: DividerShowType.OFF } } })
       .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM])
@@ -711,7 +708,7 @@ export struct P1Shell {
         TabContent() {
           this.followingContent(this.followingReloadToken,
             (destination: P1Destination): void => this.navigate(destination),
-            this.followingTitleBarIndexes[0]);
+            this.followingTitleSelectedIndex);
         }
         .id('p1_top_level_following_content')
         .tabBar(this.topLevelTabBarStyle(P1TopLevelTab.FOLLOWING))
@@ -918,13 +915,12 @@ export struct P1Shell {
       .hitTestBehavior(HitTestMode.Transparent)
     } else if (this.topLevelTabIndex === P1TopLevelTab.FOLLOWING) {
       Column() {
-        SegmentButton({
-          options: this.followingSegmentOptions,
-          selectedIndexes: $followingTitleBarIndexes,
-          onItemClicked: (index: number): void => this.selectFollowingTitleBarTab(index)
-        })
-          .width('52%')
-          .height(44)
+        Row() {
+          this.followingTitleTabItem('推荐', 0)
+          this.followingTitleTabItem('动态', 1)
+        }
+          .width(180)
+          .height(40)
       }
       .width('100%')
       .height('100%')
@@ -997,25 +993,39 @@ export struct P1Shell {
     .monopolizeEvents(false)
   }
 
-  // SegmentButton uses two-way binding; keep the selected index as observable
-  // component state so taps immediately rebuild the following feed content.
-  @State private followingTitleBarIndexes: number[] = [0];
+  // 关注子页签：鸿蒙规范的文字页签（选中加重 + 短下划线指示条），
+  // 点选经 AppStorage 广播给关注页 Swiper。
+  @Builder
+  private followingTitleTabItem(title: string, index: number) {
+    Column({ space: 4 }) {
+      Text(title)
+        .fontSize(16)
+        .fontWeight(this.followingTitleSelectedIndex === index ? FontWeight.Medium : FontWeight.Regular)
+        .fontColor(this.followingTitleSelectedIndex === index
+          ? $r('app.color.primary_text')
+          : $r('app.color.secondary_text'))
+      Row()
+        .width(this.followingTitleSelectedIndex === index ? 24 : 0)
+        .height(3)
+        .borderRadius(1.5)
+        .backgroundColor($r('app.color.zhihu_blue'))
+        .animation({ duration: 250, curve: Curve.EaseInOut })
+    }
+      .id(`p2_following_titlebar_tab_${index}`)
+      .layoutWeight(1)
+      .height(40)
+      .justifyContent(FlexAlign.Center)
+      .accessibilityText(`切换到${title}`)
+      .onClick((): void => this.selectFollowingTitleBarTab(index))
+  }
 
   private selectFollowingTitleBarTab(index: number): void {
     if (index < 0 || index > 1) {
       return;
     }
-    this.followingTitleBarIndexes = [index];
-    this.channelFeedInteractionBridge.selectFollowingTab(index);
-  }
-
-  private createFollowingSegmentOptions(): SegmentButtonOptions {
-    return SegmentButtonOptions.tab({
-      buttons: [{ text: '推荐' }, { text: '动态' }],
-      backgroundColor: Color.Transparent,
-      selectedBackgroundColor: $r('app.color.brand_primary_container'),
-      buttonPadding: 10
-    });
+    AppStorage.setOrCreate('followingSelectedTabIndex', index);
+    AppStorage.setOrCreate('followingTabSelectionTick',
+      (AppStorage.get<number>('followingTabSelectionTick') ?? 0) + 1);
   }
 
   private openDailyDatePicker(): void {

--- a/entry/src/main/ets/pages/P1Shell.ets
+++ b/entry/src/main/ets/pages/P1Shell.ets
@@ -118,6 +118,8 @@ export struct P1Shell {
   /** 回答页双击正文动作（对齐上游 answerDoubleTapAction）：AppStorage 广播与详情页双向同步。 */
   @StorageProp('answerDoubleTapAction') private answerDoubleTapAction: AnswerDoubleTapAction =
     AnswerDoubleTapAction.ASK;
+  /** 回答/文章详情页沉浸式阅读中（页面广播）：隐藏 NavDestination 顶栏（对齐上游 topBar={}）。 */
+  @StorageProp('detailImmersiveActive') private detailImmersiveActive: boolean = false;
   @State private installedVersionLabel: string = '正在读取已安装版本…';
   @State private aboutVersionSheetShown: boolean = false;
   /** GitHub 最新 Release 检出有新版本时非空：驱动“我的”页横幅与版本弹层下载入口。 */
@@ -407,6 +409,16 @@ export struct P1Shell {
       }
       .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { stackBuilder: (): void => this.answerTitleBar(destination.id), divider: { showType: DividerShowType.OFF } } })
       .hideBackButton(true)
+      // 沉浸式隐藏顶栏（对齐上游）；返回键优先退沉浸式（对齐上游 PlatformBackHandler）。
+      .hideTitleBar(this.detailImmersiveActive)
+      .onBackPressed((): boolean => {
+        if (this.detailImmersiveActive) {
+          AppStorage.setOrCreate('detailImmersiveExitTick',
+            (AppStorage.get<number>('detailImmersiveExitTick') ?? 0) + 1);
+          return true;
+        }
+        return false;
+      })
       .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM])
       .backgroundColor($r('app.color.page_background'))
     } else if (destination.name === P1DestinationName.ARTICLE) {
@@ -421,6 +433,16 @@ export struct P1Shell {
       }
       .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { stackBuilder: (): void => this.articleTitleBar(destination.id), divider: { showType: DividerShowType.OFF } } })
       .hideBackButton(true)
+      // 与回答页一致：沉浸式隐藏顶栏，返回键优先退沉浸式。
+      .hideTitleBar(this.detailImmersiveActive)
+      .onBackPressed((): boolean => {
+        if (this.detailImmersiveActive) {
+          AppStorage.setOrCreate('detailImmersiveExitTick',
+            (AppStorage.get<number>('detailImmersiveExitTick') ?? 0) + 1);
+          return true;
+        }
+        return false;
+      })
       .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM])
       .backgroundColor($r('app.color.page_background'))
     } else if (destination.name === P1DestinationName.VIDEO) {

--- a/entry/src/main/ets/pages/P1Shell.ets
+++ b/entry/src/main/ets/pages/P1Shell.ets
@@ -1,3 +1,4 @@
+import { QuestionTitleBar } from './QuestionTitleBar';
 import {
   AppPreferencesStore,
   AppThemeMode,
@@ -380,7 +381,7 @@ export struct P1Shell {
           }
         );
       }
-      .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { stackBuilder: (): void => this.detailTitleBar('问题'), divider: { showType: DividerShowType.OFF } } })
+      .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { stackBuilder: (): void => this.questionTitleBar(destination.id), divider: { showType: DividerShowType.OFF } } })
       .hideBackButton(true)
       .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM])
       .backgroundColor($r('app.color.page_background'))
@@ -742,6 +743,11 @@ export struct P1Shell {
   }
 
   /** 详情页 HDS 标题栏内容：返回键 + 页面标题（替代各详情页自绘页头，消除标题栏空置占位）。 */
+  @Builder
+  private questionTitleBar(id: string) {
+    QuestionTitleBar({ questionId: id, onBack: (): void => { this.pathStack.pop(); } })
+  }
+
   @Builder
   private detailTitleBar(title: string) {
     Row({ space: $r('app.float.p1_spacing_small') }) {

--- a/entry/src/main/ets/pages/P1Shell.ets
+++ b/entry/src/main/ets/pages/P1Shell.ets
@@ -1,4 +1,5 @@
 import { QuestionTitleBar } from './QuestionTitleBar';
+import { AnswerTitleBar } from './AnswerTitleBar';
 import {
   AppPreferencesStore,
   AppThemeMode,
@@ -396,7 +397,7 @@ export struct P1Shell {
           }
         );
       }
-      .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { stackBuilder: (): void => this.detailTitleBar('回答'), divider: { showType: DividerShowType.OFF } } })
+      .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { stackBuilder: (): void => this.answerTitleBar(destination.id), divider: { showType: DividerShowType.OFF } } })
       .hideBackButton(true)
       .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM])
       .backgroundColor($r('app.color.page_background'))
@@ -747,6 +748,12 @@ export struct P1Shell {
   @Builder
   private questionTitleBar(id: string) {
     QuestionTitleBar({ questionId: id, onBack: (): void => { this.pathStack.pop(); } })
+  }
+
+  /** 回答页标题栏：滚动折叠时在返回键右侧显示问题单行 + 答主摘要（对齐上游折叠顶栏）。 */
+  @Builder
+  private answerTitleBar(id: string) {
+    AnswerTitleBar({ answerId: id, onBack: (): void => { this.pathStack.pop(); } })
   }
 
   @Builder

--- a/entry/src/main/ets/pages/P1Shell.ets
+++ b/entry/src/main/ets/pages/P1Shell.ets
@@ -2,6 +2,9 @@ import { QuestionTitleBar } from './QuestionTitleBar';
 import { AnswerTitleBar } from './AnswerTitleBar';
 import { ArticleTitleBar } from './ArticleTitleBar';
 import {
+  allAnswerDoubleTapActions,
+  AnswerDoubleTapAction,
+  answerDoubleTapActionLabel,
   AppPreferencesStore,
   AppThemeMode,
   AppUpdateCheckResult,
@@ -112,6 +115,9 @@ export struct P1Shell {
   @StorageProp('sessionStateTick') @Watch('onSessionStateTick') sessionStateTick: number = 0;
   @State private sessionSnapshot?: SessionState = undefined;
   @State private themeMode: AppThemeMode = AppThemeMode.SYSTEM;
+  /** 回答页双击正文动作（对齐上游 answerDoubleTapAction）：AppStorage 广播与详情页双向同步。 */
+  @StorageProp('answerDoubleTapAction') private answerDoubleTapAction: AnswerDoubleTapAction =
+    AnswerDoubleTapAction.ASK;
   @State private installedVersionLabel: string = '正在读取已安装版本…';
   @State private aboutVersionSheetShown: boolean = false;
   /** GitHub 最新 Release 检出有新版本时非空：驱动“我的”页横幅与版本弹层下载入口。 */
@@ -149,6 +155,7 @@ export struct P1Shell {
     this.themeMounted = true;
     this.sessionSnapshot = this.session?.getState();
     this.restoreThemeMode();
+    void this.restoreAnswerDoubleTapAction();
     this.refreshInstalledVersionLabel();
     this.unsubscribeStartupDestination?.();
     const listener: StartupDestinationListener = (destination: P1Destination): void => {
@@ -1044,6 +1051,29 @@ export struct P1Shell {
                 this.themeButton('深色', AppThemeMode.DARK, 'p1_theme_dark');
               }
               .width('100%')
+            }
+            .alignItems(HorizontalAlign.Start)
+            .width('100%')
+            .padding($r('app.float.p1_card_padding'))
+            Divider().color($r('app.color.divider_color'))
+            Column({ space: $r('app.float.p1_spacing_small') }) {
+              Text('双击回答动作')
+                .fontSize($r('app.float.p1_body_font_size'))
+                .fontColor($r('app.color.primary_text'))
+              Text('双击回答正文时执行的动作。默认弹窗询问。')
+                .fontSize($r('app.float.p1_secondary_font_size'))
+                .fontColor($r('app.color.secondary_text'))
+              Select(this.answerDoubleTapSelectOptions())
+                .id('p3_settings_answer_double_tap_select')
+                .selected(this.answerDoubleTapAction)
+                .value(answerDoubleTapActionLabel(this.answerDoubleTapAction))
+                .fontColor($r('app.color.primary_text'))
+                .onSelect((index: number): void => {
+                  const actions = allAnswerDoubleTapActions();
+                  if (index >= 0 && index < actions.length) {
+                    void this.selectAnswerDoubleTapAction(actions[index]);
+                  }
+                })
             }
             .alignItems(HorizontalAlign.Start)
             .width('100%')
@@ -1951,6 +1981,40 @@ export struct P1Shell {
       default:
         return destination.name;
     }
+  }
+
+  private answerDoubleTapSelectOptions(): SelectOption[] {
+    return allAnswerDoubleTapActions().map((action: AnswerDoubleTapAction): SelectOption => {
+      return { value: answerDoubleTapActionLabel(action) } as SelectOption;
+    });
+  }
+
+  private async restoreAnswerDoubleTapAction(): Promise<void> {
+    const context = this.getUIContext().getHostContext();
+    if (context === undefined) {
+      return;
+    }
+    try {
+      this.answerDoubleTapAction = await new AppPreferencesStore(context).loadAnswerDoubleTapAction();
+      AppStorage.setOrCreate('answerDoubleTapAction', this.answerDoubleTapAction);
+    } catch (_error) {
+      // 读取失败保持默认 Ask。
+    }
+  }
+
+  private async selectAnswerDoubleTapAction(action: AnswerDoubleTapAction): Promise<void> {
+    const context = getAbilityContext();
+    if (context === undefined) {
+      return;
+    }
+    AppStorage.setOrCreate('answerDoubleTapAction', action);
+    try {
+      await new AppPreferencesStore(context).saveAnswerDoubleTapAction(action);
+    } catch (_error) {
+      // 保存失败时选择已生效，重启后可能恢复此前设置。
+    }
+    this.getUIContext().getPromptAction()
+      .showToast({ message: `已设置为：${answerDoubleTapActionLabel(action)}` });
   }
 
   private async restoreThemeMode(): Promise<void> {

--- a/entry/src/main/ets/pages/P1Shell.ets
+++ b/entry/src/main/ets/pages/P1Shell.ets
@@ -1,4 +1,5 @@
 import { QuestionTitleBar } from './QuestionTitleBar';
+import { SearchTitleBar } from './SearchTitleBar';
 import { AnswerTitleBar } from './AnswerTitleBar';
 import { ArticleTitleBar } from './ArticleTitleBar';
 import {
@@ -346,7 +347,16 @@ export struct P1Shell {
           }
         );
       }
-      .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { title: { mainTitle: '搜索' }, divider: { showType: DividerShowType.OFF } } })
+      .titleBar({
+        style: getImmersiveTitleBarStyle(),
+        avoidLayoutSafeArea: true,
+        // 返回键用 HDS 标题栏自带 backIcon（自定义 action 接管），避免与 stackBuilder 内自绘返回键重叠。
+        content: {
+          stackBuilder: (): void => this.searchTitleBar(),
+          backIcon: { action: (): void => { this.pathStack.pop(); } },
+          divider: { showType: DividerShowType.OFF }
+        }
+      })
       .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM])
       .backgroundColor($r('app.color.page_background'))
     } else if (destination.name === P1DestinationName.FOLLOWING) {
@@ -797,6 +807,12 @@ export struct P1Shell {
   @Builder
   private questionTitleBar(id: string) {
     QuestionTitleBar({ questionId: id, onBack: (): void => { this.pathStack.pop(); } })
+  }
+
+  /** 搜索页 HDS 标题栏内容：返回键 + 搜索框 + 排序方式菜单（对齐上游搜索顶栏）。 */
+  @Builder
+  private searchTitleBar() {
+    SearchTitleBar()
   }
 
   /** 回答页标题栏：滚动折叠时在返回键右侧显示问题单行 + 答主摘要（对齐上游折叠顶栏）。 */

--- a/entry/src/main/ets/pages/P1Shell.ets
+++ b/entry/src/main/ets/pages/P1Shell.ets
@@ -14,7 +14,8 @@ import {
   AppUpdateRelease,
   LoginSessionGateway,
   SessionState,
-  SessionStatus
+  SessionStatus,
+  shouldAutoCheckForUpdate
 } from 'data';
 import ConfigurationConstant from '@ohos.app.ability.ConfigurationConstant';
 import bundleManager from '@ohos.bundle.bundleManager';
@@ -1752,7 +1753,8 @@ export struct P1Shell {
     }
   }
 
-  /** verbose=true 供“应用与版本”弹层手动检查（展示状态）；false 供启动静默检查（仅检出新版本时提示）。 */
+  /** verbose=true 供“应用与版本”弹层手动检查（展示状态、不受节流限制）；false 供启动静默检查
+    * （3 小时节流，对齐上游 shouldPerformAutoCheck）。检出新版本时经 AppStorage 广播驱动首页更新卡片。 */
   private async runUpdateCheck(verbose: boolean): Promise<void> {
     if (this.updateCheckBusy) {
       return;
@@ -1763,6 +1765,10 @@ export struct P1Shell {
       }
       return;
     }
+    if (!verbose && !(await this.shouldAutoCheckUpdateNow())) {
+      return;
+    }
+    await this.markUpdateCheckedNow();
     this.updateCheckBusy = true;
     if (verbose) {
       this.updateCheckMessage = '正在检查更新…';
@@ -1772,20 +1778,60 @@ export struct P1Shell {
         await this.updateClient.checkLatestRelease(this.installedVersionName);
       if (result.status === AppUpdateCheckStatus.UPDATE_AVAILABLE && result.release !== undefined) {
         this.pendingUpdateRelease = result.release;
+        this.broadcastHomeUpdateAnnouncement(result.release.versionName, this.releaseDownloadUrl(result.release));
         if (verbose) {
           this.updateCheckMessage = `发现新版本 ${result.release.versionName}，可前往下载`;
         }
       } else if (result.status === AppUpdateCheckStatus.UP_TO_DATE) {
         this.pendingUpdateRelease = undefined;
+        this.broadcastHomeUpdateAnnouncement('', '');
         if (verbose) {
           this.updateCheckMessage = '当前已是最新版本';
         }
       } else if (verbose) {
         this.updateCheckMessage = result.message.length > 0 ? result.message : '检查更新失败，请稍后重试';
       }
+      hilog.info(0x0000, 'AppUpdate', 'check status=%{public}s remoteVersion=%{public}s',
+        result.status, result.release !== undefined ? result.release.versionName : '');
     } finally {
       this.updateCheckBusy = false;
     }
+  }
+
+  private async shouldAutoCheckUpdateNow(): Promise<boolean> {
+    const context = getAbilityContext();
+    if (context === undefined) {
+      return true;
+    }
+    try {
+      const lastUpdateCheckAt = await new AppPreferencesStore(context).loadLastUpdateCheckAt();
+      return shouldAutoCheckForUpdate(lastUpdateCheckAt, Date.now());
+    } catch (_error) {
+      // 节流时间戳读取失败按未节流处理，宁可多检查一次。
+      return true;
+    }
+  }
+
+  private async markUpdateCheckedNow(): Promise<void> {
+    const context = getAbilityContext();
+    if (context === undefined) {
+      return;
+    }
+    try {
+      await new AppPreferencesStore(context).saveLastUpdateCheckAt(Date.now());
+    } catch (_error) {
+      // 节流时间戳保存失败仅影响下次自动检查频率，不打扰用户。
+    }
+  }
+
+  /** 首页更新卡片经 AppStorage 广播（HdsTabs 树下跨页面信号唯一可靠通道）。 */
+  private broadcastHomeUpdateAnnouncement(version: string, url: string): void {
+    AppStorage.setOrCreate('homeUpdateAnnouncementVersion', version);
+    AppStorage.setOrCreate('homeUpdateAnnouncementUrl', url);
+  }
+
+  private releaseDownloadUrl(release: AppUpdateRelease): string {
+    return release.htmlUrl.length > 0 ? release.htmlUrl : PROJECT_HOME_URI + '/releases/latest';
   }
 
   private pendingUpdateTitle(): string {

--- a/entry/src/main/ets/pages/P1Shell.ets
+++ b/entry/src/main/ets/pages/P1Shell.ets
@@ -1,5 +1,6 @@
 import { QuestionTitleBar } from './QuestionTitleBar';
 import { AnswerTitleBar } from './AnswerTitleBar';
+import { ArticleTitleBar } from './ArticleTitleBar';
 import {
   AppPreferencesStore,
   AppThemeMode,
@@ -411,7 +412,7 @@ export struct P1Shell {
           }
         );
       }
-      .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { stackBuilder: (): void => this.detailTitleBar('文章'), divider: { showType: DividerShowType.OFF } } })
+      .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { stackBuilder: (): void => this.articleTitleBar(destination.id), divider: { showType: DividerShowType.OFF } } })
       .hideBackButton(true)
       .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM])
       .backgroundColor($r('app.color.page_background'))
@@ -754,6 +755,12 @@ export struct P1Shell {
   @Builder
   private answerTitleBar(id: string) {
     AnswerTitleBar({ answerId: id, onBack: (): void => { this.pathStack.pop(); } })
+  }
+
+  /** 文章页标题栏：滚动折叠时在返回键右侧显示文章标题单行（对齐问题页折叠模式）。 */
+  @Builder
+  private articleTitleBar(id: string) {
+    ArticleTitleBar({ articleId: id, onBack: (): void => { this.pathStack.pop(); } })
   }
 
   @Builder

--- a/entry/src/main/ets/pages/P1Shell.ets
+++ b/entry/src/main/ets/pages/P1Shell.ets
@@ -120,6 +120,8 @@ export struct P1Shell {
     AnswerDoubleTapAction.ASK;
   /** 回答/文章详情页沉浸式阅读中（页面广播）：隐藏 NavDestination 顶栏（对齐上游 topBar={}）。 */
   @StorageProp('detailImmersiveActive') private detailImmersiveActive: boolean = false;
+  /** 全屏图片查看器打开中（详情页广播）：同样隐藏顶栏，使查看器真全屏。 */
+  @StorageProp('p2ImagePreviewUrl') private imagePreviewUrl: string = '';
   @State private installedVersionLabel: string = '正在读取已安装版本…';
   @State private aboutVersionSheetShown: boolean = false;
   /** GitHub 最新 Release 检出有新版本时非空：驱动“我的”页横幅与版本弹层下载入口。 */
@@ -395,6 +397,15 @@ export struct P1Shell {
       }
       .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { stackBuilder: (): void => this.questionTitleBar(destination.id), divider: { showType: DividerShowType.OFF } } })
       .hideBackButton(true)
+      // 问题页正文图片同样可打开全屏查看器：隐藏顶栏，返回键优先关查看器。
+      .hideTitleBar(this.detailImmersiveActive || this.imagePreviewUrl.length > 0)
+      .onBackPressed((): boolean => {
+        if (this.imagePreviewUrl.length > 0) {
+          AppStorage.setOrCreate('p2ImagePreviewUrl', '');
+          return true;
+        }
+        return false;
+      })
       .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM])
       .backgroundColor($r('app.color.page_background'))
     } else if (destination.name === P1DestinationName.ANSWER) {
@@ -409,9 +420,13 @@ export struct P1Shell {
       }
       .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { stackBuilder: (): void => this.answerTitleBar(destination.id), divider: { showType: DividerShowType.OFF } } })
       .hideBackButton(true)
-      // 沉浸式隐藏顶栏（对齐上游）；返回键优先退沉浸式（对齐上游 PlatformBackHandler）。
-      .hideTitleBar(this.detailImmersiveActive)
+      // 沉浸式/图片查看器中隐藏顶栏（对齐上游 topBar={}）；返回键优先关查看器、再退沉浸式。
+      .hideTitleBar(this.detailImmersiveActive || this.imagePreviewUrl.length > 0)
       .onBackPressed((): boolean => {
+        if (this.imagePreviewUrl.length > 0) {
+          AppStorage.setOrCreate('p2ImagePreviewUrl', '');
+          return true;
+        }
         if (this.detailImmersiveActive) {
           AppStorage.setOrCreate('detailImmersiveExitTick',
             (AppStorage.get<number>('detailImmersiveExitTick') ?? 0) + 1);
@@ -433,9 +448,13 @@ export struct P1Shell {
       }
       .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { stackBuilder: (): void => this.articleTitleBar(destination.id), divider: { showType: DividerShowType.OFF } } })
       .hideBackButton(true)
-      // 与回答页一致：沉浸式隐藏顶栏，返回键优先退沉浸式。
-      .hideTitleBar(this.detailImmersiveActive)
+      // 与回答页一致：沉浸式/图片查看器中隐藏顶栏，返回键优先关查看器。
+      .hideTitleBar(this.detailImmersiveActive || this.imagePreviewUrl.length > 0)
       .onBackPressed((): boolean => {
+        if (this.imagePreviewUrl.length > 0) {
+          AppStorage.setOrCreate('p2ImagePreviewUrl', '');
+          return true;
+        }
         if (this.detailImmersiveActive) {
           AppStorage.setOrCreate('detailImmersiveExitTick',
             (AppStorage.get<number>('detailImmersiveExitTick') ?? 0) + 1);

--- a/entry/src/main/ets/pages/P1Shell.ets
+++ b/entry/src/main/ets/pages/P1Shell.ets
@@ -1,5 +1,6 @@
 import { QuestionTitleBar } from './QuestionTitleBar';
 import { SearchTitleBar } from './SearchTitleBar';
+import { HistoryTitleBar } from './HistoryTitleBar';
 import { AnswerTitleBar } from './AnswerTitleBar';
 import { ArticleTitleBar } from './ArticleTitleBar';
 import {
@@ -98,6 +99,8 @@ export struct P1Shell {
   @BuilderParam blockingRulesContent: (onBack: () => void) => void = this.emptyProbe;
   @BuilderParam blockedFeedHistoryContent: (onBack: () => void) => void = this.emptyPage;
   @BuilderParam readHistoryContent: (navigate: (destination: P1Destination) => void, onBack: () => void) => void =
+    this.emptyHome;
+  @BuilderParam localHistoryContent: (navigate: (destination: P1Destination) => void, onBack: () => void) => void =
     this.emptyHome;
   @BuilderParam loginContent: (onBack: () => void, onAuthenticated: () => void,
     onScanDesktopLogin: () => void) => void = this.emptyLogin;
@@ -312,7 +315,26 @@ export struct P1Shell {
           this.pathStack.pop();
         });
       }
-      .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { title: { mainTitle: '已读记录' }, divider: { showType: DividerShowType.OFF } } })
+      .titleBar({
+        style: getImmersiveTitleBarStyle(),
+        avoidLayoutSafeArea: true,
+        // 返回键用 HDS 标题栏自带 backIcon，右上角选项菜单由 stackBuilder 注入（同搜索页模式）。
+        content: {
+          stackBuilder: (): void => this.readHistoryTitleBar(),
+          backIcon: { action: (): void => { this.pathStack.pop(); } },
+          divider: { showType: DividerShowType.OFF }
+        }
+      })
+      .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM])
+      .backgroundColor($r('app.color.page_background'))
+    } else if (destination.name === P1DestinationName.LOCAL_HISTORY) {
+      HdsNavDestination() {
+        this.localHistoryContent((nextDestination: P1Destination): void => this.navigate(nextDestination),
+          (): void => {
+            this.pathStack.pop();
+          });
+      }
+      .titleBar({ style: getImmersiveTitleBarStyle(), avoidLayoutSafeArea: true, content: { title: { mainTitle: '本地历史记录' }, divider: { showType: DividerShowType.OFF } } })
       .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM])
       .backgroundColor($r('app.color.page_background'))
     } else if (destination.name === P1DestinationName.TECHNICAL_LAB) {
@@ -813,6 +835,12 @@ export struct P1Shell {
     SearchTitleBar()
   }
 
+  /** 历史记录页 HDS 标题栏内容：标题 + 右上角溢出菜单（查看本地历史记录/清除历史记录）。 */
+  @Builder
+  private readHistoryTitleBar() {
+    HistoryTitleBar()
+  }
+
   /** 回答页标题栏：滚动折叠时在返回键右侧显示问题单行 + 答主摘要（对齐上游折叠顶栏）。 */
   @Builder
   private answerTitleBar(id: string) {
@@ -1082,9 +1110,6 @@ export struct P1Shell {
             .fontColor($r('app.color.secondary_text'))
             .width('100%')
           Column() {
-            AppNavigationRow({ title: '历史', description: '查看已打开的内容', testId: 'p2_open_read_history', grouped: true,
-              onRowClick: (): void => this.navigate({ name: P1DestinationName.READ_HISTORY }) });
-            Divider().color($r('app.color.divider_color'))
             AppNavigationRow({ title: '内容屏蔽', description: '管理作者与关键词屏蔽规则', testId: 'p2_open_blocking_rules', grouped: true,
               onRowClick: (): void => this.navigate({ name: P1DestinationName.BLOCKING_RULES }) });
             Divider().color($r('app.color.divider_color'))
@@ -1358,7 +1383,7 @@ export struct P1Shell {
 
       Button({ type: ButtonType.Normal, stateEffect: true }) {
         Column({ space: $r('app.float.p1_spacing_xsmall') }) {
-          SymbolGlyph($r('sys.symbol.line_3_horizontal'))
+          SymbolGlyph($r('sys.symbol.arrow_counterclockwise_clock'))
             .fontSize(20)
             .fontColor([$r('app.color.brand_primary')])
           Text('历史')
@@ -1436,10 +1461,6 @@ export struct P1Shell {
       if (this.settingsSearchMatches('我的收藏夹', '查看自己的知乎收藏夹')) {
         AppNavigationRow({ title: '我的收藏夹', description: '查看自己的知乎收藏夹', testId: 'p3_open_my_collections',
           onRowClick: (): void => this.openMyCollections() });
-      }
-      if (this.settingsSearchMatches('历史', '查看已打开的内容')) {
-        AppNavigationRow({ title: '历史', description: '查看已打开的内容', testId: 'p2_open_read_history',
-          onRowClick: (): void => this.navigate({ name: P1DestinationName.READ_HISTORY }) });
       }
       if (this.settingsSearchMatches('内容屏蔽', '管理作者与关键词屏蔽规则')) {
         AppNavigationRow({ title: '内容屏蔽', description: '管理作者与关键词屏蔽规则', testId: 'p2_open_blocking_rules',
@@ -1853,7 +1874,6 @@ export struct P1Shell {
       this.settingsSearchMatches('发布想法', '创建一条新的想法') ||
       this.settingsSearchMatches('想法草稿', '继续编辑本地保存的草稿') ||
       this.settingsSearchMatches('我的收藏夹', '查看自己的知乎收藏夹') ||
-      this.settingsSearchMatches('历史', '查看已打开的内容') ||
       this.settingsSearchMatches('内容屏蔽', '管理作者与关键词屏蔽规则') ||
       this.settingsSearchMatches('屏蔽记录', '查看最近隐藏的内容') ||
       this.settingsSearchMatches('通知', '查看互动和系统消息') ||

--- a/entry/src/main/ets/pages/PeoplePinDetailPages.ets
+++ b/entry/src/main/ets/pages/PeoplePinDetailPages.ets
@@ -1031,11 +1031,13 @@ export struct PinDetailPage {
       this.shareStatus = '暂时无法打开分享面板';
       return;
     }
+    const avatarUrl = pin.author.avatarUrl?.trim() ?? '';
     const payload: ShareTextPayload = {
       kind: SharePayloadKind.TEXT,
       title: '想法',
       summary: '来自知乎++的受信想法链接',
-      contentUrl: pin.url
+      contentUrl: pin.url,
+      thumbnailUrl: /^https:\/\/(?:pic|pica|picx|pic[0-9]+)\.zhimg\.com\//.test(avatarUrl) ? avatarUrl : undefined
     };
     createSystemShareService(context).share(payload).then((outcome: ShareOutcome): void => {
       this.shareStatus = outcome === ShareOutcome.CANCELLED ? '' : '已打开系统分享面板';

--- a/entry/src/main/ets/pages/QuestionAnswerDataSource.ets
+++ b/entry/src/main/ets/pages/QuestionAnswerDataSource.ets
@@ -1,0 +1,18 @@
+import { ChannelContentItem } from 'data';
+
+export class QuestionAnswerDataSource implements IDataSource {
+  private items: ChannelContentItem[] = [];
+  private listeners: DataChangeListener[] = [];
+  totalCount(): number { return this.items.length; }
+  getData(index: number): ChannelContentItem { return this.items[index]; }
+  replace(items: ChannelContentItem[]): void {
+    this.items = items.slice();
+    this.listeners.forEach((listener: DataChangeListener): void => listener.onDataReloaded());
+  }
+  registerDataChangeListener(listener: DataChangeListener): void {
+    if (this.listeners.indexOf(listener) < 0) { this.listeners.push(listener); }
+  }
+  unregisterDataChangeListener(listener: DataChangeListener): void {
+    this.listeners = this.listeners.filter((item: DataChangeListener): boolean => item !== listener);
+  }
+}

--- a/entry/src/main/ets/pages/QuestionAnswerNavigator.ets
+++ b/entry/src/main/ets/pages/QuestionAnswerNavigator.ets
@@ -1,29 +1,97 @@
 import { QuestionAnswerFeedRepository } from 'data';
 import { QuestionAnswersController, QuestionAnswersViewState } from './QuestionAnswersState';
 
-/** 连续阅读独占分页仓库，排序与列表从问题页快照继承，不改动返回栈。 */
+/** 下一个回答预览信息（对齐上游 CachedAnswerContent 的预览卡片数据）。 */
+export interface AnswerNavigationPreview {
+  readonly answerId: string;
+  readonly authorName: string;
+  readonly authorAvatarUrl: string;
+  readonly excerpt: string;
+  /** false：下一答还在未加载的分页里，暂无作者/摘要等详情。 */
+  readonly detailLoaded: boolean;
+}
+
+/**
+ * 连续阅读独占分页仓库，排序与列表从问题页快照继承，不改动返回栈。
+ * 信息流直达回答（无种子）也可构造：控制器自动拉取问题回答列表并回填当前索引。
+ */
 export class QuestionAnswerNavigator {
   private readonly controller: QuestionAnswersController;
   private index: number;
+  /** 当前回答 id：种子列表可能不含（信息流直达），索引待列表加载后回填。 */
+  private currentAnswerId: string;
   private busy: boolean = false;
   private active: boolean = true;
+  private readonly onStateChange?: () => void;
 
-  constructor(questionId: string, answerId: string, seed: QuestionAnswersViewState,
-    repository: QuestionAnswerFeedRepository) {
-    this.index = seed.items.findIndex((item): boolean => item.feedItem.target.id === answerId);
+  constructor(questionId: string, answerId: string, seed: QuestionAnswersViewState | undefined,
+    repository: QuestionAnswerFeedRepository, onStateChange?: () => void) {
+    this.currentAnswerId = answerId;
+    this.index = seed?.items.findIndex((item): boolean => item.feedItem.target.id === answerId) ?? -1;
+    this.onStateChange = onStateChange;
     this.controller = new QuestionAnswersController(repository, questionId,
-      (_state: QuestionAnswersViewState): void => {}, seed);
+      (state: QuestionAnswersViewState): void => { this.onControllerState(state); }, seed);
     this.controller.activate();
   }
 
+  /** 列表到达后回填当前索引（信息流直达时种子为空）。 */
+  private onControllerState(state: QuestionAnswersViewState): void {
+    if (this.index < 0 && state.items.length > 0) {
+      const located = state.items.findIndex((item): boolean => item.feedItem.target.id === this.currentAnswerId);
+      if (located >= 0) {
+        this.index = located;
+      }
+    }
+    if (this.onStateChange !== undefined) {
+      this.onStateChange();
+    }
+  }
+
   currentId(): string | undefined {
-    return this.controller.snapshot().items[this.index]?.feedItem.target.id;
+    return this.currentAnswerId;
+  }
+
+  /** 下一答预览数据：无下一答返回 undefined；下一答在未加载分页时 detailLoaded=false。 */
+  nextAnswerPreview(): AnswerNavigationPreview | undefined {
+    if (!this.hasNext()) { return undefined; }
+    const target = this.controller.snapshot().items[this.index + 1]?.feedItem.target;
+    if (target === undefined) {
+      return { answerId: '', authorName: '', authorAvatarUrl: '', excerpt: '', detailLoaded: false };
+    }
+    return {
+      answerId: target.id,
+      authorName: target.author?.name ?? '',
+      authorAvatarUrl: target.author?.avatarUrl ?? '',
+      excerpt: target.excerpt,
+      detailLoaded: true
+    };
+  }
+
+  /** 上一答预览数据：首答（无上一答）返回 undefined。 */
+  previousAnswerPreview(): AnswerNavigationPreview | undefined {
+    if (!this.hasPrevious()) { return undefined; }
+    const target = this.controller.snapshot().items[this.index - 1]?.feedItem.target;
+    if (target === undefined) {
+      return { answerId: '', authorName: '', authorAvatarUrl: '', excerpt: '', detailLoaded: false };
+    }
+    return {
+      answerId: target.id,
+      authorName: target.author?.name ?? '',
+      authorAvatarUrl: target.author?.avatarUrl ?? '',
+      excerpt: target.excerpt,
+      detailLoaded: true
+    };
   }
 
   hasPrevious(): boolean { return this.index > 0; }
   hasNext(): boolean {
     const state = this.controller.snapshot();
-    return this.index + 1 < state.items.length || state.canLoadMore;
+    if (this.index >= 0) {
+      return this.index + 1 < state.items.length || state.canLoadMore;
+    }
+    // 未定位（列表未加载或不含当前回答）：存在其他回答即可切下一答（首个非当前回答）。
+    return state.items.some((item): boolean => item.feedItem.target.id !== this.currentAnswerId) ||
+      state.canLoadMore;
   }
   errorMessage(): string { return this.controller.snapshot().errorMessage; }
 
@@ -38,7 +106,7 @@ export class QuestionAnswerNavigator {
   }
 
   async move(direction: number): Promise<string | undefined> {
-    if (!this.active || this.busy || this.index < 0 || (direction !== -1 && direction !== 1)) {
+    if (!this.active || this.busy || (direction !== -1 && direction !== 1)) {
       return undefined;
     }
     this.busy = true;
@@ -51,7 +119,8 @@ export class QuestionAnswerNavigator {
       const item = this.controller.snapshot().items[nextIndex];
       if (item === undefined) { return undefined; }
       this.index = nextIndex;
-      return item.feedItem.target.id;
+      this.currentAnswerId = item.feedItem.target.id;
+      return this.currentAnswerId;
     } finally {
       this.busy = false;
     }

--- a/entry/src/main/ets/pages/QuestionAnswerNavigator.ets
+++ b/entry/src/main/ets/pages/QuestionAnswerNavigator.ets
@@ -1,0 +1,81 @@
+import { QuestionAnswerFeedRepository } from 'data';
+import { QuestionAnswersController, QuestionAnswersViewState } from './QuestionAnswersState';
+
+/** 连续阅读独占分页仓库，排序与列表从问题页快照继承，不改动返回栈。 */
+export class QuestionAnswerNavigator {
+  private readonly controller: QuestionAnswersController;
+  private index: number;
+  private busy: boolean = false;
+  private active: boolean = true;
+
+  constructor(questionId: string, answerId: string, seed: QuestionAnswersViewState,
+    repository: QuestionAnswerFeedRepository) {
+    this.index = seed.items.findIndex((item): boolean => item.feedItem.target.id === answerId);
+    this.controller = new QuestionAnswersController(repository, questionId,
+      (_state: QuestionAnswersViewState): void => {}, seed);
+    this.controller.activate();
+  }
+
+  currentId(): string | undefined {
+    return this.controller.snapshot().items[this.index]?.feedItem.target.id;
+  }
+
+  hasPrevious(): boolean { return this.index > 0; }
+  hasNext(): boolean {
+    const state = this.controller.snapshot();
+    return this.index + 1 < state.items.length || state.canLoadMore;
+  }
+  errorMessage(): string { return this.controller.snapshot().errorMessage; }
+
+  pause(): void {
+    this.active = false;
+    this.controller.deactivate();
+  }
+
+  resume(): void {
+    this.active = true;
+    this.controller.activate();
+  }
+
+  async move(direction: number): Promise<string | undefined> {
+    if (!this.active || this.busy || this.index < 0 || (direction !== -1 && direction !== 1)) {
+      return undefined;
+    }
+    this.busy = true;
+    try {
+      if (direction === 1 && this.index + 1 >= this.controller.snapshot().items.length && this.hasNext()) {
+        await this.controller.loadMore();
+      }
+      if (!this.active) { return undefined; }
+      const nextIndex = this.index + direction;
+      const item = this.controller.snapshot().items[nextIndex];
+      if (item === undefined) { return undefined; }
+      this.index = nextIndex;
+      return item.feedItem.target.id;
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  dispose(): void {
+    this.pause();
+  }
+}
+
+let pending: QuestionAnswerNavigator | undefined;
+
+export function stageQuestionAnswerNavigator(navigator: QuestionAnswerNavigator): void {
+  pending?.dispose();
+  pending = navigator;
+}
+
+/** 与编辑种子相同，只在紧接着打开的回答页消费一次；不持久化。 */
+export function takeQuestionAnswerNavigator(answerId: string): QuestionAnswerNavigator | undefined {
+  const navigator = pending;
+  pending = undefined;
+  if (navigator?.currentId() !== answerId) {
+    navigator?.dispose();
+    return undefined;
+  }
+  return navigator;
+}

--- a/entry/src/main/ets/pages/QuestionAnswersState.ets
+++ b/entry/src/main/ets/pages/QuestionAnswersState.ets
@@ -1,0 +1,215 @@
+import {
+  ChannelContentItem,
+  QuestionAnswerFeedRepository,
+  QuestionAnswerFeedPage,
+  QuestionAnswerSortOrder
+} from 'data';
+import { contentDetailRequiresLogin, contentDetailErrorMessage } from './ContentDetailState';
+
+export enum QuestionAnswersPhase {
+  IDLE = 'idle',
+  INITIAL_LOADING = 'initial_loading',
+  READY = 'ready',
+  EMPTY = 'empty',
+  ERROR = 'error'
+}
+
+export interface QuestionAnswersViewState {
+  readonly phase: QuestionAnswersPhase;
+  readonly items: Array<ChannelContentItem>;
+  readonly loadingMore: boolean;
+  readonly canLoadMore: boolean;
+  readonly sortOrder: QuestionAnswerSortOrder;
+  readonly errorMessage: string;
+  readonly requiresLogin: boolean;
+  readonly nextCursor?: string;
+}
+
+/**
+ * 问题详情页回答信息流控制器（P1）：分页/排序/代际取消，模式对齐 ChannelFeedController。
+ * 匿名态不创建控制器，由页面侧负责登录门禁（对齐上游 allowGuestAccess=false）。
+ */
+export class QuestionAnswersController {
+  private readonly repository: QuestionAnswerFeedRepository;
+  private readonly questionId: string;
+  private readonly observer: (state: QuestionAnswersViewState) => void;
+  private active: boolean = false;
+  private generation: number = 0;
+  private phase: QuestionAnswersPhase = QuestionAnswersPhase.IDLE;
+  private items: Array<ChannelContentItem> = [];
+  private loadingMore: boolean = false;
+  private canLoadMore: boolean = false;
+  private nextCursor?: string;
+  private sortOrder: QuestionAnswerSortOrder = QuestionAnswerSortOrder.DEFAULT;
+  private errorMessage: string = '';
+  private requiresLogin: boolean = false;
+
+  constructor(repository: QuestionAnswerFeedRepository, questionId: string,
+    observer: (state: QuestionAnswersViewState) => void, seed?: QuestionAnswersViewState) {
+    this.repository = repository;
+    this.questionId = questionId;
+    this.observer = observer;
+    if (seed !== undefined) {
+      this.items = seed.items.slice();
+      this.sortOrder = seed.sortOrder;
+      this.nextCursor = seed.nextCursor;
+      this.canLoadMore = seed.canLoadMore;
+      this.phase = this.items.length > 0 ? QuestionAnswersPhase.READY : QuestionAnswersPhase.IDLE;
+    }
+  }
+
+  activate(): void {
+    if (this.active) {
+      return;
+    }
+    this.active = true;
+    if (this.items.length === 0 && (this.phase === QuestionAnswersPhase.IDLE ||
+      this.phase === QuestionAnswersPhase.INITIAL_LOADING)) {
+      this.phase = QuestionAnswersPhase.INITIAL_LOADING;
+      this.emit();
+      void this.loadFirstPage();
+      return;
+    }
+    this.emit();
+  }
+
+  deactivate(): void {
+    if (!this.active) {
+      return;
+    }
+    this.active = false;
+    this.generation += 1;
+    this.loadingMore = false;
+    this.repository.cancel();
+  }
+
+  async setSortOrder(order: QuestionAnswerSortOrder): Promise<void> {
+    if (!this.active || order === this.sortOrder) {
+      return;
+    }
+    this.sortOrder = order;
+    await this.resetAndReload();
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.active) {
+      return;
+    }
+    await this.resetAndReload();
+  }
+
+  async loadMore(): Promise<void> {
+    if (!this.active || this.loadingMore || !this.canLoadMore || this.phase !== QuestionAnswersPhase.READY) {
+      return;
+    }
+    const cursor = this.nextCursor;
+    if (cursor === undefined) {
+      return;
+    }
+    this.loadingMore = true;
+    this.errorMessage = '';
+    this.requiresLogin = false;
+    this.emit();
+    const requestGeneration = this.generation;
+    try {
+      const page = await this.loadVisiblePage(cursor);
+      if (!this.active || requestGeneration !== this.generation) {
+        return;
+      }
+      const known = new Set<string>(this.items.map((item: ChannelContentItem): string =>
+        feedItemKey(item)));
+      const fresh: Array<ChannelContentItem> = [];
+      page.items.forEach((item: ChannelContentItem): void => {
+        const key = feedItemKey(item);
+        if (known.has(key)) {
+          return;
+        }
+        known.add(key);
+        fresh.push(item);
+      });
+      this.items = this.items.concat(fresh);
+      this.nextCursor = page.cursor.isEnd ? undefined : page.cursor.next;
+      this.canLoadMore = this.nextCursor !== undefined;
+      this.loadingMore = false;
+      this.emit();
+    } catch (error) {
+      if (!this.active || requestGeneration !== this.generation) {
+        return;
+      }
+      this.loadingMore = false;
+      this.errorMessage = contentDetailErrorMessage(error);
+      this.requiresLogin = contentDetailRequiresLogin(error);
+      this.emit();
+    }
+  }
+
+  private async resetAndReload(): Promise<void> {
+    this.generation += 1;
+    this.repository.cancel();
+    this.errorMessage = '';
+    this.requiresLogin = false;
+    this.items = [];
+    this.nextCursor = undefined;
+    this.canLoadMore = false;
+    this.loadingMore = false;
+    this.phase = QuestionAnswersPhase.INITIAL_LOADING;
+    this.emit();
+    await this.loadFirstPage();
+  }
+
+  private async loadFirstPage(): Promise<void> {
+    const requestGeneration = this.generation;
+    try {
+      const page = await this.loadVisiblePage();
+      if (!this.active || requestGeneration !== this.generation) {
+        return;
+      }
+      this.items = page.items;
+      this.nextCursor = page.cursor.isEnd ? undefined : page.cursor.next;
+      this.canLoadMore = this.nextCursor !== undefined;
+      this.phase = this.items.length > 0 ? QuestionAnswersPhase.READY : QuestionAnswersPhase.EMPTY;
+      this.errorMessage = '';
+      this.emit();
+    } catch (error) {
+      if (!this.active || requestGeneration !== this.generation) {
+        return;
+      }
+      this.phase = QuestionAnswersPhase.ERROR;
+      this.errorMessage = contentDetailErrorMessage(error);
+      this.requiresLogin = contentDetailRequiresLogin(error);
+      this.emit();
+    }
+  }
+
+  snapshot(): QuestionAnswersViewState {
+    return {
+      phase: this.phase,
+      items: this.items.slice(),
+      loadingMore: this.loadingMore,
+      canLoadMore: this.canLoadMore,
+      sortOrder: this.sortOrder,
+      errorMessage: this.errorMessage,
+      requiresLogin: this.requiresLogin,
+      nextCursor: this.nextCursor
+    };
+  }
+
+  private async loadVisiblePage(cursor?: string): Promise<QuestionAnswerFeedPage> {
+    const generation = this.generation;
+    let page = await this.repository.loadPage(this.questionId, this.sortOrder, cursor);
+    // 被屏蔽/广告占满的一页不是终点；继续到可见回答或真正末页。
+    while (this.active && generation === this.generation && page.items.length === 0 &&
+      !page.cursor.isEnd && page.cursor.next !== undefined) {
+      page = await this.repository.loadPage(this.questionId, this.sortOrder, page.cursor.next);
+    }
+    return page;
+  }
+
+  private emit(): void {
+    this.observer(this.snapshot());
+  }
+}
+
+function feedItemKey(item: ChannelContentItem): string {
+  return `${item.feedItem.target.kind}:${item.feedItem.target.id}`;
+}

--- a/entry/src/main/ets/pages/QuestionTitleBar.ets
+++ b/entry/src/main/ets/pages/QuestionTitleBar.ets
@@ -1,0 +1,89 @@
+import { Want } from '@kit.AbilityKit';
+import { getAbilityContext } from '../entryability/AbilityContextHolder';
+import { createSystemShareService } from '../platform/SystemShareService';
+import { SharePayloadKind } from '../platform/ShareContracts';
+
+export interface QuestionTitleState {
+  id: string;
+  title: string;
+  scrolled: boolean;
+}
+
+export function publishQuestionTitle(state: QuestionTitleState): void {
+  const states = AppStorage.get<QuestionTitleState[]>('questionTitleStates') ?? [];
+  const previous = states.find((item: QuestionTitleState): boolean => item.id === state.id);
+  if (previous?.title === state.title && previous?.scrolled === state.scrolled) { return; }
+  AppStorage.setOrCreate('questionTitleStates',
+    states.filter((item: QuestionTitleState): boolean => item.id !== state.id).concat([state]));
+}
+
+export function removeQuestionTitle(id: string): void {
+  const states = AppStorage.get<QuestionTitleState[]>('questionTitleStates') ?? [];
+  AppStorage.setOrCreate('questionTitleStates', states.filter((item: QuestionTitleState): boolean => item.id !== id));
+}
+
+@Component
+export struct QuestionTitleBar {
+  questionId: string = '';
+  onBack: () => void = (): void => {};
+  @StorageProp('questionTitleStates') private states: QuestionTitleState[] = [];
+
+  private state(): QuestionTitleState | undefined {
+    return this.states.find((item: QuestionTitleState): boolean => item.id === this.questionId);
+  }
+  private async openLog(): Promise<void> {
+    const context = getAbilityContext();
+    if (context === undefined || !/^[1-9][0-9]{0,29}$/.test(this.questionId)) { return; }
+    const want: Want = {
+      action: 'ohos.want.action.viewData',
+      uri: `https://www.zhihu.com/question/${this.questionId}/log`
+    };
+    try { await context.startAbility(want); } catch (_error) {
+      this.getUIContext().getPromptAction().showToast({ message: '暂时无法打开问题日志' });
+    }
+  }
+  private async share(): Promise<void> {
+    const context = getAbilityContext();
+    if (context === undefined || this.state() === undefined) { return; }
+    try {
+      await createSystemShareService(context).share({
+        kind: SharePayloadKind.TEXT,
+        title: this.state()?.title ?? '问题',
+        summary: this.state()?.title ?? '',
+        contentUrl: `https://www.zhihu.com/question/${this.questionId}`
+      });
+    } catch (_error) {
+      this.getUIContext().getPromptAction().showToast({ message: '暂时无法打开分享面板' });
+    }
+  }
+  build() {
+    Row({ space: 8 }) {
+      Button({ type: ButtonType.Normal }) {
+        SymbolGlyph($r('sys.symbol.chevron_left')).fontSize(20).fontColor([$r('app.color.primary_text')])
+      }.width(40).height(40).borderRadius(20).backgroundColor($r('app.color.surface_background'))
+        .id('question_back').accessibilityText('返回').onClick((): void => this.onBack())
+      Stack({ alignContent: Alignment.Start }) {
+        Text('问题').id('question_top_label')
+          .fontSize($r('app.float.p1_heading_font_size'))
+          .fontColor($r('app.color.primary_text')).fontWeight(FontWeight.Medium)
+          .opacity(this.state()?.scrolled ? 0 : 1)
+          .translate({ y: this.state()?.scrolled ? -8 : 0 })
+        Text(this.state()?.title ?? '')
+          .id('question_top_title').fontSize($r('app.float.p1_heading_font_size'))
+          .fontColor($r('app.color.primary_text')).fontWeight(FontWeight.Medium)
+          .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis }).width('100%')
+          .opacity(this.state()?.scrolled ? 1 : 0)
+          .translate({ y: this.state()?.scrolled ? 0 : 8 })
+      }.layoutWeight(1).height(40).clip(true)
+      Button({ type: ButtonType.Normal }) {
+        SymbolGlyph($r('sys.symbol.clock')).fontSize(20).fontColor([$r('app.color.primary_text')])
+      }.id('question_log').width(40).height(40).backgroundColor(Color.Transparent)
+        .accessibilityText('问题日志').onClick((): void => { void this.openLog(); })
+      Button({ type: ButtonType.Normal }) {
+        SymbolGlyph($r('sys.symbol.share')).fontSize(20).fontColor([$r('app.color.primary_text')])
+      }.id('question_share').width(40).height(40).backgroundColor(Color.Transparent)
+        .enabled(this.state() !== undefined).accessibilityText('分享问题')
+        .onClick((): void => { void this.share(); })
+    }.width('100%').padding({ left: $r('app.float.p1_page_padding'), right: $r('app.float.p1_page_padding') })
+  }
+}

--- a/entry/src/main/ets/pages/ReadHistoryPage.ets
+++ b/entry/src/main/ets/pages/ReadHistoryPage.ets
@@ -1,27 +1,19 @@
+import { ComponentContent } from '@kit.ArkUI';
+import { LoginSessionGateway, OnlineHistoryRepository, ReadHistoryGateway, SessionStatus } from 'data';
+import { FeedPullDownIndicatorOptions, feedPullDownIndicator } from './AppPageChrome';
 import {
-  LoginSessionGateway,
-  OnlineHistoryRepository,
-  ReadHistoryGateway,
-  SessionStatus
-} from 'data';
-import {
-  filterReadHistoryItems,
-  groupReadHistoryItems,
   ReadHistoryController,
-  ReadHistoryGroup,
   ReadHistoryItem,
   readHistoryKindLabel,
-  readHistoryOpenTarget,
   ReadHistoryOpenTarget,
   ReadHistoryPhase,
-  ReadHistorySourceFilter,
-  readHistorySourceFilterLabel,
-  readHistorySourceLabel,
+  readHistoryTimeLabel,
   ReadHistoryViewState
 } from './ReadHistoryState';
 
 export type OpenReadHistoryItem = (target: ReadHistoryOpenTarget) => void;
 
+/** 在线历史记录页：对齐上游 OnlineHistoryScreen 的卡片信息流。 */
 @Component
 export struct ReadHistoryPage {
   history: ReadHistoryGateway | undefined = undefined;
@@ -29,27 +21,28 @@ export struct ReadHistoryPage {
   session: LoginSessionGateway | undefined = undefined;
   onOpen: OpenReadHistoryItem = (_target: ReadHistoryOpenTarget): void => {};
   onGoLogin: () => void = (): void => {};
-  onBack: () => void = (): void => {};
+  onNavigateLocal: () => void = (): void => {};
   @State private viewState: ReadHistoryViewState = {
     phase: ReadHistoryPhase.LOADING,
     items: [],
     busy: false,
-    message: '正在读取本地已读记录',
+    message: '正在加载历史记录',
     requiresLogin: false,
-    onlineEnabled: false,
     loadingMore: false,
     canLoadMore: false
   };
+  @State private refreshing: boolean = false;
   @State private confirmClear: boolean = false;
-  @State private sourceFilterSheetShown: boolean = false;
-  @State private historyActionsSheetShown: boolean = false;
-  @State private itemActionsSheetShown: boolean = false;
-  @State private selectedSourceFilter: ReadHistorySourceFilter = ReadHistorySourceFilter.ALL;
-  @State private itemActionTarget: ReadHistoryItem | undefined = undefined;
+  // 标题栏溢出菜单在 stackBuilder 子树内，动作经 AppStorage tick 广播到本页（同 loginFeedReloadTick 模式）。
+  // @StorageProp 键用字面量（装饰器要求编译期常量），值与 HistoryTitleBar.ets 导出常量一一对应。
+  @StorageProp('readHistoryOpenLocalTick') @Watch('onOpenLocalTick') private openLocalTick: number = 0;
+  @StorageProp('readHistoryClearTick') @Watch('onClearTick') private clearTick: number = 0;
   private controller?: ReadHistoryController;
+  // 下拉刷新自定义加载圆圈（refreshingContent 需 ComponentContent，随页面销毁释放）
+  private refreshContent?: ComponentContent<FeedPullDownIndicatorOptions> = undefined;
 
   aboutToAppear(): void {
-    // P3-7：返回栈重显（页面实例与状态保留）时 aboutToAppear 可能再次触发；
+    // 返回栈重显（页面实例与状态保留）时 aboutToAppear 可能再次触发；
     // 控制器仍存活时直接复用，避免重建控制器并重载记录导致滚动位置丢失。
     if (this.controller !== undefined) {
       this.controller.activate();
@@ -61,9 +54,8 @@ export struct ReadHistoryPage {
         phase: ReadHistoryPhase.ERROR,
         items: [],
         busy: false,
-        message: '已读记录数据源未配置',
+        message: '历史记录数据源未配置',
         requiresLogin: false,
-        onlineEnabled: false,
         loadingMore: false,
         canLoadMore: false
       };
@@ -75,34 +67,37 @@ export struct ReadHistoryPage {
     this.controller = new ReadHistoryController(history, this.onlineHistory, onlineEnabled,
       (state: ReadHistoryViewState): void => {
         this.viewState = state;
+        this.refreshing = false;
       });
+    this.refreshContent = new ComponentContent(this.getUIContext(), wrapBuilder(feedPullDownIndicator),
+      new FeedPullDownIndicatorOptions());
     this.controller.activate();
   }
 
   aboutToDisappear(): void {
     this.controller?.deactivate();
     this.controller = undefined;
+    this.refreshContent?.dispose();
+    this.refreshContent = undefined;
+    this.refreshing = false;
     this.confirmClear = false;
-    this.sourceFilterSheetShown = false;
-    this.historyActionsSheetShown = false;
-    this.itemActionsSheetShown = false;
-    this.itemActionTarget = undefined;
+  }
+
+  private onOpenLocalTick(): void {
+    if (this.openLocalTick > 0) {
+      this.onNavigateLocal();
+    }
+  }
+
+  private onClearTick(): void {
+    if (this.clearTick > 0) {
+      this.confirmClear = true;
+    }
   }
 
   build() {
     Stack({ alignContent: Alignment.TopStart }) {
       Column({ space: $r('app.float.p1_spacing_medium') }) {
-        Text('只保存在本机；不保存正文、Cookie、搜索词或账号信息。')
-          .id('p2_read_history_privacy')
-          .fontSize($r('app.float.p1_caption_font_size'))
-          .fontColor($r('app.color.secondary_text'))
-          .width('100%')
-        Text(this.viewState.message)
-          .id('p2_read_history_status')
-          .fontSize($r('app.float.p1_body_font_size'))
-          .fontColor(this.viewState.phase === ReadHistoryPhase.ERROR ?
-            $r('app.color.error_text') : $r('app.color.secondary_text'))
-          .width('100%')
         if (this.viewState.requiresLogin) {
           this.loginBanner()
         }
@@ -112,19 +107,20 @@ export struct ReadHistoryPage {
             .width(40)
             .height(40)
             .color($r('app.color.brand_primary'))
-        } else if (this.visibleItems().length === 0) {
+        } else if (this.viewState.items.length === 0) {
           Column({ space: $r('app.float.p1_spacing_medium') }) {
-            Text(this.emptyHistoryMessage())
+            Text(this.viewState.message)
+              .id('p2_read_history_empty')
               .fontSize($r('app.float.p1_body_font_size'))
               .fontColor($r('app.color.secondary_text'))
               .textAlign(TextAlign.Center)
               .width('100%')
-            if (this.viewState.phase === ReadHistoryPhase.ERROR && this.viewState.items.length === 0) {
-              Button('重新读取')
+            if (this.viewState.phase === ReadHistoryPhase.ERROR) {
+              Button('重新加载')
                 .id('p2_read_history_retry')
                 .enabled(!this.viewState.busy)
                 .onClick((): void => {
-                  this.controller?.reload();
+                  void this.controller?.reload();
                 })
             }
           }
@@ -132,30 +128,56 @@ export struct ReadHistoryPage {
           .layoutWeight(1)
           .width('100%')
         } else {
-          List({ space: 10 }) {
-            ForEach(groupReadHistoryItems(this.visibleItems()), (group: ReadHistoryGroup) => {
-              ListItem() {
-                this.groupSection(group)
-              }
-            }, (group: ReadHistoryGroup): string => group.dayKey)
-            if ((this.viewState.canLoadMore || this.viewState.loadingMore) &&
-              this.selectedSourceFilter !== ReadHistorySourceFilter.LOCAL) {
-              ListItem() {
-                Button(this.viewState.loadingMore ? '正在加载更多…' : '加载更多在线历史')
-                  .id('p3_read_history_load_more')
-                  .width('100%')
-                  .fontSize($r('app.float.p1_secondary_font_size'))
-                  .enabled(!this.viewState.loadingMore && !this.viewState.busy)
-                  .onClick((): void => {
-                    this.controller?.loadMore();
-                  })
+          Refresh({
+            refreshing: this.refreshing,
+            refreshingContent: this.refreshContent,
+            offset: 80,
+            friction: 100
+          }) {
+            List({ space: 12 }) {
+              ForEach(this.viewState.items, (item: ReadHistoryItem) => {
+                ListItem() {
+                  this.historyCard(item)
+                }
+                .width('100%')
+              }, (item: ReadHistoryItem): string => item.contentKey)
+
+              if (this.viewState.loadingMore) {
+                ListItem() {
+                  LoadingProgress()
+                    .id('p3_read_history_load_more')
+                    .width(40)
+                    .height(40)
+                    .color($r('app.color.brand_primary'))
+                }
+                .width('100%')
+                .padding({ top: 12, bottom: 12 })
+              } else if (!this.viewState.canLoadMore) {
+                ListItem() {
+                  Text('已经到底啦')
+                    .id('p2_read_history_end')
+                    .fontSize($r('app.float.p1_secondary_font_size'))
+                    .fontColor($r('app.color.secondary_text'))
+                    .textAlign(TextAlign.Center)
+                    .width('100%')
+                    .padding({ top: 12, bottom: 12 })
+                }
               }
             }
+            .id('p2_read_history_list')
+            .width('100%')
+            .scrollBar(BarState.Off)
+            .edgeEffect(EdgeEffect.Spring)
+            .onReachEnd((): void => {
+              void this.controller?.loadMore();
+            })
           }
-          .id('p2_read_history_list')
-          .layoutWeight(1)
+          .id('p2_read_history_pull_refresh')
           .width('100%')
-          .scrollBar(BarState.Off)
+          .layoutWeight(1)
+          .onRefreshing((): void => {
+            void this.controller?.reload();
+          })
         }
       }
       .width('100%')
@@ -164,46 +186,6 @@ export struct ReadHistoryPage {
         top: 94, bottom: $r('app.float.p1_page_padding') })
       .backgroundColor($r('app.color.page_background'))
 
-      Column()
-        .bindSheet(this.sourceFilterSheetShown, this.sourceFilterSheet(), {
-          height: SheetSize.FIT_CONTENT,
-          dragBar: true,
-          showClose: false,
-          maskColor: '#66000000',
-          backgroundColor: $r('app.color.surface_background'),
-          onDisappear: (): void => {
-            if (this.sourceFilterSheetShown) {
-              this.sourceFilterSheetShown = false;
-            }
-          }
-        })
-      Column()
-        .bindSheet(this.historyActionsSheetShown, this.historyActionsSheet(), {
-          height: SheetSize.FIT_CONTENT,
-          dragBar: true,
-          showClose: false,
-          maskColor: '#66000000',
-          backgroundColor: $r('app.color.surface_background'),
-          onDisappear: (): void => {
-            if (this.historyActionsSheetShown) {
-              this.historyActionsSheetShown = false;
-            }
-          }
-        })
-      Column()
-        .bindSheet(this.itemActionsSheetShown, this.itemActionsSheet(), {
-          height: SheetSize.FIT_CONTENT,
-          dragBar: true,
-          showClose: false,
-          maskColor: '#66000000',
-          backgroundColor: $r('app.color.surface_background'),
-          onDisappear: (): void => {
-            if (this.itemActionsSheetShown) {
-              this.itemActionsSheetShown = false;
-            }
-            this.itemActionTarget = undefined;
-          }
-        })
       Column()
         .bindSheet(this.confirmClear, this.clearConfirmation(), {
           height: SheetSize.FIT_CONTENT,
@@ -224,151 +206,85 @@ export struct ReadHistoryPage {
     .backgroundColor($r('app.color.page_background'))
   }
 
+  /** 对齐上游 FeedCard：标题 2 行、作者 1 行、摘要 3 行 + 元信息行与右上角“更多”菜单。 */
   @Builder
-  private pageHeader() {
-    Row({ space: $r('app.float.p1_spacing_small') }) {
-      Button({ type: ButtonType.Normal, stateEffect: true }) {
-        SymbolGlyph($r('sys.symbol.chevron_left'))
-          .fontSize(20)
-          .fontColor([$r('app.color.primary_text')])
-      }
-      .id('p3_read_history_back')
-      .width(40)
-      .height(40)
-      .padding(0)
-      .backgroundColor(Color.Transparent)
-      .accessibilityText('返回')
-      .onClick((): void => this.onBack())
-      Text('历史')
-        .fontSize($r('app.float.p1_heading_font_size'))
-        .fontWeight(FontWeight.Bold)
-        .fontColor($r('app.color.primary_text'))
-        .layoutWeight(1)
-      Button({ type: ButtonType.Normal, stateEffect: true }) {
-        SymbolGlyph($r('sys.symbol.line_3_horizontal'))
-          .fontSize(20)
-          .fontColor([$r('app.color.primary_text')])
-      }
-      .id('p3_read_history_source_filter')
-      .width(40)
-      .height(40)
-      .padding(0)
-      .backgroundColor(Color.Transparent)
-      .accessibilityText(`筛选已读记录来源，当前${readHistorySourceFilterLabel(this.selectedSourceFilter)}`)
-      .onClick((): void => {
-        this.sourceFilterSheetShown = true;
-      })
-      Button({ type: ButtonType.Normal, stateEffect: true }) {
-        SymbolGlyph($r('sys.symbol.ellipsis_circle'))
-          .fontSize(20)
-          .fontColor([$r('app.color.primary_text')])
-      }
-      .id('p3_read_history_actions')
-      .width(40)
-      .height(40)
-      .padding(0)
-      .backgroundColor(Color.Transparent)
-      .accessibilityText('已读记录操作')
-      .onClick((): void => {
-        this.historyActionsSheetShown = true;
-      })
-    }
-    .width('100%')
-  }
-
-  @Builder
-  private sourceFilterSheet() {
-    Column({ space: $r('app.float.p1_spacing_medium') }) {
-      Row({ space: $r('app.float.p1_spacing_small') }) {
-        Text('筛选记录来源')
-          .fontSize($r('app.float.p1_heading_font_size'))
-          .fontWeight(FontWeight.Bold)
-          .fontColor($r('app.color.primary_text'))
-          .layoutWeight(1)
-        Button({ type: ButtonType.Normal, stateEffect: true }) {
-          SymbolGlyph($r('sys.symbol.xmark'))
-            .fontSize(20)
-            .fontColor([$r('app.color.primary_text')])
+  private historyCard(item: ReadHistoryItem) {
+    Button({ type: ButtonType.Normal, stateEffect: true }) {
+      Column({ space: $r('app.float.p1_spacing_small') }) {
+        Row({ space: $r('app.float.p1_spacing_xsmall') }) {
+          Text(`${readHistoryKindLabel(item.kind)} · ${readHistoryTimeLabel(item.openedAt)}`)
+            .fontSize($r('app.float.p1_secondary_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .layoutWeight(1)
+          Button({ type: ButtonType.Normal, stateEffect: true }) {
+            SymbolGlyph($r('sys.symbol.ellipsis_circle'))
+              .fontSize(18)
+              .fontColor([$r('app.color.secondary_text')])
+          }
+          .id(`p3_read_history_item_menu_${item.contentKey}`)
+          .width(32)
+          .height(32)
+          .padding(0)
+          .backgroundColor(Color.Transparent)
+          .enabled(!this.viewState.busy)
+          .bindMenu(this.itemMenu(item))
+          .accessibilityText('该条历史记录操作')
         }
-        .id('p3_read_history_source_filter_close')
-        .width(40)
-        .height(40)
-        .padding(0)
-        .backgroundColor(Color.Transparent)
-        .accessibilityText('关闭来源筛选')
-        .onClick((): void => {
-          this.sourceFilterSheetShown = false;
-        })
-      }
-      .width('100%')
-      this.sourceFilterOption(ReadHistorySourceFilter.ALL, '全部记录', 'p3_read_history_source_all')
-      this.sourceFilterOption(ReadHistorySourceFilter.LOCAL, '本地记录', 'p3_read_history_source_local')
-      this.sourceFilterOption(ReadHistorySourceFilter.ONLINE, '在线记录', 'p3_read_history_source_online')
-    }
-    .width('100%')
-    .padding($r('app.float.p1_page_padding'))
-  }
-
-  @Builder
-  private sourceFilterOption(filter: ReadHistorySourceFilter, label: string, testId: string) {
-    Button(label)
-      .id(testId)
-      .width('100%')
-      .fontSize($r('app.float.p1_body_font_size'))
-      .fontColor(this.selectedSourceFilter === filter ? $r('app.color.on_brand') : $r('app.color.primary_text'))
-      .backgroundColor(this.selectedSourceFilter === filter ?
-        $r('app.color.brand_primary') : $r('app.color.control_background'))
-      .onClick((): void => {
-        this.selectedSourceFilter = filter;
-        this.sourceFilterSheetShown = false;
-      })
-  }
-
-  @Builder
-  private historyActionsSheet() {
-    Column({ space: $r('app.float.p1_spacing_medium') }) {
-      Row({ space: $r('app.float.p1_spacing_small') }) {
-        Text('历史操作')
-          .fontSize($r('app.float.p1_heading_font_size'))
-          .fontWeight(FontWeight.Bold)
-          .fontColor($r('app.color.primary_text'))
-          .layoutWeight(1)
-        Button({ type: ButtonType.Normal, stateEffect: true }) {
-          SymbolGlyph($r('sys.symbol.xmark'))
-            .fontSize(20)
-            .fontColor([$r('app.color.primary_text')])
-        }
-        .id('p3_read_history_actions_close')
-        .width(40)
-        .height(40)
-        .padding(0)
-        .backgroundColor(Color.Transparent)
-        .accessibilityText('关闭历史操作')
-        .onClick((): void => {
-          this.historyActionsSheetShown = false;
-        })
-      }
-      .width('100%')
-      Button('清空本地已读记录')
-        .id('p3_read_history_clear')
         .width('100%')
-        .fontSize($r('app.float.p1_body_font_size'))
-        .fontColor($r('app.color.error_text'))
-        .backgroundColor($r('app.color.control_background'))
-        .enabled(!this.viewState.busy && this.hasLocalItems())
-        .onClick((): void => {
-          this.historyActionsSheetShown = false;
-          this.confirmClear = true;
-        })
+
+        Text(this.itemTitle(item))
+          .fontSize($r('app.float.p1_heading_font_size'))
+          .fontWeight(FontWeight.Medium)
+          .fontColor($r('app.color.primary_text'))
+          .maxLines(2)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .width('100%')
+
+        if (item.authorName !== undefined && item.authorName.length > 0) {
+          Text(item.authorName)
+            .fontSize($r('app.float.p1_secondary_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .width('100%')
+        }
+
+        if (item.summary.trim().length > 0) {
+          Text(item.summary)
+            .fontSize($r('app.float.p1_body_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .maxLines(3)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .width('100%')
+        }
+      }
+      .alignItems(HorizontalAlign.Start)
+      .width('100%')
     }
+    .id(`p2_read_history_card_${item.contentKey}`)
     .width('100%')
-    .padding($r('app.float.p1_page_padding'))
+    .padding($r('app.float.p1_card_padding'))
+    .borderRadius($r('app.float.p1_card_radius'))
+    .backgroundColor($r('app.color.surface_background'))
+    .accessibilityText(`打开${readHistoryKindLabel(item.kind)}：${this.itemTitle(item)}`)
+    .onClick((): void => this.onOpen({ kind: item.kind, id: item.id }))
+  }
+
+  private itemMenu(item: ReadHistoryItem): Array<MenuElement> {
+    return [{
+      value: '删除该条历史记录',
+      action: (): void => {
+        void this.controller?.deleteEntry(item.contentKey);
+      }
+    }];
   }
 
   @Builder
   private loginBanner() {
     Row({ space: $r('app.float.p1_spacing_small') }) {
-      Text('登录后可同步查看知乎账号的在线浏览历史')
+      Text('登录后可同步查看知乎账号的浏览历史')
         .id('p3_read_history_online_notice')
         .fontSize($r('app.float.p1_secondary_font_size'))
         .fontColor($r('app.color.secondary_text'))
@@ -384,138 +300,32 @@ export struct ReadHistoryPage {
     .backgroundColor($r('app.color.surface_background'))
   }
 
-  @Builder
-  private groupSection(group: ReadHistoryGroup) {
-    Column({ space: $r('app.float.p1_spacing_small') }) {
-      Text(group.label)
-        .id(`p3_read_history_group_${group.dayKey}`)
-        .fontSize($r('app.float.p1_secondary_font_size'))
-        .fontColor($r('app.color.brand_primary'))
-        .width('100%')
-      ForEach(group.items, (item: ReadHistoryItem) => {
-        this.historyRow(item)
-      }, (item: ReadHistoryItem): string => item.contentKey)
-    }
-    .width('100%')
-  }
-
-  @Builder
-  private historyRow(item: ReadHistoryItem) {
-    Row({ space: $r('app.float.p1_spacing_small') }) {
-      Column({ space: 2 }) {
-        Text(this.itemTitle(item))
-          .fontSize($r('app.float.p1_body_font_size'))
-          .width('100%')
-        Text(`${readHistoryKindLabel(item.kind)} · ${this.displayTime(item.openedAt)} · ${readHistorySourceLabel(item)}`)
-          .fontSize($r('app.float.p1_caption_font_size'))
-          .fontColor($r('app.color.secondary_text'))
-          .width('100%')
-      }
-      .id(`p2_read_history_open_${item.contentKey}`)
-      .layoutWeight(1)
-      .enabled(!this.viewState.busy)
-      .onClick((): void => this.onOpen(readHistoryOpenTarget(item)))
-      if (item.deletable) {
-        Button({ type: ButtonType.Normal, stateEffect: true }) {
-          SymbolGlyph($r('sys.symbol.ellipsis_circle'))
-            .fontSize(20)
-            .fontColor([$r('app.color.primary_text')])
-        }
-        .id(`p3_read_history_item_actions_${item.contentKey}`)
-        .width(40)
-        .height(40)
-        .padding(0)
-        .backgroundColor(Color.Transparent)
-        .accessibilityText('已读记录操作')
-        .enabled(!this.viewState.busy)
-        .onClick((): void => this.openItemActions(item))
-      }
-    }
-    .width('100%')
-    .padding($r('app.float.p1_spacing_medium'))
-    .backgroundColor($r('app.color.card_background'))
-    .borderRadius($r('app.float.p1_card_radius'))
-  }
-
-  @Builder
-  private itemActionsSheet() {
-    Column({ space: $r('app.float.p1_spacing_medium') }) {
-      Row({ space: $r('app.float.p1_spacing_small') }) {
-        Text(this.itemActionTarget === undefined ? '记录操作' : this.itemTitle(this.itemActionTarget))
-          .fontSize($r('app.float.p1_heading_font_size'))
-          .fontWeight(FontWeight.Medium)
-          .fontColor($r('app.color.primary_text'))
-          .layoutWeight(1)
-          .maxLines(1)
-        Button({ type: ButtonType.Normal, stateEffect: true }) {
-          SymbolGlyph($r('sys.symbol.xmark'))
-            .fontSize(20)
-            .fontColor([$r('app.color.primary_text')])
-        }
-        .id('p3_read_history_item_actions_close')
-        .width(40)
-        .height(40)
-        .padding(0)
-        .backgroundColor(Color.Transparent)
-        .accessibilityText('关闭已读记录操作')
-        .onClick((): void => this.closeItemActions())
-      }
-      .width('100%')
-      Button('打开')
-        .id(`p3_read_history_open_${this.itemActionTarget?.contentKey ?? ''}`)
-        .width('100%')
-        .enabled(this.itemActionTarget !== undefined && !this.viewState.busy)
-        .onClick((): void => {
-          const target = this.itemActionTarget;
-          this.closeItemActions();
-          if (target !== undefined) {
-            this.onOpen(readHistoryOpenTarget(target));
-          }
-        })
-      Button('删除本地记录')
-        .id(`p3_read_history_delete_${this.itemActionTarget?.contentKey ?? ''}`)
-        .width('100%')
-        .fontColor($r('app.color.error_text'))
-        .backgroundColor(Color.Transparent)
-        .enabled(this.itemActionTarget !== undefined && this.itemActionTarget.deletable && !this.viewState.busy)
-        .onClick((): void => {
-          const target = this.itemActionTarget;
-          this.closeItemActions();
-          if (target !== undefined) {
-            this.controller?.delete(target.contentKey);
-          }
-        })
-    }
-    .width('100%')
-    .padding($r('app.float.p1_page_padding'))
-  }
-
+  /** 对齐上游清除确认对话框：一次清除当前账号在线 + 本地全部历史记录。 */
   @Builder
   private clearConfirmation() {
     Column({ space: $r('app.float.p1_spacing_small') }) {
-      Text('清空已读记录')
+      Text('确认清除历史记录')
         .fontSize($r('app.float.p1_heading_font_size'))
         .fontWeight(FontWeight.Bold)
         .fontColor($r('app.color.primary_text'))
         .width('100%')
-      Text(this.viewState.onlineEnabled ?
-        '确认清空全部本地已读记录？在线历史不会被清除。' : '确认清空全部本地已读记录？此操作无法撤销。')
+      Text('此操作会清除当前账号的在线和本地的全部历史记录。')
         .fontSize($r('app.float.p1_body_font_size'))
         .width('100%')
       Row({ space: $r('app.float.p1_spacing_small') }) {
-        Button('取消')
+        Button('我再想想')
           .id('p3_read_history_clear_cancel')
           .layoutWeight(1)
           .onClick((): void => {
             this.confirmClear = false;
           })
-        Button('确认清空')
+        Button('确认')
           .id('p2_read_history_clear_confirm')
           .layoutWeight(1)
           .enabled(!this.viewState.busy)
           .onClick((): void => {
             this.confirmClear = false;
-            this.controller?.clear();
+            void this.controller?.clearAll();
           })
       }
       .width('100%')
@@ -524,42 +334,8 @@ export struct ReadHistoryPage {
     .padding($r('app.float.p1_spacing_medium'))
   }
 
-  private visibleItems(): Array<ReadHistoryItem> {
-    return filterReadHistoryItems(this.viewState.items, this.selectedSourceFilter);
-  }
-
-  private hasLocalItems(): boolean {
-    return this.viewState.items.some((item: ReadHistoryItem): boolean => item.deletable);
-  }
-
-  private openItemActions(item: ReadHistoryItem): void {
-    this.itemActionTarget = item;
-    this.itemActionsSheetShown = true;
-  }
-
-  private closeItemActions(): void {
-    this.itemActionsSheetShown = false;
-    this.itemActionTarget = undefined;
-  }
-
-  private emptyHistoryMessage(): string {
-    if (this.viewState.items.length === 0) {
-      return this.viewState.message;
-    }
-    return `${readHistorySourceFilterLabel(this.selectedSourceFilter)}暂无记录`;
-  }
-
   private itemTitle(item: ReadHistoryItem): string {
-    const title = item.title?.trim() ?? '';
+    const title = item.title.trim();
     return title.length > 0 ? title : `${readHistoryKindLabel(item.kind)} #${item.id}`;
-  }
-
-  private displayTime(openedAt: number): string {
-    try {
-      const value = new Date(openedAt);
-      return `${`${value.getHours()}`.padStart(2, '0')}:${`${value.getMinutes()}`.padStart(2, '0')}`;
-    } catch (_error) {
-      return '时间未知';
-    }
   }
 }

--- a/entry/src/main/ets/pages/ReadHistoryState.ets
+++ b/entry/src/main/ets/pages/ReadHistoryState.ets
@@ -23,28 +23,16 @@ export enum ReadHistoryContentKind {
   PIN = 'pin'
 }
 
-export enum ReadHistorySourceFilter {
-  ALL = 'all',
-  LOCAL = 'local',
-  ONLINE = 'online'
-}
-
+/** 历史卡片条目：在线与本地两个页面共用，对齐上游 FeedDisplayItem 的展示字段。 */
 export interface ReadHistoryItem {
   contentKey: string;
   kind: ReadHistoryContentKind;
   id: string;
+  /** 毫秒时间戳；本地为打开时间，在线为知乎 read_time。 */
   openedAt: number;
-  title?: string;
-  summary?: string;
+  title: string;
+  summary: string;
   authorName?: string;
-  deletable: boolean;
-  inOnline: boolean;
-}
-
-export interface ReadHistoryGroup {
-  dayKey: string;
-  label: string;
-  items: Array<ReadHistoryItem>;
 }
 
 export interface ReadHistoryOpenTarget {
@@ -58,7 +46,6 @@ export interface ReadHistoryViewState {
   busy: boolean;
   message: string;
   requiresLogin: boolean;
-  onlineEnabled: boolean;
   loadingMore: boolean;
   canLoadMore: boolean;
 }
@@ -95,9 +82,9 @@ export function decodeReadHistoryItem(content: OpenedContent): ReadHistoryItem |
     kind: contentKind,
     id: id,
     openedAt: content.openedAt,
-    title: content.title,
-    deletable: true,
-    inOnline: false
+    title: content.title ?? '',
+    summary: '',
+    authorName: undefined
   };
 }
 
@@ -113,9 +100,7 @@ export function onlineHistoryEntryToReadItem(entry: OnlineHistoryEntry): ReadHis
     openedAt: entry.readTime,
     title: entry.title,
     summary: entry.summary,
-    authorName: entry.authorName,
-    deletable: false,
-    inOnline: true
+    authorName: entry.authorName
   };
 }
 
@@ -136,118 +121,28 @@ export function readHistoryKindLabel(kind: ReadHistoryContentKind): string {
   return '想法';
 }
 
-export function readHistorySourceLabel(item: ReadHistoryItem): string {
-  if (item.deletable && item.inOnline) {
-    return '本地+在线';
-  }
-  return item.deletable ? '本地' : '在线';
-}
-
-export function readHistorySourceFilterLabel(filter: ReadHistorySourceFilter): string {
-  if (filter === ReadHistorySourceFilter.LOCAL) {
-    return '本地记录';
-  }
-  if (filter === ReadHistorySourceFilter.ONLINE) {
-    return '在线记录';
-  }
-  return '全部记录';
-}
-
-export function filterReadHistoryItems(items: Array<ReadHistoryItem>,
-  filter: ReadHistorySourceFilter): Array<ReadHistoryItem> {
-  if (filter === ReadHistorySourceFilter.LOCAL) {
-    return items.filter((item: ReadHistoryItem): boolean => item.deletable);
-  }
-  if (filter === ReadHistorySourceFilter.ONLINE) {
-    return items.filter((item: ReadHistoryItem): boolean => item.inOnline);
-  }
-  return items.slice();
-}
-
-export function groupReadHistoryItems(items: Array<ReadHistoryItem>): Array<ReadHistoryGroup> {
-  const groups = new Map<string, ReadHistoryGroup>();
-  const orderedKeys: Array<string> = [];
-  const orderedItems = items.slice().sort((left: ReadHistoryItem, right: ReadHistoryItem): number =>
-    right.openedAt - left.openedAt);
-  orderedItems.forEach((item: ReadHistoryItem): void => {
-    const dayKey = readHistoryDayKey(item.openedAt);
-    const current = groups.get(dayKey);
-    if (current === undefined) {
-      groups.set(dayKey, { dayKey: dayKey, label: readHistoryDayLabel(item.openedAt), items: [item] });
-      orderedKeys.push(dayKey);
-      return;
+/** 卡片元信息行的时间段：与知乎客户端一致展示到分钟。 */
+export function readHistoryTimeLabel(openedAt: number): string {
+  try {
+    if (!Number.isFinite(openedAt)) {
+      return '';
     }
-    current.items.push(item);
-  });
-  const result: Array<ReadHistoryGroup> = [];
-  orderedKeys.forEach((key: string): void => {
-    const group = groups.get(key);
-    if (group !== undefined) {
-      result.push(group);
+    const value = new Date(openedAt);
+    if (Number.isNaN(value.getFullYear())) {
+      return '';
     }
-  });
-  return result;
-}
-
-function readHistoryDayKey(openedAt: number): string {
-  const value = new Date(openedAt);
-  return `${value.getFullYear()}-${`${value.getMonth() + 1}`.padStart(2, '0')}-${`${value.getDate()}`.padStart(2, '0')}`;
-}
-
-function readHistoryDayLabel(openedAt: number): string {
-  const value = new Date(openedAt);
-  return `${value.getFullYear()}年${value.getMonth() + 1}月${value.getDate()}日`;
-}
-
-export function mergeReadHistoryItems(local: Array<ReadHistoryItem>,
-  online: Array<ReadHistoryItem>): Array<ReadHistoryItem> {
-  const byKey = new Map<string, ReadHistoryItem>();
-  local.forEach((item: ReadHistoryItem): void => {
-    byKey.set(item.contentKey, copyReadHistoryItem(item));
-  });
-  online.forEach((item: ReadHistoryItem): void => {
-    const existing = byKey.get(item.contentKey);
-    if (existing === undefined) {
-      byKey.set(item.contentKey, copyReadHistoryItem(item));
-      return;
-    }
-    byKey.set(item.contentKey, {
-      contentKey: existing.contentKey,
-      kind: existing.kind,
-      id: existing.id,
-      openedAt: Math.max(existing.openedAt, item.openedAt),
-      title: existing.title ?? item.title,
-      summary: existing.summary ?? item.summary,
-      authorName: existing.authorName ?? item.authorName,
-      deletable: true,
-      inOnline: true
-    });
-  });
-  const merged: Array<ReadHistoryItem> = [];
-  byKey.forEach((item: ReadHistoryItem): void => {
-    merged.push(item);
-  });
-  merged.sort((a: ReadHistoryItem, b: ReadHistoryItem): number => b.openedAt - a.openedAt);
-  return merged;
-}
-
-function readHistoryKindFromOnline(kind: OnlineHistoryKind): ReadHistoryContentKind | undefined {
-  if (kind === OnlineHistoryKind.QUESTION) {
-    return ReadHistoryContentKind.QUESTION;
+    const month = `${value.getMonth() + 1}`.padStart(2, '0');
+    const day = `${value.getDate()}`.padStart(2, '0');
+    const hour = `${value.getHours()}`.padStart(2, '0');
+    const minute = `${value.getMinutes()}`.padStart(2, '0');
+    return `${value.getFullYear()}-${month}-${day} ${hour}:${minute}`;
+  } catch (_error) {
+    return '';
   }
-  if (kind === OnlineHistoryKind.ANSWER) {
-    return ReadHistoryContentKind.ANSWER;
-  }
-  if (kind === OnlineHistoryKind.ARTICLE) {
-    return ReadHistoryContentKind.ARTICLE;
-  }
-  if (kind === OnlineHistoryKind.PIN) {
-    return ReadHistoryContentKind.PIN;
-  }
-  return undefined;
 }
 
 export class ReadHistoryController {
+  /** 在线历史（主页面）：分页拉取知乎服务端浏览历史；清除时同时清空本地已读记录（对齐上游 clearAllHistory）。 */
   private readonly history: ReadHistoryGateway;
   private readonly onlineHistory?: OnlineHistoryRepository;
   private readonly onlineEnabled: boolean;
@@ -255,12 +150,8 @@ export class ReadHistoryController {
   private active: boolean = false;
   private generation: number = 0;
   private state: ReadHistoryViewState;
-  private localItems: Array<ReadHistoryItem> = [];
-  private onlineItems: Array<ReadHistoryItem> = [];
   private onlineCursor?: string;
   private onlineEnded: boolean;
-  private onlineFailureMessage?: string;
-  private requiresLogin: boolean;
 
   constructor(history: ReadHistoryGateway,
     onlineHistory?: OnlineHistoryRepository,
@@ -271,14 +162,12 @@ export class ReadHistoryController {
     this.onlineEnabled = onlineEnabled;
     this.observer = observer;
     this.onlineEnded = !onlineEnabled;
-    this.requiresLogin = !onlineEnabled;
     this.state = {
       phase: ReadHistoryPhase.LOADING,
       items: [],
       busy: false,
-      message: '正在读取本地已读记录',
-      requiresLogin: this.requiresLogin,
-      onlineEnabled: onlineEnabled,
+      message: onlineEnabled ? '正在加载历史记录' : '登录后可查看知乎账号的浏览历史',
+      requiresLogin: !onlineEnabled,
       loadingMore: false,
       canLoadMore: false
     };
@@ -289,7 +178,7 @@ export class ReadHistoryController {
       return;
     }
     this.active = true;
-    this.reload();
+    void this.reload();
   }
 
   deactivate(): void {
@@ -309,82 +198,74 @@ export class ReadHistoryController {
     if (!this.active) {
       return Promise.resolve();
     }
-    const generation = ++this.generation;
-    this.publishWith(this.state.items, ReadHistoryPhase.LOADING, true,
-      this.onlineEnabled ? '正在读取浏览记录' : '正在读取本地已读记录', false, false);
-    return this.loadIntoState(generation, this.onlineEnabled ? '浏览记录已更新' : '已读记录已更新');
-  }
-
-  delete(contentKey: string): Promise<void> {
-    return this.mutate((): Promise<boolean> => this.history.delete(contentKey),
-      '已删除这条记录', '删除失败，请重试');
-  }
-
-  clear(): Promise<void> {
-    return this.mutate(async (): Promise<boolean> => {
-      await this.history.clear();
-      return true;
-    }, this.onlineEnabled ? '已清空本地已读记录，在线历史保留' : '已清空本地已读记录', '清空失败，请重试');
-  }
-
-  loadMore(): Promise<void> {
-    if (!this.active || this.state.busy || this.onlineEnded || this.onlineCursor === undefined) {
+    if (!this.onlineEnabled) {
+      this.publish(ReadHistoryPhase.EMPTY, [], false, '登录后可查看知乎账号的浏览历史', false, false);
       return Promise.resolve();
     }
     const generation = ++this.generation;
-    this.publishWith(this.state.items, this.state.phase, true, '正在加载更多在线历史', true, false);
-    return this.appendOnlinePage(generation, '在线历史已更新');
+    this.onlineCursor = undefined;
+    this.onlineEnded = false;
+    this.publish(ReadHistoryPhase.LOADING, this.state.items, true, '正在加载历史记录', false, false);
+    return this.appendOnlinePage(generation, '历史记录已更新');
   }
 
-  private async mutate(operation: () => Promise<boolean>, successMessage: string,
-    failureMessage: string): Promise<void> {
-    if (!this.active || this.state.busy) {
+  loadMore(): Promise<void> {
+    if (!this.active || this.state.busy || this.state.loadingMore || this.onlineEnded ||
+      this.onlineCursor === undefined) {
+      return Promise.resolve();
+    }
+    const generation = ++this.generation;
+    this.publish(this.state.phase, this.state.items, false, this.state.message, true, this.state.canLoadMore);
+    return this.appendOnlinePage(generation, '历史记录已更新');
+  }
+
+  /** 对齐上游 deleteItem：batch_del 单条删除成功后从列表移除。 */
+  async deleteEntry(contentKey: string): Promise<void> {
+    const repository = this.onlineHistory;
+    if (!this.active || this.state.busy || repository === undefined) {
       return;
     }
     const generation = ++this.generation;
-    this.publishWith(this.state.items, this.state.phase, true, '正在更新本地已读记录', false,
-      this.state.canLoadMore);
+    this.publish(this.state.phase, this.state.items, true, '正在删除该条历史记录', false, this.state.canLoadMore);
     try {
-      await operation();
-      if (this.isCurrent(generation)) {
-        await this.loadIntoState(generation, successMessage);
+      await repository.deleteEntry(contentKey);
+      if (!this.isCurrent(generation)) {
+        return;
       }
+      const remaining = this.state.items.filter((item: ReadHistoryItem): boolean =>
+        item.contentKey !== contentKey);
+      this.publish(this.phaseOf(remaining), remaining, false, '已删除该条历史记录', false,
+        !this.onlineEnded && this.onlineCursor !== undefined);
     } catch (_error) {
       if (this.isCurrent(generation)) {
-        this.publishWith(this.state.items, ReadHistoryPhase.ERROR, false, failureMessage, false,
-          this.onlineEnabled && !this.onlineEnded && this.onlineCursor !== undefined);
+        this.publish(this.state.phase, this.state.items, false, '操作失败，请重试', false,
+          !this.onlineEnded && this.onlineCursor !== undefined);
       }
     }
   }
 
-  private async loadIntoState(generation: number, successMessage: string): Promise<void> {
+  /** 对齐上游 clearAllHistory：一次清空服务端在线历史 + 本机已读记录。 */
+  async clearAll(): Promise<void> {
+    const repository = this.onlineHistory;
+    if (!this.active || this.state.busy || repository === undefined) {
+      return;
+    }
+    const generation = ++this.generation;
+    this.publish(this.state.phase, this.state.items, true, '正在清除历史记录', false, false);
     try {
-      const stored = await this.history.queryRecent(MAX_READ_HISTORY_ITEMS);
-      const localItems: Array<ReadHistoryItem> = [];
-      stored.forEach((content: OpenedContent): void => {
-        const item = decodeReadHistoryItem(content);
-        if (item !== undefined) {
-          localItems.push(item);
-        }
-      });
-      this.localItems = localItems;
-      this.onlineItems = [];
+      await this.history.clear();
+      await repository.clearAll();
+      if (!this.isCurrent(generation)) {
+        return;
+      }
       this.onlineCursor = undefined;
-      this.onlineEnded = !this.onlineEnabled;
-      this.onlineFailureMessage = undefined;
-      if (!this.isCurrent(generation)) {
-        return;
-      }
-      this.publishMerged(generation, localItems.length === 0 ? '暂无本地已读记录' : '本地已读记录已读取');
-      if (this.onlineEnabled && this.onlineHistory !== undefined && this.isCurrent(generation)) {
-        this.publishWith(this.state.items, this.state.phase, true, '正在加载在线历史', false, false);
-        await this.appendOnlinePage(generation, successMessage);
-      }
+      this.onlineEnded = true;
+      this.publish(ReadHistoryPhase.EMPTY, [], false, '已清除所有历史记录', false, false);
     } catch (_error) {
-      if (!this.isCurrent(generation)) {
-        return;
+      if (this.isCurrent(generation)) {
+        this.publish(this.state.phase, this.state.items, false, '清除失败，请重试', false,
+          !this.onlineEnded && this.onlineCursor !== undefined);
       }
-      this.publishWith(this.state.items, ReadHistoryPhase.ERROR, false, '已读记录读取失败，请重试', false, false);
     }
   }
 
@@ -393,8 +274,9 @@ export class ReadHistoryController {
     if (repository === undefined || this.onlineEnded) {
       return;
     }
+    const replacing = this.onlineCursor === undefined;
     try {
-      const page = await repository.loadPage(this.onlineCursor);
+      const page = await repository.loadPage(replacing ? undefined : this.onlineCursor);
       if (!this.isCurrent(generation)) {
         return;
       }
@@ -405,63 +287,209 @@ export class ReadHistoryController {
           incoming.push(item);
         }
       });
-      this.onlineItems = this.onlineItems.concat(incoming);
+      const merged = replacing ? incoming
+        : appendUniqueItems(this.state.items, incoming);
       this.onlineCursor = page.cursor.next;
       this.onlineEnded = page.cursor.isEnd || incoming.length === 0;
-      this.onlineFailureMessage = undefined;
-      this.publishMerged(generation, successMessage);
+      const message = merged.length === 0 ? '暂无浏览记录' : successMessage;
+      this.publish(this.phaseOf(merged), merged, false, message, false,
+        !this.onlineEnded && this.onlineCursor !== undefined);
     } catch (error) {
       if (!this.isCurrent(generation)) {
         return;
       }
       this.onlineEnded = true;
       if (error instanceof HttpFailure && error.kind === HttpFailureKind.AUTHENTICATION) {
-        this.requiresLogin = true;
-        this.onlineFailureMessage = '登录已失效，请重新登录后查看在线历史';
-      } else {
-        this.onlineFailureMessage = this.state.items.length === 0
-          ? '在线历史加载失败，请重试'
-          : '在线历史加载失败，已显示本地记录';
+        this.publish(ReadHistoryPhase.EMPTY, this.state.items, false, '登录已失效，请重新登录后查看历史记录',
+          false, false);
+        return;
       }
-      this.publishMerged(generation, this.onlineFailureMessage);
+      if (replacing) {
+        this.publish(ReadHistoryPhase.ERROR, [], false, '历史记录加载失败，请重试', false, false);
+        return;
+      }
+      this.publish(this.state.phase, this.state.items, false, '加载更多失败，请重试', false, false);
     }
   }
 
-  private publishMerged(generation: number, message: string): void {
-    if (!this.isCurrent(generation)) {
-      return;
-    }
-    const merged = mergeReadHistoryItems(this.localItems, this.onlineItems);
-    const finalMessage = merged.length === 0
-      ? (this.onlineFailureMessage ?? (this.onlineEnabled ? '暂无浏览记录' : '暂无本地已读记录'))
-      : message;
-    this.publishWith(merged, merged.length === 0 ? ReadHistoryPhase.EMPTY : ReadHistoryPhase.READY,
-      false, finalMessage, false,
-      this.onlineEnabled && !this.onlineEnded && this.onlineCursor !== undefined);
+  private phaseOf(items: Array<ReadHistoryItem>): ReadHistoryPhase {
+    return items.length === 0 ? ReadHistoryPhase.EMPTY : ReadHistoryPhase.READY;
   }
 
-  private publishWith(items: Array<ReadHistoryItem>, phase: ReadHistoryPhase, busy: boolean,
+  private publish(phase: ReadHistoryPhase, items: Array<ReadHistoryItem>, busy: boolean,
     message: string, loadingMore: boolean, canLoadMore: boolean): void {
-    this.publish({
+    this.state = {
       phase: phase,
-      items: items,
+      items: items.map((item: ReadHistoryItem): ReadHistoryItem => copyReadHistoryItem(item)),
       busy: busy,
       message: message,
-      requiresLogin: this.requiresLogin,
-      onlineEnabled: this.onlineEnabled,
+      requiresLogin: !this.onlineEnabled,
       loadingMore: loadingMore,
       canLoadMore: canLoadMore
-    });
+    };
+    this.observer(this.snapshot());
   }
 
   private isCurrent(generation: number): boolean {
     return this.active && this.generation === generation;
   }
+}
 
-  private publish(state: ReadHistoryViewState): void {
-    this.state = copyReadHistoryState(state);
+export class LocalHistoryController {
+  /** 本地历史（对齐上游 LegacyLocalHistoryScreen）：一次性读取本机已读记录，无分页。 */
+  private readonly history: ReadHistoryGateway;
+  private readonly observer: ReadHistoryObserver;
+  private active: boolean = false;
+  private generation: number = 0;
+  private state: ReadHistoryViewState;
+
+  constructor(history: ReadHistoryGateway,
+    observer: ReadHistoryObserver = (_state: ReadHistoryViewState): void => {}) {
+    this.history = history;
+    this.observer = observer;
+    this.state = {
+      phase: ReadHistoryPhase.LOADING,
+      items: [],
+      busy: false,
+      message: '正在读取本地历史记录',
+      requiresLogin: false,
+      loadingMore: false,
+      canLoadMore: false
+    };
+  }
+
+  activate(): void {
+    if (this.active) {
+      return;
+    }
+    this.active = true;
+    void this.reload();
+  }
+
+  deactivate(): void {
+    this.active = false;
+    this.generation += 1;
+  }
+
+  snapshot(): ReadHistoryViewState {
+    return copyReadHistoryState(this.state);
+  }
+
+  reload(): Promise<void> {
+    if (!this.active) {
+      return Promise.resolve();
+    }
+    const generation = ++this.generation;
+    this.publishWith(this.state.items, ReadHistoryPhase.LOADING, true, '正在读取本地历史记录');
+    return this.loadIntoState(generation, '本地历史记录已读取');
+  }
+
+  async delete(contentKey: string): Promise<void> {
+    return this.mutate((): Promise<boolean> => this.history.delete(contentKey),
+      '已删除该条本地记录', '删除失败，请重试');
+  }
+
+  async clear(): Promise<void> {
+    return this.mutate(async (): Promise<boolean> => {
+      await this.history.clear();
+      return true;
+    }, '已清空本地历史记录', '清空失败，请重试');
+  }
+
+  private async mutate(operation: () => Promise<boolean>, successMessage: string,
+    failureMessage: string): Promise<void> {
+    if (!this.active || this.state.busy) {
+      return;
+    }
+    const generation = ++this.generation;
+    this.publishWith(this.state.items, this.state.phase, true, '正在更新本地历史记录');
+    try {
+      await operation();
+      if (this.isCurrent(generation)) {
+        await this.loadIntoState(generation, successMessage);
+      }
+    } catch (_error) {
+      if (this.isCurrent(generation)) {
+        this.publishWith(this.state.items, ReadHistoryPhase.ERROR, false, failureMessage);
+      }
+    }
+  }
+
+  private async loadIntoState(generation: number, successMessage: string): Promise<void> {
+    try {
+      const stored = await this.history.queryRecent(MAX_READ_HISTORY_ITEMS);
+      const items: Array<ReadHistoryItem> = [];
+      stored.forEach((content: OpenedContent): void => {
+        const item = decodeReadHistoryItem(content);
+        if (item !== undefined) {
+          items.push(item);
+        }
+      });
+      items.sort((left: ReadHistoryItem, right: ReadHistoryItem): number => right.openedAt - left.openedAt);
+      if (!this.isCurrent(generation)) {
+        return;
+      }
+      const message = items.length === 0 ? '暂无本地历史记录' : successMessage;
+      this.publishWith(items, items.length === 0 ? ReadHistoryPhase.EMPTY : ReadHistoryPhase.READY,
+        false, message);
+    } catch (_error) {
+      if (!this.isCurrent(generation)) {
+        return;
+      }
+      this.publishWith(this.state.items, ReadHistoryPhase.ERROR, false, '本地历史记录读取失败，请重试');
+    }
+  }
+
+  private publishWith(items: Array<ReadHistoryItem>, phase: ReadHistoryPhase, busy: boolean,
+    message: string): void {
+    this.state = {
+      phase: phase,
+      items: items.map((item: ReadHistoryItem): ReadHistoryItem => copyReadHistoryItem(item)),
+      busy: busy,
+      message: message,
+      requiresLogin: false,
+      loadingMore: false,
+      canLoadMore: false
+    };
     this.observer(this.snapshot());
   }
+
+  private isCurrent(generation: number): boolean {
+    return this.active && this.generation === generation;
+  }
+}
+
+function appendUniqueItems(current: Array<ReadHistoryItem>, incoming: Array<ReadHistoryItem>)
+  : Array<ReadHistoryItem> {
+  const seen = new Set<string>();
+  current.forEach((item: ReadHistoryItem): void => {
+    seen.add(item.contentKey);
+  });
+  const merged = current.slice();
+  incoming.forEach((item: ReadHistoryItem): void => {
+    if (seen.has(item.contentKey)) {
+      return;
+    }
+    seen.add(item.contentKey);
+    merged.push(item);
+  });
+  return merged;
+}
+
+function readHistoryKindFromOnline(kind: OnlineHistoryKind): ReadHistoryContentKind | undefined {
+  if (kind === OnlineHistoryKind.QUESTION) {
+    return ReadHistoryContentKind.QUESTION;
+  }
+  if (kind === OnlineHistoryKind.ANSWER) {
+    return ReadHistoryContentKind.ANSWER;
+  }
+  if (kind === OnlineHistoryKind.ARTICLE) {
+    return ReadHistoryContentKind.ARTICLE;
+  }
+  if (kind === OnlineHistoryKind.PIN) {
+    return ReadHistoryContentKind.PIN;
+  }
+  return undefined;
 }
 
 function copyReadHistoryState(state: ReadHistoryViewState): ReadHistoryViewState {
@@ -471,7 +499,6 @@ function copyReadHistoryState(state: ReadHistoryViewState): ReadHistoryViewState
     busy: state.busy,
     message: state.message,
     requiresLogin: state.requiresLogin,
-    onlineEnabled: state.onlineEnabled,
     loadingMore: state.loadingMore,
     canLoadMore: state.canLoadMore
   };
@@ -485,8 +512,6 @@ function copyReadHistoryItem(item: ReadHistoryItem): ReadHistoryItem {
     openedAt: item.openedAt,
     title: item.title,
     summary: item.summary,
-    authorName: item.authorName,
-    deletable: item.deletable,
-    inOnline: item.inOnline
+    authorName: item.authorName
   };
 }

--- a/entry/src/main/ets/pages/SearchPage.ets
+++ b/entry/src/main/ets/pages/SearchPage.ets
@@ -1,19 +1,46 @@
-import { P1Destination, P1DestinationName } from 'core';
-import { FeedTargetKind, SearchRepository, SearchResultItem, searchResultIdentity } from 'data';
+import { Want } from '@kit.AbilityKit';
+import { P1Destination, P1DestinationName, isSafePeopleIdentifier } from 'core';
+import {
+  AppPreferencesStore,
+  SEARCH_HISTORY_MAX_SIZE,
+  FeedTargetKind,
+  SearchEntity,
+  SearchEntityKind,
+  SearchHotItem,
+  SearchPersonItem,
+  SearchRepository,
+  isContentSearchTab,
+  SearchSortOption,
+  SearchTab,
+  SearchTimeRange,
+  SearchTopicItem,
+  SearchResultItem
+} from 'data';
+import { getAbilityContext } from '../entryability/AbilityContextHolder';
 import { SearchController, SearchPhase, SearchViewState } from './SearchState';
+import {
+  SEARCH_FILTER_ENABLED_KEY,
+  SEARCH_FILTER_TICK_KEY,
+  SEARCH_INPUT_ENTRY_TICK_KEY,
+  SEARCH_INPUT_VALUE_KEY,
+  SEARCH_SORT_OPTION_KEY,
+  SEARCH_SUBMIT_QUERY_KEY,
+  SEARCH_SUBMIT_TICK_KEY,
+  SEARCH_TIME_RANGE_KEY
+} from './SearchTitleBar';
 
 interface EmphasisPart {
   text: string;
   emphasized: boolean;
 }
 
-/** 当前搜索接口稳定返回内容实体，结果页按实体类型在端侧切换。 */
-export enum SearchResultFilter {
-  ALL = 0,
-  QUESTION = 1,
-  ANSWER = 2,
-  ARTICLE = 3
-}
+const SEARCH_TABS: Array<SearchTab> = [
+  SearchTab.GENERAL,
+  SearchTab.PEOPLE,
+  SearchTab.ANSWER,
+  SearchTab.ARTICLE,
+  SearchTab.TOPIC
+];
 
 /** 把搜索接口返回的 `<em>关键词</em>` 拆成高亮片段（无标签时整段普通文本）。 */
 function splitEmphasis(text: string): Array<EmphasisPart> {
@@ -41,31 +68,62 @@ function splitEmphasis(text: string): Array<EmphasisPart> {
   return parts;
 }
 
+function stripEmphasis(text: string): string {
+  return splitEmphasis(text).map((part: EmphasisPart): string => part.text).join('');
+}
+
+export function searchTabLabel(tab: SearchTab): string {
+  if (tab === SearchTab.PEOPLE) {
+    return '用户';
+  }
+  if (tab === SearchTab.ANSWER) {
+    return '回答';
+  }
+  if (tab === SearchTab.ARTICLE) {
+    return '文章';
+  }
+  if (tab === SearchTab.TOPIC) {
+    return '话题';
+  }
+  return '综合';
+}
+
 @Component
 export struct SearchPage {
   initialQuery: string = '';
   repository: SearchRepository | undefined = undefined;
+  preferences: AppPreferencesStore | undefined = undefined;
   navigate: (destination: P1Destination) => void = (_destination: P1Destination): void => {
   };
   onBack: () => void = (): void => {
   };
-  @State private input: string = '';
   @State private phase: SearchPhase = SearchPhase.IDLE;
   @State private query: string = '';
-  @State private items: Array<SearchResultItem> = [];
+  @State private entities: Array<SearchEntity> = [];
+  @State private activeTabIndex: number = 0;
   @State private loadingMore: boolean = false;
   @State private canLoadMore: boolean = false;
   @State private requiresLogin: boolean = false;
   @State private errorMessage: string = '';
-  @State private selectedResultFilter: number = SearchResultFilter.ALL;
+  @State private history: Array<string> = [];
+  @State private hotItems: Array<SearchHotItem> = [];
+  // @StorageProp 键用字面量（装饰器要求编译期常量），值与 SearchTitleBar 导出的常量一一对应。
+  @StorageProp('searchSubmitTick') @Watch('onSubmitTick') private submitTick: number = 0;
+  @StorageProp('searchFilterTick') @Watch('onFilterTick') private filterTick: number = 0;
   private controller?: SearchController;
+  private lastSubmitTick: number = -1;
+  private lastFilterTick: number = -1;
 
   aboutToAppear(): void {
-    if (this.controller !== undefined) {
-      this.controller.activate();
-      return;
-    }
-    this.input = this.initialQuery;
+    this.lastSubmitTick = AppStorage.get<number>(SEARCH_SUBMIT_TICK_KEY) ?? 0;
+    this.lastFilterTick = AppStorage.get<number>(SEARCH_FILTER_TICK_KEY) ?? 0;
+    AppStorage.setOrCreate(SEARCH_INPUT_VALUE_KEY, this.initialQuery);
+    // 每次进入递增 entryTick，标题栏据此强制清空输入框（TextInput 内部状态不随外部 text 更新）。
+    AppStorage.setOrCreate(SEARCH_INPUT_ENTRY_TICK_KEY,
+      (AppStorage.get<number>(SEARCH_INPUT_ENTRY_TICK_KEY) ?? 0) + 1);
+    AppStorage.setOrCreate(SEARCH_FILTER_ENABLED_KEY, false);
+    AppStorage.setOrCreate(SEARCH_SORT_OPTION_KEY, SearchSortOption.DEFAULT);
+    AppStorage.setOrCreate(SEARCH_TIME_RANGE_KEY, SearchTimeRange.ALL);
     if (this.repository === undefined) {
       return;
     }
@@ -75,6 +133,9 @@ export struct SearchPage {
     this.controller.activate();
     if (this.initialQuery.trim().length > 0) {
       this.controller.submit(this.initialQuery);
+    } else {
+      void this.loadHistory();
+      void this.loadHotSearch();
     }
   }
 
@@ -82,149 +143,115 @@ export struct SearchPage {
     this.controller?.deactivate();
   }
 
+  private onSubmitTick(): void {
+    const tick = AppStorage.get<number>(SEARCH_SUBMIT_TICK_KEY) ?? 0;
+    if (tick === this.lastSubmitTick) {
+      return;
+    }
+    this.lastSubmitTick = tick;
+    const query = AppStorage.get<string>(SEARCH_SUBMIT_QUERY_KEY) ?? '';
+    this.performSubmit(query);
+  }
+
+  private onFilterTick(): void {
+    const tick = AppStorage.get<number>(SEARCH_FILTER_TICK_KEY) ?? 0;
+    if (tick === this.lastFilterTick) {
+      return;
+    }
+    this.lastFilterTick = tick;
+    const sort = AppStorage.get<string>(SEARCH_SORT_OPTION_KEY) ?? SearchSortOption.DEFAULT;
+    const timeRange = AppStorage.get<string>(SEARCH_TIME_RANGE_KEY) ?? SearchTimeRange.ALL;
+    void this.controller?.updateFilters(sort as SearchSortOption, timeRange as SearchTimeRange);
+  }
+
+  private async loadHistory(): Promise<void> {
+    if (this.preferences === undefined) {
+      return;
+    }
+    try {
+      this.history = await this.preferences.loadSearchHistory();
+    } catch (_error) {
+      // 历史读取失败按空历史展示，不阻塞搜索主流程。
+    }
+  }
+
+  private async loadHotSearch(): Promise<void> {
+    if (this.repository === undefined) {
+      return;
+    }
+    try {
+      this.hotItems = (await this.repository.hotSearch()).slice(0, 15);
+    } catch (_error) {
+      this.hotItems = [];
+    }
+  }
+
+  private recordHistory(query: string): void {
+    if (this.preferences === undefined) {
+      return;
+    }
+    const next: Array<string> = [query].concat(
+      this.history.filter((item: string): boolean => item !== query)).slice(0, SEARCH_HISTORY_MAX_SIZE);
+    this.history = next;
+    this.preferences.saveSearchHistory(next).catch((_error: Object): void => {
+    });
+  }
+
+  private performSubmit(rawQuery: string): void {
+    const query = rawQuery.trim();
+    if (query.length === 0) {
+      this.controller?.submit('');
+      return;
+    }
+    AppStorage.setOrCreate(SEARCH_INPUT_VALUE_KEY, query);
+    this.recordHistory(query);
+    this.activeTabIndex = 0;
+    void this.controller?.submit(query);
+  }
+
+  private clearHistory(): void {
+    this.history = [];
+    this.preferences?.saveSearchHistory([]).catch((_error: Object): void => {
+    });
+  }
+
+  private applyState(state: SearchViewState): void {
+    this.phase = state.phase;
+    this.query = state.query;
+    this.entities = state.entities;
+    this.loadingMore = state.loadingMore;
+    this.canLoadMore = state.canLoadMore;
+    this.requiresLogin = state.requiresLogin;
+    this.errorMessage = state.errorMessage ?? '';
+    const tabIndex = SEARCH_TABS.indexOf(state.activeTab);
+    if (tabIndex >= 0) {
+      this.activeTabIndex = tabIndex;
+    }
+    // 排序菜单只在有结果时可用（含加载更多失败回退的 READY 态）。
+    AppStorage.setOrCreate(SEARCH_FILTER_ENABLED_KEY, state.phase === SearchPhase.READY && isContentSearchTab(state.activeTab));
+    AppStorage.setOrCreate(SEARCH_SORT_OPTION_KEY, state.sort);
+    AppStorage.setOrCreate(SEARCH_TIME_RANGE_KEY, state.timeRange);
+  }
+
   build() {
-    Column({ space: $r('app.float.p1_spacing_medium') }) {
-      Row({ space: $r('app.float.p1_spacing_small') }) {
-        Row({ space: $r('app.float.p1_spacing_xsmall') }) {
-          SymbolGlyph($r('sys.symbol.magnifyingglass'))
-            .fontSize(18)
-            .fontColor([$r('app.color.secondary_text')])
-          TextInput({ text: this.input, placeholder: '搜索知乎内容' })
-            .id('p2_search_input')
-            .layoutWeight(1)
-            .fontSize($r('app.float.p1_body_font_size'))
-            .maxLength(200)
-            .enterKeyType(EnterKeyType.Search)
-            .backgroundColor(Color.Transparent)
-            .onChange((value: string): void => {
-              this.input = value;
-            })
-            .onSubmit((): void => {
-              this.submitInput();
-            })
-
-          if (this.input.length > 0) {
-            Button({ type: ButtonType.Normal, stateEffect: true }) {
-              SymbolGlyph($r('sys.symbol.xmark'))
-                .fontSize(16)
-                .fontColor([$r('app.color.secondary_text')])
-            }
-            .id('p2_search_clear')
-            .width(32)
-            .height(32)
-            .padding(0)
-            .backgroundColor(Color.Transparent)
-            .accessibilityText('清除搜索内容')
-            .onClick((): void => {
-              this.input = '';
-              this.controller?.submit('');
-            })
-          }
-        }
-        .id('p2_search_input_container')
-          .layoutWeight(1)
-        .height(40)
-        .padding({ left: $r('app.float.p1_spacing_small'), right: $r('app.float.p1_spacing_xsmall') })
-        .backgroundColor($r('app.color.control_background'))
-        .borderRadius($r('app.float.p1_card_radius'))
-        .alignItems(VerticalAlign.Center)
-
-        Button({ type: ButtonType.Normal, stateEffect: true }) {
-          SymbolGlyph($r('sys.symbol.line_3_horizontal'))
-            .fontSize(20)
-            .fontColor([$r('app.color.primary_text')])
-        }
-        .id('p2_search_filter')
-        .width(40)
-        .height(40)
-        .padding(0)
-        .backgroundColor(Color.Transparent)
-        .accessibilityText(`筛选搜索结果，当前${searchResultFilterLabel(this.selectedResultFilter)}`)
-        .bindMenu(this.filterMenu())
-
-      }
-      .id('p2_search_input_row')
-      .width('100%')
-      .padding({ top: 94 })
-
-      if (this.query.length > 0) {
-        this.resultTabs();
-      }
-
+    Column() {
       if (this.repository === undefined) {
         this.statusPanel('搜索数据源未配置', false, 'p2_search_unconfigured');
-      } else if (this.phase === SearchPhase.IDLE) {
-        this.statusPanel('输入关键词开始搜索', false, 'p2_search_idle');
-      } else if (this.phase === SearchPhase.LOADING) {
-        this.statusPanel('正在搜索…', false, 'p2_search_loading');
-      } else if (this.phase === SearchPhase.ERROR) {
-        this.statusPanel(this.errorMessage, true, 'p2_search_error');
-      } else if (this.phase === SearchPhase.EMPTY) {
-        this.statusPanel('没有找到可显示的相关结果', true, 'p2_search_empty');
+      } else if (this.query.length === 0 && this.phase === SearchPhase.IDLE) {
+        this.idlePanel();
       } else {
-        if (this.errorMessage.length > 0) {
-          Column({ space: $r('app.float.p1_spacing_small') }) {
-            Text(this.errorMessage)
-              .id('p2_search_recoverable_error_text')
-              .fontSize($r('app.float.p1_secondary_font_size'))
-              .fontColor($r('app.color.secondary_text'))
-              .width('100%')
-            Row({ space: $r('app.float.p1_spacing_small') }) {
-              Button('重试')
-                .id('p2_search_recoverable_error_retry')
-                .layoutWeight(1)
-                .onClick(() => this.controller?.retry())
-              if (this.requiresLogin) {
-                Button('去登录')
-                  .id('p2_search_recoverable_error_login')
-                  .layoutWeight(1)
-                  .onClick(() => this.openLogin())
-              }
-            }
-            .width('100%')
-          }
-          .alignItems(HorizontalAlign.Start)
-          .width('100%')
-          .padding($r('app.float.p1_spacing_small'))
-          .borderRadius($r('app.float.p1_card_radius'))
-          .backgroundColor($r('app.color.surface_background'))
+        if (this.query.length > 0) {
+          this.resultTabs();
         }
-
-        if (this.filteredItems().length === 0) {
-          Text(`${searchResultFilterLabel(this.selectedResultFilter)}分类下暂无结果`)
-            .id('p2_search_filtered_empty')
-            .fontSize($r('app.float.p1_body_font_size'))
-            .fontColor($r('app.color.secondary_text'))
-            .textAlign(TextAlign.Center)
-            .width('100%')
-            .padding($r('app.float.p1_spacing_large'))
+        if (this.phase === SearchPhase.LOADING) {
+          this.statusPanel('正在搜索…', false, 'p2_search_loading');
+        } else if (this.phase === SearchPhase.ERROR) {
+          this.statusPanel(this.errorMessage, true, 'p2_search_error');
+        } else if (this.phase === SearchPhase.EMPTY) {
+          this.statusPanel('没有找到可显示的相关结果', false, 'p2_search_empty');
+        } else {
+          this.resultList();
         }
-
-        List() {
-          ForEach(this.filteredItems(), (item: SearchResultItem) => {
-            ListItem() {
-              this.resultCard(item);
-            }
-            .margin({ bottom: $r('app.float.p1_spacing_medium') })
-          }, (item: SearchResultItem): string => searchResultIdentity(item))
-
-          if (this.loadingMore || this.canLoadMore) {
-            ListItem() {
-              Button(this.loadingMore ? '正在加载更多…' : '加载更多')
-                .id('p2_search_load_more')
-                .width('100%')
-                .fontSize($r('app.float.p1_secondary_font_size'))
-                .enabled(!this.loadingMore)
-                .onClick(() => this.controller?.loadMore())
-            }
-          }
-        }
-        .id('p2_search_result_list')
-        .width('100%')
-        .scrollBar(BarState.Off)
-        .layoutWeight(1)
-        .edgeEffect(EdgeEffect.Spring)
-        .onReachEnd(() => this.controller?.loadMore())
       }
     }
     .alignItems(HorizontalAlign.Start)
@@ -233,73 +260,199 @@ export struct SearchPage {
     .padding({
       left: $r('app.float.p1_page_padding'),
       right: $r('app.float.p1_page_padding'),
+      // 94vp 为标题栏（stackBuilder 注入的搜索框行）叠加预留，对齐详情页约定。
+      top: 94,
       bottom: $r('app.float.p1_page_padding')
     })
     .backgroundColor($r('app.color.page_background'))
   }
 
   @Builder
+  private idlePanel() {
+    Scroll() {
+      Column() {
+        if (this.history.length > 0) {
+          Row() {
+            Text('搜索历史')
+              .fontSize($r('app.float.p1_body_font_size'))
+              .fontWeight(FontWeight.Medium)
+              .fontColor($r('app.color.secondary_text'))
+            Blank()
+            Button({ type: ButtonType.Normal, stateEffect: true }) {
+              SymbolGlyph($r('sys.symbol.ellipsis_circle'))
+                .fontSize(18)
+                .fontColor([$r('app.color.secondary_text')])
+            }
+            .id('p2_search_history_more')
+            .width(36)
+            .height(36)
+            .padding(0)
+            .backgroundColor(Color.Transparent)
+            .accessibilityText('搜索历史选项')
+            .bindMenu([{
+              value: '清空搜索历史',
+              action: (): void => {
+                this.clearHistory();
+              }
+            } as MenuElement])
+          }
+          .width('100%')
+          .margin({ top: 8 })
+
+          ForEach(this.history, (item: string) => {
+            Row({ space: 8 }) {
+              SymbolGlyph($r('sys.symbol.magnifyingglass'))
+                .fontSize(16)
+                .fontColor([$r('app.color.secondary_text')])
+              Text(item)
+                .fontSize($r('app.float.p1_body_font_size'))
+                .fontColor($r('app.color.primary_text'))
+                .maxLines(1)
+                .textOverflow({ overflow: TextOverflow.Ellipsis })
+            }
+            .id(`p2_search_history_${item}`)
+            .width('100%')
+            .height(40)
+            .onClick((): void => this.performSubmit(item))
+          }, (item: string): string => item)
+
+          Divider()
+            .color($r('app.color.control_background'))
+            .margin({ top: 12, bottom: 12 })
+        }
+
+        Row() {
+          Text('热搜')
+            .fontSize($r('app.float.p1_body_font_size'))
+            .fontWeight(FontWeight.Medium)
+            .fontColor($r('app.color.secondary_text'))
+          Blank()
+          Button({ type: ButtonType.Normal, stateEffect: true }) {
+            SymbolGlyph($r('sys.symbol.arrow_clockwise'))
+              .fontSize(18)
+              .fontColor([$r('app.color.secondary_text')])
+          }
+          .id('p2_search_hot_refresh')
+          .width(36)
+          .height(36)
+          .padding(0)
+          .backgroundColor(Color.Transparent)
+          .accessibilityText('刷新热搜')
+          .onClick((): void => {
+            void this.loadHotSearch();
+          })
+        }
+        .width('100%')
+
+        if (this.hotItems.length === 0) {
+          Text('暂无热搜内容')
+            .fontSize($r('app.float.p1_secondary_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .width('100%')
+            .padding(12)
+        } else {
+          ForEach(this.hotItems, (item: SearchHotItem, index: number) => {
+            Row({ space: 8 }) {
+              Text(`${index + 1}`)
+                .fontSize($r('app.float.p1_body_font_size'))
+                .fontColor(index < 3 ? $r('app.color.error_text') : $r('app.color.secondary_text'))
+                .width(24)
+              Text(item.query)
+                .fontSize($r('app.float.p1_body_font_size'))
+                .fontColor($r('app.color.primary_text'))
+                .maxLines(1)
+                .textOverflow({ overflow: TextOverflow.Ellipsis })
+                .layoutWeight(1)
+              if (item.hotShow.length > 0) {
+                Text(item.hotShow)
+                  .fontSize($r('app.float.p1_secondary_font_size'))
+                  .fontColor($r('app.color.secondary_text'))
+              }
+            }
+            .id(`p2_search_hot_${index}`)
+            .width('100%')
+            .height(40)
+            .onClick((): void => this.performSubmit(item.query))
+          }, (item: SearchHotItem, index: number): string => `${index}:${item.query}`)
+        }
+
+        if (this.history.length === 0 && this.hotItems.length === 0) {
+          Text('暂无搜索历史，输入关键词搜索后会保存在这里')
+            .fontSize($r('app.float.p1_body_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .width('100%')
+            .padding(12)
+        }
+      }
+      .width('100%')
+    }
+    .id('p2_search_idle_panel')
+    .width('100%')
+    .layoutWeight(1)
+    .align(Alignment.Top)
+    .scrollBar(BarState.Off)
+  }
+
+  @Builder
   private resultTabs() {
-    Tabs({ barPosition: BarPosition.Start, index: $$this.selectedResultFilter }) {
-      TabContent() {
-        Column() {
-          Blank();
+    Tabs({ barPosition: BarPosition.Start, index: this.activeTabIndex }) {
+      ForEach(SEARCH_TABS, (tab: SearchTab) => {
+        TabContent() {
+          Column() {
+            Blank();
+          }
         }
-      }
-      .tabBar(searchResultFilterLabel(SearchResultFilter.ALL))
-      TabContent() {
-        Column() {
-          Blank();
-        }
-      }
-      .tabBar(searchResultFilterLabel(SearchResultFilter.QUESTION))
-      TabContent() {
-        Column() {
-          Blank();
-        }
-      }
-      .tabBar(searchResultFilterLabel(SearchResultFilter.ANSWER))
-      TabContent() {
-        Column() {
-          Blank();
-        }
-      }
-      .tabBar(searchResultFilterLabel(SearchResultFilter.ARTICLE))
+        .tabBar(searchTabLabel(tab))
+      }, (tab: SearchTab): string => tab)
     }
     .id('p2_search_result_tabs')
     .width('100%')
     .height(44)
     .barHeight(44)
-    .barMode(BarMode.Fixed)
+    .barMode(BarMode.Scrollable)
     .scrollable(false)
     .onChange((index: number): void => {
-      if (isSearchResultFilter(index)) {
-        this.selectedResultFilter = index;
+      if (index >= 0 && index < SEARCH_TABS.length) {
+        this.activeTabIndex = index;
+        void this.controller?.selectTab(SEARCH_TABS[index]);
       }
     })
   }
 
-  private filteredItems(): Array<SearchResultItem> {
-    return filterSearchResults(this.items, this.selectedResultFilter);
-  }
-
-  private filterMenu(): Array<MenuElement> {
-    const menu: Array<MenuElement> = [];
-    const filters: Array<SearchResultFilter> = [
-      SearchResultFilter.ALL,
-      SearchResultFilter.QUESTION,
-      SearchResultFilter.ANSWER,
-      SearchResultFilter.ARTICLE
-    ];
-    filters.forEach((filter: SearchResultFilter): void => {
-      menu.push({
-        value: searchResultFilterLabel(filter),
-        action: (): void => {
-          this.selectedResultFilter = filter;
+  @Builder
+  private resultList() {
+    List() {
+      ForEach(this.entities, (entity: SearchEntity) => {
+        ListItem() {
+          if (entity.kind === SearchEntityKind.CONTENT && entity.content !== undefined) {
+            this.resultCard(entity.content);
+          } else if (entity.kind === SearchEntityKind.PERSON && entity.person !== undefined) {
+            this.personRow(entity.person);
+          } else if (entity.kind === SearchEntityKind.TOPIC && entity.topic !== undefined) {
+            this.topicRow(entity.topic);
+          }
         }
-      });
-    });
-    return menu;
+        .margin({ top: $r('app.float.p1_spacing_medium') })
+      }, (entity: SearchEntity): string => entity.id)
+
+      if (this.loadingMore || this.canLoadMore) {
+        ListItem() {
+          Button(this.loadingMore ? '正在加载更多…' : '加载更多')
+            .id('p2_search_load_more')
+            .width('100%')
+            .fontSize($r('app.float.p1_secondary_font_size'))
+            .enabled(!this.loadingMore)
+            .onClick(() => this.controller?.loadMore())
+        }
+        .margin({ top: $r('app.float.p1_spacing_medium') })
+      }
+    }
+    .id('p2_search_result_list')
+    .width('100%')
+    .scrollBar(BarState.Off)
+    .layoutWeight(1)
+    .edgeEffect(EdgeEffect.Spring)
+    .onReachEnd(() => this.controller?.loadMore())
   }
 
   @Builder
@@ -365,7 +518,7 @@ export struct SearchPage {
             .fontSize($r('app.float.p1_secondary_font_size'))
             .fontColor($r('app.color.brand_primary'))
           if (item.authorName !== undefined) {
-            Text(item.authorName)
+            Text(stripEmphasis(item.authorName))
               .fontSize($r('app.float.p1_secondary_font_size'))
               .fontColor($r('app.color.secondary_text'))
               .layoutWeight(1)
@@ -396,33 +549,122 @@ export struct SearchPage {
     .padding($r('app.float.p1_card_padding'))
     .borderRadius($r('app.float.p1_card_radius'))
     .backgroundColor($r('app.color.surface_background'))
-    .accessibilityText(`打开${searchKindLabel(item.kind)}：${item.title}`)
+    .accessibilityText(`打开${searchKindLabel(item.kind)}：${stripEmphasis(item.title)}`)
     .onClick(() => this.navigate(searchResultDestination(item)))
   }
 
-  private submitInput(): void {
-    const query = this.input.trim();
-    if (query.length === 0) {
-      this.controller?.submit('');
-      return;
+  @Builder
+  private personRow(item: SearchPersonItem) {
+    Row({ space: 12 }) {
+      if (item.avatarUrl !== undefined && item.avatarUrl.length > 0) {
+        Image(item.avatarUrl)
+          .width(48)
+          .height(48)
+          .borderRadius(24)
+          .objectFit(ImageFit.Cover)
+      }
+      Column({ space: 4 }) {
+        this.highlightedText(item.name, $r('app.float.p1_heading_font_size'),
+          $r('app.color.primary_text'), FontWeight.Medium)
+        if (item.headline.length > 0) {
+          Text(item.headline)
+            .fontSize($r('app.float.p1_secondary_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .maxLines(2)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .width('100%')
+        }
+        Text(`${item.followerCount} 粉丝 · ${item.answerCount} 回答`)
+          .fontSize($r('app.float.p1_secondary_font_size'))
+          .fontColor($r('app.color.secondary_text'))
+          .width('100%')
+      }
+      .alignItems(HorizontalAlign.Start)
+      .layoutWeight(1)
     }
-    this.input = query;
-    this.controller?.submit(query);
+    .id(`p2_search_person_${item.id}`)
+    .width('100%')
+    .padding({ top: 8, bottom: 8 })
+    .alignItems(VerticalAlign.Center)
+    .accessibilityText(`打开用户主页：${stripEmphasis(item.name)}`)
+    .onClick(() => this.openPerson(item))
   }
 
-  private applyState(state: SearchViewState): void {
-    this.phase = state.phase;
-    this.query = state.query;
-    this.items = state.items;
-    this.loadingMore = state.loadingMore;
-    this.canLoadMore = state.canLoadMore;
-    this.requiresLogin = state.requiresLogin;
-    this.errorMessage = state.errorMessage ?? '';
+  @Builder
+  private topicRow(item: SearchTopicItem) {
+    Row({ space: 12 }) {
+      if (item.avatarUrl !== undefined && item.avatarUrl.length > 0) {
+        Image(item.avatarUrl)
+          .width(48)
+          .height(48)
+          .borderRadius(24)
+          .objectFit(ImageFit.Cover)
+      }
+      Column({ space: 4 }) {
+        this.highlightedText(item.name, $r('app.float.p1_heading_font_size'),
+          $r('app.color.primary_text'), FontWeight.Medium)
+        if (item.excerpt.length > 0) {
+          Text(stripEmphasis(item.excerpt))
+            .fontSize($r('app.float.p1_secondary_font_size'))
+            .fontColor($r('app.color.secondary_text'))
+            .maxLines(2)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .width('100%')
+        }
+        Text(`${formatSearchCount(item.visitCount)} 浏览 · ${formatSearchCount(item.discussCount)} 讨论`)
+          .fontSize($r('app.float.p1_secondary_font_size'))
+          .fontColor($r('app.color.secondary_text'))
+          .width('100%')
+      }
+      .alignItems(HorizontalAlign.Start)
+      .layoutWeight(1)
+    }
+    .id(`p2_search_topic_${item.id}`)
+    .width('100%')
+    .padding({ top: 8, bottom: 8 })
+    .alignItems(VerticalAlign.Center)
+    .accessibilityText(`在浏览器打开话题：${stripEmphasis(item.name)}`)
+    .onClick(() => this.openTopicInBrowser(item))
+  }
+
+  private openPerson(item: SearchPersonItem): void {
+    const identifier = isSafePeopleIdentifier(item.id) ? item.id :
+      (item.urlToken !== undefined && isSafePeopleIdentifier(item.urlToken) ? item.urlToken : undefined);
+    if (identifier === undefined) {
+      return;
+    }
+    this.navigate({ name: P1DestinationName.PEOPLE, id: identifier });
+  }
+
+  private async openTopicInBrowser(item: SearchTopicItem): Promise<void> {
+    const context = getAbilityContext();
+    if (context === undefined || !/^[A-Za-z0-9_-]{1,64}$/.test(item.id)) {
+      return;
+    }
+    const want: Want = {
+      action: 'ohos.want.action.viewData',
+      uri: `https://www.zhihu.com/topic/${item.id}`
+    };
+    try {
+      await context.startAbility(want);
+    } catch (_error) {
+      this.getUIContext().getPromptAction().showToast({ message: '暂时无法打开话题页面' });
+    }
   }
 
   private openLogin(): void {
     this.navigate({ name: P1DestinationName.LOGIN });
   }
+}
+
+function formatSearchCount(value: number): string {
+  if (value >= 100000000) {
+    return `${(value / 100000000).toFixed(1)} 亿`;
+  }
+  if (value >= 10000) {
+    return `${(value / 10000).toFixed(1)} 万`;
+  }
+  return `${value}`;
 }
 
 export function searchResultDestination(item: SearchResultItem): P1Destination {
@@ -443,35 +685,4 @@ export function searchKindLabel(kind: FeedTargetKind): string {
     return '回答';
   }
   return '文章';
-}
-
-export function isSearchResultFilter(value: number): boolean {
-  return value === SearchResultFilter.ALL || value === SearchResultFilter.QUESTION ||
-    value === SearchResultFilter.ANSWER || value === SearchResultFilter.ARTICLE;
-}
-
-export function searchResultFilterLabel(filter: number): string {
-  if (filter === SearchResultFilter.QUESTION) {
-    return '问题';
-  }
-  if (filter === SearchResultFilter.ANSWER) {
-    return '回答';
-  }
-  if (filter === SearchResultFilter.ARTICLE) {
-    return '文章';
-  }
-  return '综合';
-}
-
-export function filterSearchResults(items: Array<SearchResultItem>, filter: number): Array<SearchResultItem> {
-  if (filter === SearchResultFilter.QUESTION) {
-    return items.filter((item: SearchResultItem): boolean => item.kind === FeedTargetKind.QUESTION);
-  }
-  if (filter === SearchResultFilter.ANSWER) {
-    return items.filter((item: SearchResultItem): boolean => item.kind === FeedTargetKind.ANSWER);
-  }
-  if (filter === SearchResultFilter.ARTICLE) {
-    return items.filter((item: SearchResultItem): boolean => item.kind === FeedTargetKind.ARTICLE);
-  }
-  return items.slice();
 }

--- a/entry/src/main/ets/pages/SearchState.ets
+++ b/entry/src/main/ets/pages/SearchState.ets
@@ -3,10 +3,14 @@ import {
   HttpFailureKind,
   SearchDecodeError,
   SearchDecodeFailureKind,
+  SearchEntity,
+  SearchFilters,
+  searchEntityIdentity,
   SearchRepository,
-  SearchResultItem,
   SearchResultPage,
-  searchResultIdentity
+  SearchSortOption,
+  SearchTab,
+  SearchTimeRange
 } from 'data';
 
 export enum SearchPhase {
@@ -20,7 +24,10 @@ export enum SearchPhase {
 export interface SearchViewState {
   readonly phase: SearchPhase;
   readonly query: string;
-  readonly items: Array<SearchResultItem>;
+  readonly entities: Array<SearchEntity>;
+  readonly activeTab: SearchTab;
+  readonly sort: SearchSortOption;
+  readonly timeRange: SearchTimeRange;
   readonly loadingMore: boolean;
   readonly canLoadMore: boolean;
   readonly requiresLogin: boolean;
@@ -36,7 +43,9 @@ export class SearchController {
   private generation: number = 0;
   private phase: SearchPhase = SearchPhase.IDLE;
   private query: string = '';
-  private items: Array<SearchResultItem> = [];
+  private entities: Array<SearchEntity> = [];
+  private tab: SearchTab = SearchTab.GENERAL;
+  private filters: SearchFilters = { sort: SearchSortOption.DEFAULT, timeRange: SearchTimeRange.ALL };
   private loadingMore: boolean = false;
   private nextCursor?: string;
   private reachedEnd: boolean = true;
@@ -59,6 +68,7 @@ export class SearchController {
     this.active = true;
     if (this.restartFirstPageOnActivate && this.query.length > 0) {
       this.restartFirstPageOnActivate = false;
+      // 绕过 reload 的 LOADING 守卫：失活时被中断的首页请求在复活时原样重启（对齐上游）。
       this.submit(this.query);
       return;
     }
@@ -80,7 +90,10 @@ export class SearchController {
     return {
       phase: this.phase,
       query: this.query,
-      items: this.items.slice(),
+      entities: this.entities.slice(),
+      activeTab: this.tab,
+      sort: this.filters.sort,
+      timeRange: this.filters.timeRange,
       loadingMore: this.loadingMore,
       canLoadMore: !this.paginationBlocked && this.hasNextPage(),
       requiresLogin: this.requiresLogin,
@@ -94,31 +107,32 @@ export class SearchController {
     }
     const query = rawQuery.trim();
     this.repository.cancel();
-    const generation = ++this.generation;
+    this.generation += 1;
     this.query = query;
-    this.items = [];
-    this.loadingMore = false;
-    this.nextCursor = undefined;
-    this.reachedEnd = true;
-    this.retryLoadMore = false;
-    this.paginationBlocked = false;
-    this.requiresLogin = false;
-    this.errorMessage = undefined;
-    if (query.length === 0) {
-      this.phase = SearchPhase.IDLE;
-      this.emit();
-      return Promise.resolve();
-    }
-    this.phase = SearchPhase.LOADING;
-    this.emit();
-    return this.loadFirstPage(query, generation);
+    // 新搜索回到综合 tab（对齐上游每次搜索新建 ViewModel 的行为），筛选保留本页会话选择。
+    this.tab = SearchTab.GENERAL;
+    return this.resetForReload(query.length > 0);
   }
 
-  refresh(): Promise<void> {
-    if (!this.active || this.phase === SearchPhase.LOADING || this.loadingMore || this.query.length === 0) {
+  selectTab(tab: SearchTab): Promise<void> {
+    if (!this.active || tab === this.tab || this.query.length === 0) {
       return Promise.resolve();
     }
-    return this.submit(this.query);
+    this.repository.cancel();
+    this.generation += 1;
+    this.tab = tab;
+    return this.resetForReload(true);
+  }
+
+  updateFilters(sort: SearchSortOption, timeRange: SearchTimeRange): Promise<void> {
+    if (!this.active || this.query.length === 0 ||
+      (sort === this.filters.sort && timeRange === this.filters.timeRange)) {
+      return Promise.resolve();
+    }
+    this.repository.cancel();
+    this.generation += 1;
+    this.filters = { sort: sort, timeRange: timeRange };
+    return this.resetForReload(true);
   }
 
   retry(): Promise<void> {
@@ -126,7 +140,36 @@ export class SearchController {
       this.paginationBlocked = false;
       return this.loadMore();
     }
-    return this.refresh();
+    return this.reload();
+  }
+
+  private resetForReload(loading: boolean): Promise<void> {
+    this.entities = [];
+    this.loadingMore = false;
+    this.nextCursor = undefined;
+    this.reachedEnd = true;
+    this.retryLoadMore = false;
+    this.paginationBlocked = false;
+    this.requiresLogin = false;
+    this.errorMessage = undefined;
+    if (!loading) {
+      this.phase = SearchPhase.IDLE;
+      this.emit();
+      return Promise.resolve();
+    }
+    this.phase = SearchPhase.LOADING;
+    this.emit();
+    return this.loadFirstPage(this.query, this.generation);
+  }
+
+  private reload(): Promise<void> {
+    if (!this.active || this.phase === SearchPhase.LOADING || this.loadingMore ||
+      this.query.length === 0) {
+      return Promise.resolve();
+    }
+    this.repository.cancel();
+    this.generation += 1;
+    return this.resetForReload(true);
   }
 
   async loadMore(): Promise<void> {
@@ -146,28 +189,20 @@ export class SearchController {
     this.errorMessage = undefined;
     this.emit();
     try {
-      const page = await this.repository.search(this.query, cursor);
+      const page = await this.repository.search(this.query, this.filters, this.tab, cursor);
       if (!this.isCurrent(generation)) {
         return;
       }
-      this.items = mergeSearchResults(this.items, page.items);
+      this.entities = mergeSearchEntities(this.entities, page.entities);
       this.applyCursor(page);
-      this.phase = this.items.length > 0 ? SearchPhase.READY : SearchPhase.EMPTY;
-      this.retryLoadMore = this.items.length === 0 && this.hasNextPage();
+      this.phase = this.entities.length > 0 ? SearchPhase.READY : SearchPhase.EMPTY;
+      this.retryLoadMore = this.entities.length === 0 && this.hasNextPage();
     } catch (error) {
       if (!this.isCurrent(generation)) {
         return;
       }
-      let authenticationStatus: number | undefined = undefined;
-      let authenticationFailure: boolean = false;
-      if (error instanceof HttpFailure && error.kind === HttpFailureKind.AUTHENTICATION) {
-        authenticationFailure = true;
-        authenticationStatus = error.status;
-      }
-      this.requiresLogin = authenticationFailure &&
-        (authenticationStatus === undefined || authenticationStatus === 401);
-      this.errorMessage = searchErrorMessage(error, this.requiresLogin, authenticationStatus, true);
-      this.phase = this.items.length > 0 ? SearchPhase.READY : SearchPhase.ERROR;
+      this.applyLoadFailure(error as Object, true);
+      this.phase = this.entities.length > 0 ? SearchPhase.READY : SearchPhase.ERROR;
       this.retryLoadMore = true;
       this.paginationBlocked = true;
     } finally {
@@ -180,33 +215,37 @@ export class SearchController {
 
   private async loadFirstPage(query: string, generation: number): Promise<void> {
     try {
-      const page = await this.repository.search(query);
+      const page = await this.repository.search(query, this.filters, this.tab);
       if (!this.isCurrent(generation)) {
         return;
       }
-      this.items = mergeSearchResults([], page.items);
+      this.entities = mergeSearchEntities([], page.entities);
       this.applyCursor(page);
-      this.phase = this.items.length > 0 ? SearchPhase.READY : SearchPhase.EMPTY;
-      this.retryLoadMore = this.items.length === 0 && this.hasNextPage();
+      this.phase = this.entities.length > 0 ? SearchPhase.READY : SearchPhase.EMPTY;
+      this.retryLoadMore = this.entities.length === 0 && this.hasNextPage();
     } catch (error) {
       if (!this.isCurrent(generation)) {
         return;
       }
       this.phase = SearchPhase.ERROR;
-      let authenticationStatus: number | undefined = undefined;
-      let authenticationFailure: boolean = false;
-      if (error instanceof HttpFailure && error.kind === HttpFailureKind.AUTHENTICATION) {
-        authenticationFailure = true;
-        authenticationStatus = error.status;
-      }
-      this.requiresLogin = authenticationFailure &&
-        (authenticationStatus === undefined || authenticationStatus === 401);
-      this.errorMessage = searchErrorMessage(error, this.requiresLogin, authenticationStatus, false);
+      this.applyLoadFailure(error as Object, false);
     } finally {
       if (this.isCurrent(generation)) {
         this.emit();
       }
     }
+  }
+
+  private applyLoadFailure(error: Object, loadingMore: boolean): void {
+    let authenticationStatus: number | undefined = undefined;
+    let authenticationFailure: boolean = false;
+    if (error instanceof HttpFailure && error.kind === HttpFailureKind.AUTHENTICATION) {
+      authenticationFailure = true;
+      authenticationStatus = error.status;
+    }
+    this.requiresLogin = authenticationFailure &&
+      (authenticationStatus === undefined || authenticationStatus === 401);
+    this.errorMessage = searchErrorMessage(error, this.requiresLogin, authenticationStatus, loadingMore);
   }
 
   private applyCursor(page: SearchResultPage): void {
@@ -230,7 +269,7 @@ export class SearchController {
   }
 }
 
-function searchErrorMessage(error: Error, requiresLogin: boolean, authenticationStatus: number | undefined,
+function searchErrorMessage(error: Object, requiresLogin: boolean, authenticationStatus: number | undefined,
   loadingMore: boolean): string {
   const action = loadingMore ? '加载更多搜索结果' : '搜索';
   if (authenticationStatus === 403) {
@@ -261,15 +300,15 @@ function searchErrorMessage(error: Error, requiresLogin: boolean, authentication
   return `${action}失败，请检查网络后重试`;
 }
 
-export function mergeSearchResults(current: Array<SearchResultItem>, incoming: Array<SearchResultItem>):
-  Array<SearchResultItem> {
-  const merged: Array<SearchResultItem> = [];
+export function mergeSearchEntities(current: Array<SearchEntity>, incoming: Array<SearchEntity>):
+  Array<SearchEntity> {
+  const merged: Array<SearchEntity> = [];
   const identities: Set<string> = new Set<string>();
-  current.concat(incoming).forEach((item: SearchResultItem): void => {
-    const identity = searchResultIdentity(item);
+  current.concat(incoming).forEach((entity: SearchEntity): void => {
+    const identity = searchEntityIdentity(entity);
     if (!identities.has(identity)) {
       identities.add(identity);
-      merged.push(item);
+      merged.push(entity);
     }
   });
   return merged;

--- a/entry/src/main/ets/pages/SearchTitleBar.ets
+++ b/entry/src/main/ets/pages/SearchTitleBar.ets
@@ -1,0 +1,205 @@
+import { SearchSortOption, SearchTimeRange } from 'data';
+
+/**
+ * 搜索页 HDS 标题栏注入内容：返回键 + 搜索框 + 排序方式菜单。
+ * 与 SearchPage 分属 HdsNavDestination 的 stackBuilder 与内容两棵子树，经 AppStorage 键通信
+ * （同 questionTitleStates 模式）；键在 SearchPage aboutToAppear 初始化，仅一个搜索页活跃。
+ */
+export const SEARCH_INPUT_VALUE_KEY = 'searchInputValue';
+export const SEARCH_SUBMIT_QUERY_KEY = 'searchSubmitQuery';
+export const SEARCH_SUBMIT_TICK_KEY = 'searchSubmitTick';
+export const SEARCH_FILTER_ENABLED_KEY = 'searchFilterEnabled';
+export const SEARCH_SORT_OPTION_KEY = 'searchSortOption';
+export const SEARCH_TIME_RANGE_KEY = 'searchTimeRange';
+export const SEARCH_FILTER_TICK_KEY = 'searchFilterTick';
+/** SearchPage 每次进入递增此键，标题栏据此强制清空输入框（TextInput 内部状态优先，外部 text 绑定不生效）。 */
+export const SEARCH_INPUT_ENTRY_TICK_KEY = 'searchInputEntryTick';
+
+export function publishSearchInputValue(value: string): void {
+  AppStorage.setOrCreate(SEARCH_INPUT_VALUE_KEY, value);
+}
+
+export function publishSearchSubmit(query: string): void {
+  AppStorage.setOrCreate(SEARCH_SUBMIT_QUERY_KEY, query);
+  AppStorage.setOrCreate(SEARCH_SUBMIT_TICK_KEY, (AppStorage.get<number>(SEARCH_SUBMIT_TICK_KEY) ?? 0) + 1);
+}
+
+interface SearchMenuOption {
+  readonly label: string;
+  readonly value: string;
+}
+
+const SORT_OPTIONS: Array<SearchMenuOption> = [
+  { label: '综合排序', value: SearchSortOption.DEFAULT },
+  { label: '最新发布', value: SearchSortOption.LATEST },
+  { label: '最多赞同', value: SearchSortOption.MOST_VOTED }
+];
+
+const TIME_RANGE_OPTIONS: Array<SearchMenuOption> = [
+  { label: '不限时间', value: SearchTimeRange.ALL },
+  { label: '一天内', value: SearchTimeRange.DAY },
+  { label: '一周内', value: SearchTimeRange.WEEK },
+  { label: '一个月内', value: SearchTimeRange.MONTH },
+  { label: '三个月内', value: SearchTimeRange.THREE_MONTHS },
+  { label: '半年内', value: SearchTimeRange.HALF_YEAR },
+  { label: '一年内', value: SearchTimeRange.YEAR }
+];
+
+@Component
+export struct SearchTitleBar {
+  // @StorageProp 键用字面量（装饰器要求编译期常量），值与上方导出的常量一一对应。
+  // TextInput 组件状态为内部优先，外部 text 绑定对已挂载实例（标题栏节点复用）不强制更新；
+  // 重进页面时用 controller.deleteText() 强制清空旧输入。
+  private readonly textController: TextInputController = new TextInputController();
+  @StorageProp('searchInputValue') private inputValue: string = '';
+  @StorageProp('searchInputEntryTick') @Watch('onEntryTick') private entryTick: number = 0;
+  @StorageProp('searchFilterEnabled') private filterEnabled: boolean = false;
+  @State private menuVisible: boolean = false;
+  @StorageProp('searchSortOption') private sortOption: string = SearchSortOption.DEFAULT;
+  @StorageProp('searchTimeRange') private timeRange: string = SearchTimeRange.ALL;
+  private lastEntryTick: number = -1;
+
+  private onEntryTick(): void {
+    this.resetForEntry();
+  }
+
+  private writeInput(value: string): void {
+    publishSearchInputValue(value);
+  }
+
+  /** 页面重进（SearchPage 递增 entryTick）时强制清空输入框，防止上次搜索内容残留。 */
+  private resetForEntry(): void {
+    if (this.entryTick === this.lastEntryTick) {
+      return;
+    }
+    this.lastEntryTick = this.entryTick;
+    this.textController.deleteText();
+    publishSearchInputValue('');
+  }
+
+  private selectOption(key: string, value: string): void {
+    AppStorage.setOrCreate(key, value);
+    AppStorage.setOrCreate(SEARCH_FILTER_TICK_KEY,
+      (AppStorage.get<number>(SEARCH_FILTER_TICK_KEY) ?? 0) + 1);
+    this.menuVisible = false;
+  }
+
+  private submitInput(): void {
+    const query = this.inputValue.trim();
+    if (query.length === 0) {
+      return;
+    }
+    publishSearchSubmit(query);
+  }
+
+  @Builder
+  private menuSection(title: string, options: Array<SearchMenuOption>, selected: string, key: string) {
+    Text(title)
+      .fontSize(12)
+      .fontColor($r('app.color.secondary_text'))
+      .padding({ left: 16, right: 16, top: 8, bottom: 4 })
+    ForEach(options, (option: SearchMenuOption) => {
+      Row({ space: 8 }) {
+        SymbolGlyph($r('sys.symbol.checkmark'))
+          .fontSize(16)
+          .fontColor([$r('app.color.brand_primary')])
+          .opacity(option.value === selected ? 1 : 0)
+        Text(option.label)
+          .fontSize(14)
+          .fontColor($r('app.color.primary_text'))
+      }
+      .width('100%')
+      .padding({ left: 16, right: 24, top: 10, bottom: 10 })
+      .onClick((): void => this.selectOption(key, option.value))
+    }, (option: SearchMenuOption): string => `${option.value}`)
+  }
+
+  @Builder
+  private filterMenu() {
+    Column() {
+      this.menuSection('排序', SORT_OPTIONS, this.sortOption, SEARCH_SORT_OPTION_KEY)
+      Divider().color($r('app.color.control_background')).margin({ top: 4, bottom: 4 })
+      this.menuSection('时间范围', TIME_RANGE_OPTIONS, this.timeRange, SEARCH_TIME_RANGE_KEY)
+    }
+    .width(180)
+    .backgroundColor($r('app.color.surface_background'))
+    .borderRadius($r('app.float.p1_card_radius'))
+  }
+
+  build() {
+    Row({ space: 8 }) {
+      // 返回键由 HDS 标题栏默认 backIcon 承载（P1Shell 传入 action），这里从其右侧起排，
+      // 避免自绘返回键与默认返回键重叠（28vp 错位的双箭头）。
+      Row({ space: 4 }) {
+        SymbolGlyph($r('sys.symbol.magnifyingglass'))
+          .fontSize(18)
+          .fontColor([$r('app.color.secondary_text')])
+        TextInput({ text: this.inputValue, placeholder: '搜索知乎内容', controller: this.textController })
+          .id('p2_search_input')
+          .layoutWeight(1)
+          .fontSize($r('app.float.p1_body_font_size'))
+          .maxLength(200)
+          .enterKeyType(EnterKeyType.Search)
+          .backgroundColor(Color.Transparent)
+          .padding(0)
+          .onChange((value: string): void => {
+            this.writeInput(value);
+          })
+          .onSubmit((): void => {
+            this.submitInput();
+          })
+
+        if (this.inputValue.length > 0) {
+          Button({ type: ButtonType.Normal, stateEffect: true }) {
+            SymbolGlyph($r('sys.symbol.xmark'))
+              .fontSize(14)
+              .fontColor([$r('app.color.secondary_text')])
+          }
+          .id('p2_search_clear')
+          .width(28)
+          .height(28)
+          .padding(0)
+          .backgroundColor(Color.Transparent)
+          .accessibilityText('清除搜索内容')
+          .onClick((): void => {
+            this.writeInput('');
+          })
+        }
+      }
+      .id('p2_search_input_container')
+      .layoutWeight(1)
+      .height(40)
+      .padding({ left: 12, right: 6 })
+      .backgroundColor($r('app.color.control_background'))
+      .borderRadius(20)
+      .alignItems(VerticalAlign.Center)
+
+      Button({ type: ButtonType.Normal, stateEffect: true }) {
+        SymbolGlyph($r('sys.symbol.line_3_horizontal'))
+          .fontSize(20)
+          .fontColor([$r('app.color.primary_text')])
+          .opacity(this.filterEnabled ? 1 : 0.35)
+      }
+      .id('p2_search_filter')
+      .width(40)
+      .height(40)
+      .padding(0)
+      .backgroundColor(Color.Transparent)
+      .enabled(this.filterEnabled)
+      .accessibilityText('排序方式')
+      .onClick((): void => {
+        this.menuVisible = !this.menuVisible;
+      })
+      .bindMenu(this.menuVisible, this.filterMenu())
+    }
+    .id('p2_search_title_bar')
+    .width('100%')
+    .height(48)
+    // 左侧 64vp 让出 HDS 默认返回键的区域（实测 36/48 会压到其触摸区）。
+    .padding({ left: 64, right: 8 })
+    .alignItems(VerticalAlign.Center)
+    .onAppear((): void => {
+      this.resetForEntry();
+    })
+  }
+}

--- a/entry/src/main/ets/pages/components/FeedContentSummary.ets
+++ b/entry/src/main/ets/pages/components/FeedContentSummary.ets
@@ -1,0 +1,44 @@
+import { FeedTargetKind, FeedTargetSummary } from 'data';
+
+/** 信息流和问题回答卡片共享正文、作者及统计的排版。 */
+@Component
+export struct FeedContentSummary {
+  target: FeedTargetSummary = {
+    kind: FeedTargetKind.ANSWER, id: '', title: '', excerpt: '', url: '', voteupCount: 0, commentCount: 0,
+    topicIds: []
+  };
+  showTitle: boolean = true;
+
+  build() {
+    Column({ space: $r('app.float.p1_spacing_small') }) {
+      if (this.showTitle && this.target.title.length > 0) {
+        Text(this.target.title)
+          .fontSize($r('app.float.p1_heading_font_size'))
+          .fontWeight(FontWeight.Medium)
+          .fontColor($r('app.color.primary_text'))
+          .maxLines(2)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .width('100%')
+      }
+      Row({ space: 8 }) {
+        if ((this.target.author?.avatarUrl ?? '').length > 0) {
+          Image(this.target.author?.avatarUrl)
+            .width(24).height(24).borderRadius(12).objectFit(ImageFit.Cover)
+        }
+        Text(this.target.author?.name || '知乎用户')
+          .fontSize($r('app.float.p1_secondary_font_size'))
+          .fontColor($r('app.color.secondary_text'))
+          .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis }).layoutWeight(1)
+      }.width('100%')
+      if (this.target.excerpt.trim().length > 0) {
+        Text(this.target.excerpt)
+          .fontSize($r('app.float.p1_body_font_size'))
+          .fontColor($r('app.color.primary_text'))
+          .maxLines(3).textOverflow({ overflow: TextOverflow.Ellipsis }).width('100%')
+      }
+      Text(`${this.target.voteupCount} 赞同 · ${this.target.commentCount} 评论`)
+        .fontSize($r('app.float.p1_secondary_font_size'))
+        .fontColor($r('app.color.secondary_text'))
+    }.width('100%').alignItems(HorizontalAlign.Start)
+  }
+}

--- a/entry/src/main/ets/pages/components/FeedContentSummary.ets
+++ b/entry/src/main/ets/pages/components/FeedContentSummary.ets
@@ -8,6 +8,7 @@ export struct FeedContentSummary {
     topicIds: []
   };
   showTitle: boolean = true;
+  showStatistics: boolean = true;
 
   build() {
     Column({ space: $r('app.float.p1_spacing_small') }) {
@@ -36,9 +37,11 @@ export struct FeedContentSummary {
           .fontColor($r('app.color.primary_text'))
           .maxLines(3).textOverflow({ overflow: TextOverflow.Ellipsis }).width('100%')
       }
-      Text(`${this.target.voteupCount} 赞同 · ${this.target.commentCount} 评论`)
-        .fontSize($r('app.float.p1_secondary_font_size'))
-        .fontColor($r('app.color.secondary_text'))
+      if (this.showStatistics) {
+        Text(`${this.target.voteupCount} 赞同 · ${this.target.commentCount} 评论`)
+          .fontSize($r('app.float.p1_secondary_font_size'))
+          .fontColor($r('app.color.secondary_text'))
+      }
     }.width('100%').alignItems(HorizontalAlign.Start)
   }
 }

--- a/entry/src/main/ets/pages/components/FollowingUsersRow.ets
+++ b/entry/src/main/ets/pages/components/FollowingUsersRow.ets
@@ -1,0 +1,82 @@
+import { P1Destination, P1DestinationName } from 'core';
+import { RecentFollowingUser, RecentFollowingUsersRepository } from 'data';
+
+/**
+ * 关注推荐页顶部“最近更新的关注用户”头像行，对齐上游 FollowingUsersRow：
+ * 横向滚动头像 + 未读红点 + 昵称，点击进入用户主页；加载失败时静默收起整行。
+ */
+@Component
+export struct FollowingUsersRow {
+  repository: RecentFollowingUsersRepository | undefined = undefined;
+  navigate: (destination: P1Destination) => void = (_destination: P1Destination): void => {
+  };
+  @State private users: Array<RecentFollowingUser> = [];
+  private loaded: boolean = false;
+
+  aboutToAppear(): void {
+    this.loadUsers();
+  }
+
+  private loadUsers(): void {
+    const repository = this.repository;
+    if (repository === undefined || this.loaded || this.users.length > 0) {
+      return;
+    }
+    this.loaded = true;
+    repository.loadRecentUsers().then((users: Array<RecentFollowingUser>): void => {
+      this.users = users;
+    }).catch((): void => {
+      // 对齐上游：关注行加载失败仅不展示，不打断推荐流。
+    });
+  }
+
+  build() {
+    if (this.users.length > 0) {
+      Scroll() {
+        Row({ space: 16 }) {
+          ForEach(this.users, (user: RecentFollowingUser) => {
+            Column({ space: 4 }) {
+              Stack({ alignContent: Alignment.TopEnd }) {
+                Image(user.actor.avatarUrl)
+                  .width(56)
+                  .height(56)
+                  .borderRadius(28)
+                  .objectFit(ImageFit.Cover)
+                  .alt(user.actor.name)
+                if (user.unreadCount > 0) {
+                  Circle()
+                    .width(10)
+                    .height(10)
+                    .fill('#FF4D4F')
+                    .stroke('#FFFFFF')
+                    .strokeWidth(1.5)
+                    .margin({ top: 2, right: 2 })
+                }
+              }
+              .width(56)
+              .height(56)
+              Text(user.actor.name)
+                .fontSize(12)
+                .fontColor($r('app.color.secondary_text'))
+                .maxLines(1)
+                .textOverflow({ overflow: TextOverflow.Ellipsis })
+                .width(60)
+                .textAlign(TextAlign.Center)
+            }
+            .id(`p2_following_users_item_${user.actor.id}`)
+            .alignItems(HorizontalAlign.Center)
+            .onClick((): void => {
+              this.navigate({ name: P1DestinationName.PEOPLE, id: user.actor.urlToken });
+            })
+          }, (user: RecentFollowingUser): string => user.actor.id)
+        }
+        .padding({ left: 12, right: 12, top: 8, bottom: 8 })
+      }
+      .id('p2_following_users_row')
+      .width('100%')
+      .scrollable(ScrollDirection.Horizontal)
+      .scrollBar(BarState.Off)
+      .edgeEffect(EdgeEffect.Spring)
+    }
+  }
+}

--- a/entry/src/main/ets/pages/components/HotQuestionStatistics.ets
+++ b/entry/src/main/ets/pages/components/HotQuestionStatistics.ets
@@ -1,0 +1,92 @@
+import { ContentRepository, FeedTargetKind, FeedTargetSummary, Question } from 'data';
+
+/** 热榜不提供浏览量；仅在卡片进入可见区域后补取问题统计。 */
+@Component
+export struct HotQuestionStatistics {
+  @Prop @Watch('resetStatistics') target: FeedTargetSummary = {
+    kind: FeedTargetKind.QUESTION, id: '', title: '', excerpt: '', url: '', voteupCount: 0,
+    commentCount: 0, topicIds: []
+  };
+  repositoryFactory: () => ContentRepository | undefined = () => undefined;
+  @State private question?: Question = undefined;
+  private repository?: ContentRepository;
+  private generation: number = 0;
+  private loading: boolean = false;
+  private visible: boolean = false;
+
+  aboutToDisappear(): void {
+    this.visible = false;
+    this.cancelRequest();
+  }
+
+  private cancelRequest(): void {
+    this.generation += 1;
+    this.repository?.cancel();
+    this.repository = undefined;
+    this.loading = false;
+  }
+
+  private resetStatistics(): void {
+    this.cancelRequest();
+    this.question = undefined;
+    if (this.visible) {
+      this.loadStatistics();
+    }
+  }
+
+  private async loadStatistics(): Promise<void> {
+    if (this.loading || this.question !== undefined || this.target.kind !== FeedTargetKind.QUESTION) {
+      return;
+    }
+    const repository = this.repositoryFactory();
+    if (repository === undefined) {
+      return;
+    }
+    this.repository = repository;
+    this.loading = true;
+    const generation = this.generation;
+    try {
+      const question = await repository.getQuestion(this.target.id);
+      if (generation === this.generation) {
+        this.question = question;
+      }
+    } catch (_error) {
+      // 补查失败保留热榜已有统计，缺失浏览量显示占位符。
+    } finally {
+      if (generation === this.generation) {
+        this.loading = false;
+        this.repository = undefined;
+      }
+    }
+  }
+
+  build() {
+    Flex({ wrap: FlexWrap.Wrap }) {
+      Text(`${this.question?.answerCount ?? this.target.answerCount ?? '—'} 回答`)
+        .fontSize($r('app.float.p1_secondary_font_size'))
+        .fontColor($r('app.color.secondary_text'))
+        .margin({ right: 12, bottom: 4 })
+      Text(`${this.question?.visitCount ?? this.target.visitCount ?? '—'} 浏览`)
+        .fontSize($r('app.float.p1_secondary_font_size'))
+        .fontColor($r('app.color.secondary_text'))
+        .margin({ right: 12, bottom: 4 })
+      Text(`${this.question?.commentCount ?? this.target.commentCount} 评论`)
+        .fontSize($r('app.float.p1_secondary_font_size'))
+        .fontColor($r('app.color.secondary_text'))
+        .margin({ right: 12, bottom: 4 })
+      Text(`${this.question?.followerCount ?? this.target.followerCount ?? '—'} 关注`)
+        .fontSize($r('app.float.p1_secondary_font_size'))
+        .fontColor($r('app.color.secondary_text'))
+        .margin({ right: 12, bottom: 4 })
+    }
+    .width('100%')
+    .id(`p2_channel_hot_statistics_${this.target.id}`)
+    // 使用正阈值，确保首次从完全不可见进入屏幕时触发补查。
+    .onVisibleAreaChange([0.01], (visible: boolean): void => {
+      this.visible = visible;
+      if (visible) {
+        this.loadStatistics();
+      }
+    })
+  }
+}

--- a/entry/src/main/ets/platform/HapticFeedback.ets
+++ b/entry/src/main/ets/platform/HapticFeedback.ets
@@ -1,0 +1,21 @@
+import { vibrator } from '@kit.SensorServiceKit';
+
+/**
+ * Confirm 级震感（对齐上游 HapticFeedbackType.Confirm，用于双击赞成等轻确认操作）。
+ * 模拟器或无振动器件会直接抛错/拒绝，静默降级不影响业务流程。
+ */
+export function performConfirmHaptic(): void {
+  const effect: vibrator.VibratePreset = {
+    type: 'preset',
+    effectId: vibrator.HapticFeedback.EFFECT_SOFT,
+    count: 1
+  };
+  const attribute: vibrator.VibrateAttribute = {
+    usage: 'touch'
+  };
+  try {
+    vibrator.startVibration(effect, attribute).catch((_error: Object): void => {
+    });
+  } catch (_error) {
+  }
+}

--- a/entry/src/main/ets/platform/ShareContracts.ets
+++ b/entry/src/main/ets/platform/ShareContracts.ets
@@ -48,6 +48,8 @@ export interface ShareTextPayload {
   readonly title: string;
   readonly summary: string;
   readonly contentUrl: string;
+  /** 可选：受信 zhimg 图片 URL，用于系统分享面板的链接卡片缩略图。 */
+  readonly thumbnailUrl?: string;
 }
 
 export interface ShareTemporaryFile {
@@ -89,6 +91,8 @@ export interface PreparedSharePayload {
   readonly mimeType: string;
   /** 只会是受信知乎 HTTPS URL 或已经通过专用 cache 目录检查的临时文件路径。 */
   readonly source: string;
+  /** 仅 TEXT 链接可能有：已通过 zhimg 域白名单校验的缩略图 URL。 */
+  readonly thumbnailUrl?: string;
 }
 
 export interface TemporaryShareLifecycle {
@@ -117,13 +121,24 @@ export function prepareSharePayload(payload: SharePayload, policy: ShareRuntimeP
   const summary = normalizeSummary(payload.summary);
   if (payload.kind === SharePayloadKind.TEXT) {
     const contentUrl = normalizeTrustedContentUrl(payload.contentUrl);
-    return {
+    const thumbnailUrl = payload.thumbnailUrl === undefined ?
+      undefined : normalizeTrustedImageUrl(payload.thumbnailUrl);
+    const prepared: PreparedSharePayload = {
       kind: SharePayloadKind.TEXT,
       dispatchKind: ShareDispatchKind.TEXT_LINK,
       title: title,
       summary: summary,
       mimeType: 'text/plain',
       source: contentUrl
+    };
+    return thumbnailUrl === undefined ? prepared : {
+      kind: prepared.kind,
+      dispatchKind: prepared.dispatchKind,
+      title: prepared.title,
+      summary: prepared.summary,
+      mimeType: prepared.mimeType,
+      source: prepared.source,
+      thumbnailUrl: thumbnailUrl
     };
   }
   if (payload.kind === SharePayloadKind.IMAGE) {

--- a/entry/src/main/ets/platform/SystemBars.ets
+++ b/entry/src/main/ets/platform/SystemBars.ets
@@ -1,0 +1,21 @@
+import { window } from '@kit.ArkUI';
+import { getAbilityContext } from '../entryability/AbilityContextHolder';
+
+/**
+ * 隐藏/恢复状态栏（对齐上游 ArticleImmersiveModeEffect：沉浸式真全屏，只藏 statusBars）。
+ * 隐藏后 TYPE_SYSTEM 避让区归零，avoidAreaChange 监听会把 statusBarHeight 刷成 0，
+ * 页面顶部留空随之收起；恢复时反向还原。
+ */
+export function setStatusBarHidden(hidden: boolean): void {
+  const context = getAbilityContext();
+  try {
+    const mainWindow = context?.windowStage?.getMainWindowSync();
+    if (mainWindow === undefined) {
+      return;
+    }
+    mainWindow.setWindowSystemBarEnable(hidden ? ['navigation'] : ['status', 'navigation'])
+      .catch((_error: Object): void => {
+      });
+  } catch (_error) {
+  }
+}

--- a/entry/src/main/ets/platform/SystemShareService.ets
+++ b/entry/src/main/ets/platform/SystemShareService.ets
@@ -1,5 +1,10 @@
-import { common, Want, wantConstant } from '@kit.AbilityKit';
+import { common } from '@kit.AbilityKit';
 import { fileUri } from '@kit.CoreFileKit';
+import { image } from '@kit.ImageKit';
+import { http } from '@kit.NetworkKit';
+import { systemShare } from '@kit.ShareKit';
+import { BusinessError } from '@ohos.base';
+import uniformTypeDescriptor from '@ohos.data.uniformTypeDescriptor';
 import {
   PreparedSharePayload,
   prepareSharePayload,
@@ -13,27 +18,32 @@ import {
   toShareFailure
 } from './ShareContracts';
 
-const SEND_DATA_ACTION: string = 'ohos.want.action.sendData';
-const CONTENT_TITLE_PARAMETER: string = 'ohos.extra.param.key.contentTitle';
-const SHARE_ABSTRACT_PARAMETER: string = 'ohos.extra.param.key.shareAbstract';
-const SHARE_URL_PARAMETER: string = 'ohos.extra.param.key.shareUrl';
-const STREAM_PARAMETER: string = 'ability.params.stream';
+/** 系统面板缩略图上限：want 数据超 32 KB 会导致 Share Kit 启动失败。 */
+const MAX_THUMBNAIL_BYTES: number = 32 * 1024;
+const THUMBNAIL_MAX_EDGE: number = 240;
+const THUMBNAIL_QUALITIES: Array<number> = [80, 55, 35];
 
-/** 不向业务页面泄露 Want；测试可注入 recording launcher。 */
-export interface ShareAbilityLauncher {
-  startShare(want: SystemShareWant): Promise<void>;
+/** 不向业务页面泄露系统分享面板细节；测试可注入 recording launcher。 */
+export interface SharePanelLauncher {
+  showPanel(records: Array<ShareRecordSpec>): Promise<void>;
 }
 
 export interface ShareFileUriResolver {
   getUriFromPath(path: string): string;
 }
 
-export interface SystemShareWant {
-  readonly action: string;
-  readonly type: string;
-  readonly uri: string;
-  readonly flags?: number;
-  readonly parameters: Record<string, Object>;
+/** 尽力获取链接卡片缩略图；失败返回 undefined，不阻断分享。 */
+export interface ShareThumbnailFetcher {
+  fetchThumbnail(url: string): Promise<Uint8Array | undefined>;
+}
+
+export interface ShareRecordSpec {
+  readonly utd: string;
+  readonly title?: string;
+  readonly description?: string;
+  readonly content?: string;
+  readonly uri?: string;
+  readonly thumbnail?: Uint8Array;
 }
 
 class AppFileUriResolver implements ShareFileUriResolver {
@@ -47,18 +57,21 @@ class AppFileUriResolver implements ShareFileUriResolver {
 }
 
 export class SystemShareService implements ShareService {
-  private readonly launcher: ShareAbilityLauncher;
+  private readonly launcher: SharePanelLauncher;
   private readonly policy: ShareRuntimePolicy;
   private readonly fileUriResolver: ShareFileUriResolver;
+  private readonly thumbnailFetcher?: ShareThumbnailFetcher;
 
   constructor(
-    launcher: ShareAbilityLauncher,
+    launcher: SharePanelLauncher,
     policy: ShareRuntimePolicy,
-    fileUriResolver: ShareFileUriResolver
+    fileUriResolver: ShareFileUriResolver,
+    thumbnailFetcher?: ShareThumbnailFetcher
   ) {
     this.launcher = launcher;
     this.policy = policy;
     this.fileUriResolver = fileUriResolver;
+    this.thumbnailFetcher = thumbnailFetcher;
   }
 
   async share(payload: SharePayload): Promise<ShareOutcome> {
@@ -66,35 +79,126 @@ export class SystemShareService implements ShareService {
       cacheDir: this.policy.cacheDir,
       nowMillis: Date.now()
     });
+    const thumbnail = await this.fetchThumbnailBestEffort(prepared.thumbnailUrl);
     try {
-      await this.launcher.startShare(createSystemShareWant(prepared, this.fileUriResolver));
+      await this.launcher.showPanel(
+        createSystemShareRecords(prepared, this.fileUriResolver, thumbnail)
+      );
       return ShareOutcome.OPENED;
     } catch (error) {
-      const failure = toShareFailure(error instanceof Error ? error : new Error('share launch failed'));
+      const failure = toShareFailure(error instanceof Error ? error : new Error('share panel failed'));
       if (failure.kind === ShareFailureKind.CANCELLED) {
         return ShareOutcome.CANCELLED;
       }
       throw failure;
     }
   }
+
+  private async fetchThumbnailBestEffort(url: string | undefined): Promise<Uint8Array | undefined> {
+    if (url === undefined || this.thumbnailFetcher === undefined) {
+      return undefined;
+    }
+    try {
+      return await this.thumbnailFetcher.fetchThumbnail(url);
+    } catch (_error) {
+      return undefined;
+    }
+  }
 }
 
-export class AbilityContextShareLauncher implements ShareAbilityLauncher {
+export class SystemSharePanelLauncher implements SharePanelLauncher {
   private readonly context: common.UIAbilityContext;
 
   constructor(context: common.UIAbilityContext) {
     this.context = context;
   }
 
-  async startShare(want: SystemShareWant): Promise<void> {
-    const nativeWant: Want = {
-      action: want.action,
-      type: want.type,
-      uri: want.uri,
-      flags: want.flags,
-      parameters: want.parameters
-    };
-    await this.context.startAbility(nativeWant);
+  async showPanel(records: Array<ShareRecordSpec>): Promise<void> {
+    const sharedData = new systemShare.SharedData(toSharedRecord(records[0]));
+    for (let index = 1; index < records.length; index++) {
+      sharedData.addRecord(toSharedRecord(records[index]));
+    }
+    const controller = new systemShare.ShareController(sharedData);
+    const options: systemShare.ShareControllerOptions = {};
+    try {
+      await controller.show(this.context, options);
+    } catch (error) {
+      const businessError = error as BusinessError;
+      throw new Error(`${businessError.code}: ${businessError.message}`);
+    }
+  }
+}
+
+/** 下载受信 zhimg 图片并压缩到面板缩略图限制内；任何失败都返回 undefined。 */
+export class HttpShareThumbnailFetcher implements ShareThumbnailFetcher {
+  async fetchThumbnail(url: string): Promise<Uint8Array | undefined> {
+    const buffer = await HttpShareThumbnailFetcher.download(url);
+    if (buffer === undefined) {
+      return undefined;
+    }
+    return await HttpShareThumbnailFetcher.downscale(buffer);
+  }
+
+  private static async download(url: string): Promise<ArrayBuffer | undefined> {
+    const request = http.createHttp();
+    try {
+      const options: http.HttpRequestOptions = {
+        method: http.RequestMethod.GET,
+        expectDataType: http.HttpDataType.ARRAY_BUFFER,
+        connectTimeout: 3000,
+        readTimeout: 5000
+      };
+      const response = await request.request(url, options);
+      if (response.responseCode !== 200) {
+        return undefined;
+      }
+      const result = response.result;
+      return result instanceof ArrayBuffer ? result : undefined;
+    } catch (_error) {
+      return undefined;
+    } finally {
+      request.destroy();
+    }
+  }
+
+  private static async downscale(buffer: ArrayBuffer): Promise<Uint8Array | undefined> {
+    const source = image.createImageSource(buffer);
+    try {
+      const imageInfo: image.ImageInfo = await source.getImageInfo();
+      const longestEdge = Math.max(imageInfo.size.width, imageInfo.size.height);
+      if (longestEdge <= 0) {
+        return undefined;
+      }
+      const scale = Math.min(1, THUMBNAIL_MAX_EDGE / longestEdge);
+      const decodingOptions: image.DecodingOptions = {
+        desiredSize: {
+          width: Math.max(1, Math.round(imageInfo.size.width * scale)),
+          height: Math.max(1, Math.round(imageInfo.size.height * scale))
+        }
+      };
+      const pixelMap = await source.createPixelMap(decodingOptions);
+      try {
+        const packer = image.createImagePacker();
+        try {
+          for (const quality of THUMBNAIL_QUALITIES) {
+            const packingOptions: image.PackingOption = { format: 'image/jpeg', quality: quality };
+            const packed = await packer.packToData(pixelMap, packingOptions);
+            if (packed.byteLength > 0 && packed.byteLength <= MAX_THUMBNAIL_BYTES) {
+              return new Uint8Array(packed);
+            }
+          }
+          return undefined;
+        } finally {
+          packer.release();
+        }
+      } finally {
+        pixelMap.release();
+      }
+    } catch (_error) {
+      return undefined;
+    } finally {
+      await source.release();
+    }
   }
 }
 
@@ -103,45 +207,62 @@ export function createSystemShareService(context: common.UIAbilityContext): Syst
     cacheDir: context.cacheDir,
     nowMillis: Date.now()
   };
-  return new SystemShareService(new AbilityContextShareLauncher(context), policy, new AppFileUriResolver());
+  return new SystemShareService(
+    new SystemSharePanelLauncher(context),
+    policy,
+    new AppFileUriResolver(),
+    new HttpShareThumbnailFetcher()
+  );
 }
 
-export function createSystemShareWant(
+export function createSystemShareRecords(
   prepared: PreparedSharePayload,
-  fileUriResolver: ShareFileUriResolver
-): SystemShareWant {
+  fileUriResolver: ShareFileUriResolver,
+  thumbnail?: Uint8Array
+): Array<ShareRecordSpec> {
   if (prepared.dispatchKind === ShareDispatchKind.TEMPORARY_FILE) {
     const uri = fileUriResolver.getUriFromPath(prepared.source);
-    const want: SystemShareWant = {
-      action: SEND_DATA_ACTION,
-      type: prepared.mimeType,
-      uri: uri,
-      flags: wantConstant.Flags.FLAG_AUTH_READ_URI_PERMISSION,
-      parameters: temporaryFileParameters(prepared, uri)
+    const spec: ShareRecordSpec = {
+      utd: prepared.mimeType.startsWith('image/') ? uniformTypeDescriptor.UniformDataType.IMAGE : uniformTypeDescriptor.UniformDataType.FILE,
+      title: prepared.title,
+      uri: uri
     };
-    return want;
+    return [spec];
   }
-  const want: SystemShareWant = {
-    action: SEND_DATA_ACTION,
-    type: 'text/plain',
-    uri: prepared.source,
-    parameters: linkParameters(prepared)
+  const spec: ShareRecordSpec = {
+    utd: uniformTypeDescriptor.UniformDataType.HYPERLINK,
+    title: prepared.title,
+    description: prepared.summary,
+    content: prepared.source
   };
-  return want;
+  if (thumbnail !== undefined) {
+    return [{
+      utd: spec.utd,
+      title: spec.title,
+      description: spec.description,
+      content: spec.content,
+      thumbnail: thumbnail
+    }];
+  }
+  return [spec];
 }
 
-function temporaryFileParameters(prepared: PreparedSharePayload, uri: string): Record<string, Object> {
-  const parameters: Record<string, Object> = {};
-  parameters[CONTENT_TITLE_PARAMETER] = prepared.title;
-  parameters[SHARE_ABSTRACT_PARAMETER] = prepared.summary;
-  parameters[STREAM_PARAMETER] = [uri];
-  return parameters;
-}
-
-function linkParameters(prepared: PreparedSharePayload): Record<string, Object> {
-  const parameters: Record<string, Object> = {};
-  parameters[CONTENT_TITLE_PARAMETER] = prepared.title;
-  parameters[SHARE_ABSTRACT_PARAMETER] = prepared.summary;
-  parameters[SHARE_URL_PARAMETER] = prepared.source;
-  return parameters;
+function toSharedRecord(spec: ShareRecordSpec): systemShare.SharedRecord {
+  const record: systemShare.SharedRecord = { utd: spec.utd };
+  if (spec.title !== undefined) {
+    record.title = spec.title;
+  }
+  if (spec.description !== undefined) {
+    record.description = spec.description;
+  }
+  if (spec.content !== undefined) {
+    record.content = spec.content;
+  }
+  if (spec.uri !== undefined) {
+    record.uri = spec.uri;
+  }
+  if (spec.thumbnail !== undefined) {
+    record.thumbnail = spec.thumbnail;
+  }
+  return record;
 }

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -17,6 +17,9 @@
         "name": "ohos.permission.INTERNET"
       },
       {
+        "name": "ohos.permission.VIBRATE"
+      },
+      {
         "name": "ohos.permission.WRITE_IMAGEVIDEO",
         "reason": "$string:write_imagevideo_reason",
         "usedScene": {

--- a/entry/src/main/resources/base/element/float.json
+++ b/entry/src/main/resources/base/element/float.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "p1_page_padding",
-      "value": "20vp"
+      "value": "12vp"
     },
     {
       "name": "p1_card_padding",

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "EntryAbility_label",
-      "value": "Zhihu++"
+      "value": "知乎++"
     },
     {
       "name": "write_imagevideo_reason",

--- a/entry/src/test/AppUpdateParser.test.ets
+++ b/entry/src/test/AppUpdateParser.test.ets
@@ -2,10 +2,13 @@ import { describe, expect, it } from '@ohos/hypium';
 import {
   AppUpdateCheckStatus,
   AppUpdateRelease,
+  AUTO_UPDATE_CHECK_INTERVAL_MS,
   compareVersionNames,
   decodeLatestRelease,
+  isUpdateAnnouncementVisible,
   parseHmosTagVersion,
-  resolveAppUpdateCheck
+  resolveAppUpdateCheck,
+  shouldAutoCheckForUpdate
 } from 'data';
 
 function releaseFixture(tag: string, version: string): AppUpdateRelease {
@@ -73,6 +76,20 @@ export default function appUpdateParserTest(): void {
       const failed = resolveAppUpdateCheck('0.2.1', undefined, '网络不可用');
       expect(failed.status).assertEqual(AppUpdateCheckStatus.FAILED);
       expect(failed.message).assertEqual('网络不可用');
+    });
+
+    it('throttlesAutoCheckByInterval', 0, () => {
+      expect(shouldAutoCheckForUpdate(0, 1000)).assertTrue();
+      expect(shouldAutoCheckForUpdate(1000, 1000 + AUTO_UPDATE_CHECK_INTERVAL_MS)).assertTrue();
+      expect(shouldAutoCheckForUpdate(1000, 1000 + AUTO_UPDATE_CHECK_INTERVAL_MS - 1)).assertFalse();
+      expect(shouldAutoCheckForUpdate(5000, 1000)).assertFalse();
+    });
+
+    it('gatesUpdateAnnouncementVisibility', 0, () => {
+      expect(isUpdateAnnouncementVisible('0.3.3', '')).assertTrue();
+      expect(isUpdateAnnouncementVisible('0.3.3', '0.3.2')).assertTrue();
+      expect(isUpdateAnnouncementVisible('0.3.3', '0.3.3')).assertFalse();
+      expect(isUpdateAnnouncementVisible('', '')).assertFalse();
     });
   });
 }

--- a/entry/src/test/BackStackState.test.ets
+++ b/entry/src/test/BackStackState.test.ets
@@ -19,9 +19,14 @@ import {
   FeedRepository,
   FeedTargetKind,
   LoginSessionGateway,
+  SearchEntity,
+  SearchFilters,
+  SearchHotItem,
   SearchRepository,
   SearchResultItem,
   SearchResultPage,
+  SearchTab,
+  searchEntityOfContent,
   SessionCookie,
   SessionLoginOperation,
   SessionState,
@@ -113,9 +118,13 @@ class CountingSearchRepository implements SearchRepository {
     this.page = page;
   }
 
-  search(_query: string, _cursor?: string): Promise<SearchResultPage> {
+  search(_query: string, _filters?: SearchFilters, _tab?: SearchTab, _cursor?: string): Promise<SearchResultPage> {
     this.searchCount += 1;
     return Promise.resolve(this.page);
+  }
+
+  hotSearch(): Promise<Array<SearchHotItem>> {
+    return Promise.resolve([]);
   }
 
   cancel(): void {
@@ -245,7 +254,7 @@ function searchResult(contentId: string, kind: FeedTargetKind = FeedTargetKind.A
 
 function searchPage(items: Array<SearchResultItem>, next?: string, isEnd: boolean = false): SearchResultPage {
   return {
-    items: items,
+    entities: items.map((item: SearchResultItem): SearchEntity => searchEntityOfContent(item)),
     cursor: {
       isEnd: isEnd,
       isStart: true,
@@ -417,13 +426,13 @@ export default function backStackStateTest(): void {
       controller.activate();
       await controller.submit('arkts');
       expect(controller.snapshot().phase).assertEqual(SearchPhase.READY);
-      expect(controller.snapshot().items.length).assertEqual(1);
+      expect(controller.snapshot().entities.length).assertEqual(1);
 
       controller.deactivate();
       controller.activate();
 
       expect(controller.snapshot().phase).assertEqual(SearchPhase.READY);
-      expect(controller.snapshot().items.length).assertEqual(1);
+      expect(controller.snapshot().entities.length).assertEqual(1);
       expect(repository.searchCount).assertEqual(1);
     });
   });

--- a/entry/src/test/ChannelFeedRepository.test.ets
+++ b/entry/src/test/ChannelFeedRepository.test.ets
@@ -168,6 +168,7 @@ const FOLLOW_PAGE_WITH_TARGETLESS = '{"data":[{"type":"feed","id":"agg-1","verb"
   '"paging":{"is_end":true}}';
 const HOT_PAGE = '{"data":[{"type":"hot_list_feed","id":"hot-wrapper","detail_text":"1234 万热度",' +
   '"target":{"type":"question","id":1993016651038364760,"title":"热榜问题",' +
+  '"answer_count":123,"comment_count":7,"follower_count":456,' +
   '"bound_topic_ids":[1,"2",1]}}],' +
   '"paging":{"is_end":true}}';
 const FILTER_PAGE = '{"data":[{"id":"blocked","target":{"type":"question","id":"202",' +
@@ -283,6 +284,10 @@ export default function channelFeedRepositoryTest(): void {
         expect(hot.items[0].feedItem.actionText).assertEqual('1234 万热度');
         expect(hot.items[0].feedItem.target.id).assertEqual('1993016651038364760');
         expect(hot.items[0].topicIds.join(',')).assertEqual('1,2');
+        expect(hot.items[0].feedItem.target.answerCount).assertEqual(123);
+        expect(hot.items[0].feedItem.target.commentCount).assertEqual(7);
+        expect(hot.items[0].feedItem.target.followerCount).assertEqual(456);
+        expect(hot.items[0].feedItem.target.visitCount).assertUndefined();
       } else {
         expect(false).assertTrue();
       }

--- a/entry/src/test/ChannelFeedRepository.test.ets
+++ b/entry/src/test/ChannelFeedRepository.test.ets
@@ -189,7 +189,7 @@ export default function channelFeedRepositoryTest(): void {
         'https://daily.zhihu.com/api/4/stories/latest'
       );
       expect(buildChannelFeedRequestUrl(ChannelFeedSource.DAILY, '20260810')).assertEqual(
-        'https://daily.zhihu.com/api/4/stories/before/20260811'
+        'https://daily.zhihu.com/api/4/stories/before/20260810'
       );
       expect(canonicalChannelFeedCursorKey(
         ChannelFeedSource.FOLLOWING,
@@ -342,6 +342,7 @@ export default function channelFeedRepositoryTest(): void {
       expect(latest.items[0].kind).assertEqual(ChannelFeedItemKind.DAILY_STORY);
       expect(latest.cursor.next).assertEqual('20260811');
       expect(factory.requests[0].url).assertEqual('https://daily.zhihu.com/api/4/stories/latest');
+      expect(factory.requests[1].url).assertEqual('https://daily.zhihu.com/api/4/stories/before/20260811');
       expect(factory.requests[0].headers.Cookie).assertUndefined();
       expect(JSON.stringify(factory.requests[0].headers).includes('x-zse-')).assertFalse();
       expect(older.items.length).assertEqual(0);
@@ -350,7 +351,46 @@ export default function channelFeedRepositoryTest(): void {
 
       const selectedDate = await repository.loadPage(ChannelFeedSource.DAILY, '20260810', true);
       expect(selectedDate.items.length).assertEqual(1);
-        expect(factory.requests[2].url).assertEqual('https://daily.zhihu.com/api/4/stories/before/20260811');
+      expect(factory.requests[2].url).assertEqual('https://daily.zhihu.com/api/4/stories/before/20260811');
+    });
+
+    it('loadsConsecutiveDailyEditionsAcrossYearBoundary', 0, async () => {
+      const factory = new SequenceChannelTransportFactory([
+        new ChannelOutcome(new TestHttpResponse(200, dailyEdition('20260101', '1'))),
+        new ChannelOutcome(new TestHttpResponse(200, dailyEdition('20251231', '2'))),
+        new ChannelOutcome(new TestHttpResponse(200, dailyEdition('20251230', '3')))
+      ]);
+      const repository = new DefaultChannelFeedRepository(new ZhihuHttpClient(undefined, factory));
+      const first = await repository.loadPage(ChannelFeedSource.DAILY);
+      const second = await repository.loadPage(ChannelFeedSource.DAILY, first.cursor.next);
+      const third = await repository.loadPage(ChannelFeedSource.DAILY, second.cursor.next);
+      expect(factory.requests[1].url).assertEqual('https://daily.zhihu.com/api/4/stories/before/20260101');
+      expect(factory.requests[2].url).assertEqual('https://daily.zhihu.com/api/4/stories/before/20251231');
+      expect(first.items.length + second.items.length + third.items.length).assertEqual(3);
+      expect(third.cursor.next).assertEqual('20251230');
+      expect(third.cursor.isEnd).assertFalse();
+    });
+
+    it('selectsExactDateThenContinuesHistoryAndAllowsReselecting', 0, async () => {
+      const factory = new SequenceChannelTransportFactory([
+        new ChannelOutcome(new TestHttpResponse(200, dailyEdition('20240229', '1'))),
+        new ChannelOutcome(new TestHttpResponse(200, dailyEdition('20240228', '2'))),
+        new ChannelOutcome(new TestHttpResponse(200, dailyEdition('20240229', '1'))),
+        new ChannelOutcome(new TestHttpResponse(200, dailyEdition('20251231', '3')))
+      ]);
+      const repository = new DefaultChannelFeedRepository(new ZhihuHttpClient(undefined, factory));
+      const selected = await repository.loadPage(ChannelFeedSource.DAILY, '20240229', true);
+      expect(selected.cursor.isEnd).assertFalse();
+      const older = await repository.loadPage(ChannelFeedSource.DAILY, selected.cursor.next);
+      expect(older.items.length).assertEqual(1);
+      expect(older.cursor.next).assertEqual('20240228');
+      const reselected = await repository.loadPage(ChannelFeedSource.DAILY, '20240229', true);
+      expect(reselected.items.length).assertEqual(1);
+      await repository.loadPage(ChannelFeedSource.DAILY, '20251231', true);
+      expect(factory.requests[0].url).assertEqual('https://daily.zhihu.com/api/4/stories/before/20240301');
+      expect(factory.requests[1].url).assertEqual('https://daily.zhihu.com/api/4/stories/before/20240229');
+      expect(factory.requests[2].url).assertEqual(factory.requests[0].url);
+      expect(factory.requests[3].url).assertEqual('https://daily.zhihu.com/api/4/stories/before/20260101');
     });
 
     it('fallsBackOnlyWhenPrimaryHostResolutionFails', 0, async () => {
@@ -419,4 +459,8 @@ export default function channelFeedRepositoryTest(): void {
       expect(factory.requests.length).assertEqual(3);
     });
   });
+}
+
+function dailyEdition(date: string, id: string): string {
+  return `{"date":"${date}","stories":[{"id":${id},"title":"日报标题","hint":"作者","images":[]}]}`;
 }

--- a/entry/src/test/ChannelFeedState.test.ets
+++ b/entry/src/test/ChannelFeedState.test.ets
@@ -13,6 +13,7 @@ import {
 } from 'data';
 import { P1DestinationName } from 'core';
 import { channelFeedDestination } from '../main/ets/pages/ChannelFeedPage';
+import { dailyFeedDateAtIndex, dailyDateCursor, dailyPickerDate } from '../main/ets/pages/DailyFeedDates';
 import {
   ChannelFeedController,
   ChannelFeedPhase,
@@ -153,6 +154,35 @@ export default function channelFeedStateTest(): void {
       expect((controller.snapshot().items[0] as ChannelDailyStoryItem).story.id).assertEqual('selected');
     });
 
+    it('retriesTheSelectedDailyDateAndRefreshesBackToLatest', 0, async () => {
+      const repository = new ControlledChannelRepository();
+      const controller = new ChannelFeedController(ChannelFeedSource.DAILY, repository);
+      controller.activate();
+      const selected = controller.loadDate('20260808');
+      repository.fail(0);
+      await selected;
+      const retried = controller.retry();
+      expect(repository.cursors[1]).assertEqual('20260808');
+      expect(repository.resetFlags[1]).assertTrue();
+      repository.succeed(1, page([daily('1')], '20260808'));
+      await retried;
+      const refreshed = controller.refresh();
+      expect(repository.cursors[2]).assertUndefined();
+      repository.succeed(2, page([daily('2')], '20260904'));
+      await refreshed;
+    });
+
+    it('resolvesVisibleDailyDateAcrossSectionsAndLoadingFooter', 0, () => {
+      const first = daily('1') as ChannelDailyStoryItem;
+      const older = daily('2', '20260810');
+      const items: Array<ChannelFeedItem> = [first, first, older];
+      expect(dailyFeedDateAtIndex(items, 1)).assertEqual(first.story.date);
+      expect(dailyFeedDateAtIndex(items, 2)).assertEqual('20260810');
+      expect(dailyFeedDateAtIndex(items, 3)).assertEqual('20260810');
+      expect(dailyFeedDateAtIndex([], 0)).assertEqual('');
+      expect(dailyDateCursor(dailyPickerDate('20240229'))).assertEqual('20240229');
+    });
+
     it('continuesAfterEmptyNonTerminalPage', 0, async () => {
       const repository = new ControlledChannelRepository();
       const controller = new ChannelFeedController(ChannelFeedSource.HOT, repository);
@@ -275,7 +305,7 @@ function content(id: string, kind: FeedTargetKind = FeedTargetKind.ANSWER): Chan
   };
 }
 
-function daily(id: string): ChannelFeedItem {
+function daily(id: string, date: string = '20260811'): ChannelFeedItem {
   return {
     kind: ChannelFeedItemKind.DAILY_STORY,
     story: {
@@ -284,7 +314,7 @@ function daily(id: string): ChannelFeedItem {
       hint: 'hint',
       url: `https://daily.zhihu.com/story/${id}`,
       storyType: 0,
-      date: '20260811'
+      date: date
     }
   };
 }

--- a/entry/src/test/CommentRepository.test.ets
+++ b/entry/src/test/CommentRepository.test.ets
@@ -1,7 +1,6 @@
 import { describe, expect, it } from '@ohos/hypium';
 import {
   buildChildCommentsUrl,
-  buildCommentLikeBody,
   buildCommentLikeUrl,
   buildDeleteCommentUrl,
   buildRootCommentsUrl,
@@ -116,8 +115,7 @@ export default function commentRepositoryTest(): void {
         'https://www.zhihu.com/api/v4/comment_v5/answers/456/comment'
       );
       expect(buildDeleteCommentUrl('1001')).assertEqual('https://www.zhihu.com/api/v4/comments/1001');
-      expect(buildCommentLikeUrl('1001')).assertEqual('https://www.zhihu.com/api/v4/comments/1001/voters');
-      expect(buildCommentLikeBody()).assertEqual('{"type":"up"}');
+      expect(buildCommentLikeUrl('1001')).assertEqual('https://www.zhihu.com/api/v4/comments/1001/like');
 
       expect(escapeCommentHtml('<a href="x">&</a>')).assertEqual(
         '&lt;a href=&quot;x&quot;&gt;&amp;&lt;/a&gt;'
@@ -373,7 +371,7 @@ export default function commentRepositoryTest(): void {
       expect(JSON.stringify(request.headers).includes('"x-zse-96":"2.0_')).assertTrue();
     });
 
-    it('togglesCommentLikeWithVotersPostAndDelete', 0, async () => {
+    it('togglesCommentLikeWithBodylessSignedPostAndDelete', 0, async () => {
       const factory = new CommentTransportFactory([
         { statusCode: 200, body: '{}' },
         { statusCode: 200, body: '{}' }
@@ -386,15 +384,15 @@ export default function commentRepositoryTest(): void {
 
       expect(factory.requests.length).assertEqual(2);
       const like = factory.requests[0];
-      expect(like.url).assertEqual('https://www.zhihu.com/api/v4/comments/1001/voters');
+      expect(like.url).assertEqual('https://www.zhihu.com/api/v4/comments/1001/like');
       expect(like.method).assertEqual(ZhihuHttpMethod.POST);
-      expect(like.body).assertEqual('{"type":"up"}');
+      expect(like.body).assertUndefined();
       expect(JSON.stringify(like.headers).includes('"x-zse-96":"2.0_')).assertTrue();
 
       const unlike = factory.requests[1];
-      expect(unlike.url).assertEqual('https://www.zhihu.com/api/v4/comments/1001/voters');
+      expect(unlike.url).assertEqual('https://www.zhihu.com/api/v4/comments/1001/like');
       expect(unlike.method).assertEqual(ZhihuHttpMethod.DELETE);
-      expect(unlike.body).assertEqual('{"type":"up"}');
+      expect(unlike.body).assertUndefined();
     });
 
     it('rejectsRepeatedCursorAndStopsPagination', 0, async () => {

--- a/entry/src/test/CommentState.test.ets
+++ b/entry/src/test/CommentState.test.ets
@@ -5,6 +5,7 @@ import {
   CommentPage,
   CommentRepository,
   CommentSortOrder,
+  copyCommentWithLike,
   HttpFailure,
   HttpFailureKind,
   LoginSessionGateway,
@@ -17,8 +18,10 @@ import {
 import {
   CommentController,
   CommentPhase,
+  CommentViewState,
   mergeComments
 } from '../main/ets/pages/CommentState';
+import { CommentLikeStateStore } from '../main/ets/pages/CommentLikeState';
 
 const ROOT_CURSOR =
   'https://www.zhihu.com/api/v4/comment_v5/answers/456/root_comment?order_by=score&limit=20&offset=20';
@@ -430,6 +433,107 @@ export default function commentStateTest(): void {
       expect(controller.snapshot().items[0].likeCount).assertEqual(4);
       expect(controller.snapshot().actionMessage).assertEqual('点赞操作失败，请重试');
       expect(controller.snapshot().likeBusy).assertFalse();
+    });
+
+    it('likesPinnedRootAndSynchronizesRootListAfterReturning', 0, async () => {
+      const repository = new ControlledCommentRepository();
+      const root = comment('1', '根评论');
+      repository.setRootPage({ items: [root], cursor: { isEnd: true, isStart: true, page: 0, total: 0 } });
+      const controller = new CommentController(CommentContentKind.ANSWER, '456', repository,
+        new TestSessionGateway(SessionStatus.AUTHENTICATED));
+      controller.activate();
+      await controller.loadInitial();
+      await controller.openChildComments(root);
+      await controller.toggleLike(root);
+      expect(repository.liked.length).assertEqual(1);
+      expect(controller.snapshot().activeRoot?.liked).assertTrue();
+      expect(controller.snapshot().activeRoot?.likeCount).assertEqual(4);
+      controller.closeChildComments();
+      expect(controller.snapshot().items[0].liked).assertTrue();
+      expect(controller.snapshot().items[0].likeCount).assertEqual(4);
+    });
+
+    it('likesInlineReplyAndRollsBackEveryCopyOnFailure', 0, async () => {
+      const repository = new ControlledCommentRepository();
+      const root = comment('1', '根评论');
+      const child = comment('10', '子评论');
+      root.childComments.push(child);
+      repository.setRootPage({ items: [root], cursor: { isEnd: true, isStart: true, page: 0, total: 0 } });
+      const controller = new CommentController(CommentContentKind.ANSWER, '456', repository,
+        new TestSessionGateway(SessionStatus.AUTHENTICATED));
+      controller.activate();
+      await controller.loadInitial();
+      await controller.toggleLike(child);
+      const updatedRoot = controller.snapshot().items[0];
+      expect(updatedRoot.childComments[0].liked).assertTrue();
+      expect(updatedRoot.childComments[0].likeCount).assertEqual(4);
+      repository.setChildPage({ items: [updatedRoot.childComments[0]],
+        cursor: { isEnd: true, isStart: true, page: 0, total: 0 } });
+      await controller.openChildComments(updatedRoot);
+      repository.failLike = true;
+      await controller.toggleLike(controller.snapshot().items[0]);
+      expect(controller.snapshot().items[0].liked).assertTrue();
+      expect(controller.snapshot().activeRoot?.childComments[0].likeCount).assertEqual(4);
+      expect(controller.snapshot().likeBusy).assertFalse();
+      repository.failLike = false;
+      await controller.toggleLike(controller.snapshot().items[0]);
+      controller.closeChildComments();
+      expect(controller.snapshot().items[0].childComments[0].liked).assertFalse();
+      expect(controller.snapshot().items[0].childComments[0].likeCount).assertEqual(3);
+    });
+
+    it('keepsOtherCommentObjectsAndLikeStatesStableDuringLikeAndRollback', 0, async () => {
+      const repository = new ControlledCommentRepository();
+      const root = comment('1', '根评论');
+      const child = comment('10', '回复');
+      const sibling = comment('11', '另一条回复');
+      const other = comment('2', '另一条评论');
+      root.childComments.push(child, sibling);
+      repository.setRootPage({ items: [root, other],
+        cursor: { isEnd: true, isStart: true, page: 0, total: 0 } });
+      const likes = new CommentLikeStateStore();
+      const controller = new CommentController(CommentContentKind.ANSWER, '456', repository,
+        new TestSessionGateway(SessionStatus.AUTHENTICATED),
+        (state: CommentViewState): void => likes.sync(state.items));
+      controller.activate();
+      await controller.loadInitial();
+      const childState = likes.get(child);
+      const siblingState = likes.get(sibling);
+      const otherState = likes.get(other);
+      repository.failLike = true;
+      const request = controller.toggleLike(child);
+      expect(controller.snapshot().likeBusy).assertTrue();
+      expect(childState.liked).assertTrue();
+      expect(childState.count).assertEqual(4);
+      expect(controller.snapshot().items[1] === other).assertTrue();
+      expect(controller.snapshot().items[0].childComments[1] === sibling).assertTrue();
+      expect(likes.get(controller.snapshot().items[0].childComments[0]) === childState).assertTrue();
+      expect(likes.get(sibling) === siblingState).assertTrue();
+      expect(likes.get(other) === otherState).assertTrue();
+      expect(otherState.liked).assertFalse();
+      expect(otherState.count).assertEqual(3);
+      await request;
+      expect(childState.liked).assertFalse();
+      expect(childState.count).assertEqual(3);
+      expect(controller.snapshot().items[1] === other).assertTrue();
+      expect(controller.snapshot().items[0].childComments[1] === sibling).assertTrue();
+      expect(likes.get(controller.snapshot().items[0].childComments[0]) === childState).assertTrue();
+      expect(controller.snapshot().likeBusy).assertFalse();
+    });
+
+    it('sharesOneLikeStateAcrossInlineAndChildViews', 0, () => {
+      const likes = new CommentLikeStateStore();
+      const root = comment('1', '根评论');
+      const child = comment('10', '回复');
+      root.childComments.push(child);
+      likes.sync([root]);
+      const state = likes.get(child);
+      const freshChild = copyCommentWithLike(child, true, 4);
+      likes.sync([freshChild]);
+      expect(likes.get(freshChild) === state).assertTrue();
+      expect(state.liked).assertTrue();
+      expect(state.count).assertEqual(4);
+      expect(likes.get(root).liked).assertFalse();
     });
 
     it('loginGateBlocksInteractionsForGuest', 0, async () => {

--- a/entry/src/test/ContentDetailState.test.ets
+++ b/entry/src/test/ContentDetailState.test.ets
@@ -11,14 +11,19 @@ import {
 import {
   ContentDetailController,
   ContentDetailPhase,
-  contentDetailIdentity
+  contentDetailIdentity,
+  LoadedAnswerDetail,
+  LoadedQuestionDetail
 } from '../main/ets/pages/ContentDetailState';
 import {
   contentContextTitle,
+  contentCreatedAtText,
   contentEmptyMessage,
   contentHtml,
   contentStatistics,
-  contentTitle
+  contentTitle,
+  contentUpdatedAtText,
+  formatContentDateTime
 } from '../main/ets/pages/ContentDetailPages';
 import { parseZhihuHtml, ReaderBlockKind, ReaderInlineKind } from 'reader';
 
@@ -223,6 +228,30 @@ export default function contentDetailStateTest(): void {
         'src="https://evil.example/formula.svg"></p>');
       expect(fallback[0].inlineRuns.length).assertEqual(0);
       expect(fallback[0].text.includes('secret')).assertTrue();
+    });
+
+    it('formatsAnswerPublishAndEditTimeLikeUpstreamDateTexts', 0, () => {
+      // 本地日历构造再取 unix 秒：期望值与被测函数同走本地时区，单双位数补零均覆盖。
+      const created = new Date(2026, 0, 2, 3, 4, 5);
+      const updated = new Date(2026, 8, 30, 23, 59, 0);
+      const answer = answerFixture();
+      answer.createdAt = Math.floor(created.getTime() / 1000);
+      answer.updatedAt = Math.floor(updated.getTime() / 1000);
+      const detail: LoadedAnswerDetail = { kind: ContentDetailKind.ANSWER, value: answer };
+
+      expect(formatContentDateTime(answer.createdAt)).assertEqual('2026-01-02 03:04');
+      expect(contentCreatedAtText(detail)).assertEqual('发布于 2026-01-02 03:04');
+      expect(contentUpdatedAtText(detail)).assertEqual('编辑于 2026-09-30 23:59');
+
+      // 编辑时间与发布相同（未编辑）不显示；非法时间戳返回空串；非回答类型返回空串。
+      answer.updatedAt = answer.createdAt;
+      expect(contentUpdatedAtText(detail)).assertEqual('');
+      answer.createdAt = 0;
+      expect(contentCreatedAtText(detail)).assertEqual('');
+      const question = questionFixture();
+      const questionDetail: LoadedQuestionDetail = { kind: ContentDetailKind.QUESTION, value: question };
+      expect(contentCreatedAtText(questionDetail)).assertEqual('');
+      expect(contentUpdatedAtText(questionDetail)).assertEqual('');
     });
   });
 }

--- a/entry/src/test/ContentInteractionState.test.ets
+++ b/entry/src/test/ContentInteractionState.test.ets
@@ -316,6 +316,42 @@ export default function contentInteractionStateTest(): void {
       expect(controller.snapshot().pending).assertTrue();
     });
 
+    it('doubleTapVoteUpSendsUpFromNeutralAndDown', 0, async () => {
+      const repository = new FakeVoteRepository();
+      const controller = new ContentVoteController(
+        repository, new FixedSessionGateway(SessionStatus.AUTHENTICATED),
+        ContentDetailKind.ANSWER, '2'
+      );
+      controller.activate();
+      controller.applyInitial(answerContent(ContentVoteState.NEUTRAL, 10, false, 0));
+
+      await controller.voteUpFromDoubleTap();
+      expect(repository.voteCalls.length).assertEqual(1);
+      expect(repository.voteCalls[0].state).assertEqual(ContentVoteState.UP);
+      expect(controller.snapshot().voteState).assertEqual(ContentVoteState.UP);
+
+      controller.applyInitial(answerContent(ContentVoteState.DOWN, 10, false, 0));
+      await controller.voteUpFromDoubleTap();
+      expect(repository.voteCalls.length).assertEqual(2);
+      expect(repository.voteCalls[1].state).assertEqual(ContentVoteState.UP);
+      expect(controller.snapshot().voteState).assertEqual(ContentVoteState.UP);
+    });
+
+    it('doubleTapVoteUpKeepsStateWhenAlreadyUpvoted', 0, async () => {
+      const repository = new FakeVoteRepository();
+      const controller = new ContentVoteController(
+        repository, new FixedSessionGateway(SessionStatus.AUTHENTICATED),
+        ContentDetailKind.ANSWER, '2'
+      );
+      controller.activate();
+      controller.applyInitial(answerContent(ContentVoteState.UP, 10, false, 0));
+
+      await controller.voteUpFromDoubleTap();
+      expect(repository.voteCalls.length).assertEqual(0);
+      expect(controller.snapshot().voteState).assertEqual(ContentVoteState.UP);
+      expect(controller.snapshot().voteupCount).assertEqual(10);
+    });
+
     it('followsOptimisticallyAndRollsBackOnFailure', 0, async () => {
       const repository = new FakeFollowRepository();
       repository.result = { followerCount: 99 };

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -23,6 +23,7 @@ import zhihuQrLoginClientTest from './ZhihuQrLoginClient.test';
 import searchRepositoryTest from './SearchRepository.test';
 import searchStateTest from './SearchState.test';
 import contentDetailRepositoryTest from './ContentDetailRepository.test';
+import questionAnswerFeedTest from './QuestionAnswerFeed.test';
 import contentDetailStateTest from './ContentDetailState.test';
 import loginControllerTest from './LoginController.test';
 import channelFeedRepositoryTest from './ChannelFeedRepository.test';
@@ -97,6 +98,7 @@ export default function testsuite(): void {
   searchRepositoryTest();
   searchStateTest();
   contentDetailRepositoryTest();
+  questionAnswerFeedTest();
   contentDetailStateTest();
   loginControllerTest();
   channelFeedRepositoryTest();

--- a/entry/src/test/OnlineHistoryRepository.test.ets
+++ b/entry/src/test/OnlineHistoryRepository.test.ets
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@ohos/hypium';
 import {
+  buildBatchDelBody,
   buildOnlineHistoryUrl,
   canonicalOnlineHistoryCursorKey,
   decodeOnlineHistoryPage,
@@ -10,14 +11,17 @@ import {
   OnlineHistoryDecodeError,
   OnlineHistoryDecodeFailureKind,
   OnlineHistoryKind,
+  ONLINE_HISTORY_BATCH_DEL_URL,
   OnlineHistoryRepositoryFailure,
   OnlineHistoryRepositoryFailureKind,
+  onlineHistoryDeletePairOf,
   onlineHistoryOffsetOf,
   PreparedZhihuHttpRequest,
   SessionCookie,
   SessionCookieProvider,
   ZhihuHttpClient,
   ZhihuHttpResponse,
+  ZhihuHttpMethod,
   ZhihuHttpTransport,
   ZhihuHttpTransportFactory
 } from 'data';
@@ -312,6 +316,57 @@ export default function onlineHistoryRepositoryTest(): void {
       expect(page.items.length).assertEqual(0);
       expect(page.cursor.isEnd).assertTrue();
       expect(page.cursor.next).assertUndefined();
+    });
+
+    it('clearAllPostsBatchDelWithClearFlagAndResetsPagination', 0, async () => {
+      const factory = new OnlineTransportFactory([
+        { statusCode: 200, body: FIRST_PAGE },
+        { statusCode: 200, body: '{"data":[],"paging":{"is_end":true}}' },
+        { statusCode: 200, body: FIRST_PAGE }
+      ]);
+      const repository = new DefaultOnlineHistoryRepository(
+        new ZhihuHttpClient(new OnlineCookieProvider(), factory)
+      );
+      await repository.loadPage();
+      await repository.clearAll();
+      const clearRequest = factory.requests[1];
+      expect(clearRequest.url).assertEqual(ONLINE_HISTORY_BATCH_DEL_URL);
+      expect(clearRequest.method).assertEqual(ZhihuHttpMethod.POST);
+      expect(clearRequest.body).assertEqual('{"pairs":[],"clear":true}');
+      // 清空后分页游标状态一并重置：可重新从首页拉取（对齐上游 displayItems.clear() 后的重新加载）。
+      const reload = await repository.loadPage();
+      expect(reload.items.length).assertEqual(4);
+      expect(factory.requests[2].url).assertEqual(`${ONLINE_BASE}?offset=0&limit=10`);
+    });
+
+    it('deleteEntryPostsSinglePairBuiltFromContentKey', 0, async () => {
+      const factory = new OnlineTransportFactory([{ statusCode: 200, body: '{"data":[]}' }]);
+      const repository = new DefaultOnlineHistoryRepository(
+        new ZhihuHttpClient(new OnlineCookieProvider(), factory)
+      );
+      await repository.deleteEntry('article:300001');
+      expect(factory.requests[0].url).assertEqual(ONLINE_HISTORY_BATCH_DEL_URL);
+      expect(factory.requests[0].method).assertEqual(ZhihuHttpMethod.POST);
+      expect(factory.requests[0].body)
+        .assertEqual('{"pairs":[{"content_token":"300001","content_type":"article"}],"clear":false}');
+      expect(buildBatchDelBody([onlineHistoryDeletePairOf('pin:42')], false))
+        .assertEqual('{"pairs":[{"content_token":"42","content_type":"pin"}],"clear":false}');
+    });
+
+    it('rejectsInvalidContentKeysForDeletion', 0, () => {
+      const invalidKeys: Array<string> = ['bad', 'answer:', ':123', 'answer:../123', 'video:123',
+        'answer:1:2', 'answer:0', 'article:not-a-number'];
+      invalidKeys.forEach((contentKey: string): void => {
+        let failure: OnlineHistoryRepositoryFailure | undefined = undefined;
+        try {
+          onlineHistoryDeletePairOf(contentKey);
+        } catch (error) {
+          if (error instanceof OnlineHistoryRepositoryFailure) {
+            failure = error;
+          }
+        }
+        expect(failure?.kind).assertEqual(OnlineHistoryRepositoryFailureKind.INVALID_CONTENT_KEY);
+      });
     });
 
     it('cancelsPendingTransportWithoutWaitingForItToSettle', 0, async () => {

--- a/entry/src/test/P1Navigation.test.ets
+++ b/entry/src/test/P1Navigation.test.ets
@@ -57,6 +57,7 @@ export default function p1NavigationTest(): void {
         P1DestinationName.BLOCKING_RULES,
         P1DestinationName.BLOCKED_FEED_HISTORY,
         P1DestinationName.READ_HISTORY,
+        P1DestinationName.LOCAL_HISTORY,
         P1DestinationName.TECHNICAL_LAB,
         P1DestinationName.READER_PROBE,
         P1DestinationName.IMAGE_PROBE,
@@ -297,7 +298,7 @@ export default function p1NavigationTest(): void {
       expect(decodeP1Destination(P1DestinationName.COLLECTIONS, oversizedCollectionsParam)).assertUndefined();
       [P1DestinationName.FOLLOWING, P1DestinationName.HOT, P1DestinationName.DAILY,
         P1DestinationName.BLOCKING_RULES, P1DestinationName.BLOCKED_FEED_HISTORY,
-        P1DestinationName.READ_HISTORY, P1DestinationName.PIN_DRAFTS]
+        P1DestinationName.READ_HISTORY, P1DestinationName.LOCAL_HISTORY, P1DestinationName.PIN_DRAFTS]
         .forEach((name: P1DestinationName): void => {
           const validParam: TestDestinationParam = { name: name };
           const invalidParam: TestDestinationParam = { name: name, id: 'unexpected' };

--- a/entry/src/test/P1Persistence.test.ets
+++ b/entry/src/test/P1Persistence.test.ets
@@ -1,8 +1,13 @@
 import { describe, expect, it } from '@ohos/hypium';
 import {
+  allAnswerDoubleTapActions,
+  answerDoubleTapActionLabel,
+  answerDoubleTapActionPreferenceValue,
+  AnswerDoubleTapAction,
   AppThemeMode,
   appPreferencesFailureMessage,
   DatabaseOpenPlan,
+  decodeAnswerDoubleTapAction,
   decodeAppThemeMode,
   pendingSchemaVersions,
   planDatabaseOpen
@@ -19,6 +24,28 @@ export default function p1PersistenceTest(): void {
     it('decodesPersistedThemeValues', 0, () => {
       expect(decodeAppThemeMode(AppThemeMode.LIGHT)).assertEqual(AppThemeMode.LIGHT);
       expect(decodeAppThemeMode(AppThemeMode.DARK)).assertEqual(AppThemeMode.DARK);
+    });
+
+    it('decodesAnswerDoubleTapActionPreferenceValues', 0, () => {
+      expect(decodeAnswerDoubleTapAction('none')).assertEqual(AnswerDoubleTapAction.NONE);
+      expect(decodeAnswerDoubleTapAction('ask')).assertEqual(AnswerDoubleTapAction.ASK);
+      expect(decodeAnswerDoubleTapAction('voteUp')).assertEqual(AnswerDoubleTapAction.VOTE_UP);
+      expect(decodeAnswerDoubleTapAction('openComments')).assertEqual(AnswerDoubleTapAction.OPEN_COMMENTS);
+      expect(decodeAnswerDoubleTapAction('toggleImmersive')).assertEqual(AnswerDoubleTapAction.TOGGLE_IMMERSIVE);
+      // 缺失/未知值一律回退 Ask（对齐上游 fromPreference）。
+      expect(decodeAnswerDoubleTapAction('')).assertEqual(AnswerDoubleTapAction.ASK);
+      expect(decodeAnswerDoubleTapAction('unknown')).assertEqual(AnswerDoubleTapAction.ASK);
+      expect(decodeAnswerDoubleTapAction(123)).assertEqual(AnswerDoubleTapAction.ASK);
+    });
+
+    it('roundTripsAnswerDoubleTapActionPreferenceValues', 0, () => {
+      const actions = allAnswerDoubleTapActions();
+      expect(actions.length).assertEqual(5);
+      actions.forEach((action: AnswerDoubleTapAction): void => {
+        expect(decodeAnswerDoubleTapAction(answerDoubleTapActionPreferenceValue(action))).assertEqual(action);
+      });
+      expect(answerDoubleTapActionLabel(AnswerDoubleTapAction.ASK)).assertEqual('询问并记住');
+      expect(answerDoubleTapActionLabel(AnswerDoubleTapAction.VOTE_UP)).assertEqual('点赞');
     });
 
     it('plansOnlyContiguousPendingMigrations', 0, () => {

--- a/entry/src/test/QuestionAnswerFeed.test.ets
+++ b/entry/src/test/QuestionAnswerFeed.test.ets
@@ -83,5 +83,62 @@ export default function questionAnswerFeedTest(): void {
       expect(repository.calls).assertEqual(1);
       navigator.dispose();
     });
+
+    it('navigatorSeedlessLocatesCurrentAndMovesToNext', 0, async () => {
+      // 信息流直达：无种子，控制器自动拉取问题回答列表后回填当前索引。
+      const repository = new FakeQuestionAnswerRepository([
+        { items: [content('1'), content('2'), content('3')],
+          cursor: { isEnd: false, isStart: true, next: 'next', page: 1, total: 3 } }
+      ]);
+      const navigator = new QuestionAnswerNavigator('123', '2', undefined, repository);
+      expect(navigator.hasNext()).assertFalse();
+      await new Promise<void>((resolve): void => { setTimeout(resolve, 0); });
+      expect(navigator.currentId()).assertEqual('2');
+      expect(navigator.hasNext()).assertTrue();
+      const preview = navigator.nextAnswerPreview();
+      expect(preview?.answerId).assertEqual('3');
+      expect(preview?.authorName).assertEqual('作者');
+      const previousPreview = navigator.previousAnswerPreview();
+      expect(previousPreview?.answerId).assertEqual('1');
+      expect(previousPreview?.authorName).assertEqual('作者');
+      expect(await navigator.move(1)).assertEqual('3');
+      expect(await navigator.move(-1)).assertEqual('2');
+      navigator.dispose();
+    });
+
+    it('navigatorPreviousPreviewNoneOnFirstAnswer', 0, async () => {
+      // 首答固定无上一答：预览接口返回 undefined，对应顶部过滑不生效。
+      const seed: QuestionAnswersViewState = {
+        phase: QuestionAnswersPhase.READY, items: [content('1'), content('2')], loadingMore: false,
+        canLoadMore: false, sortOrder: QuestionAnswerSortOrder.DEFAULT, errorMessage: '', requiresLogin: false
+      };
+      const repository = new FakeQuestionAnswerRepository([
+        { items: [], cursor: { isEnd: true, isStart: true, next: '', page: 1, total: 2 } }
+      ]);
+      const navigator = new QuestionAnswerNavigator('123', '2', seed, repository);
+      const preview = navigator.previousAnswerPreview();
+      expect(preview?.answerId).assertEqual('1');
+      expect(preview?.authorName).assertEqual('作者');
+      expect(await navigator.move(-1)).assertEqual('1');
+      expect(navigator.hasPrevious()).assertFalse();
+      expect(navigator.previousAnswerPreview()).assertUndefined();
+      navigator.dispose();
+    });
+
+    it('navigatorSeedlessFallsBackToFirstWhenCurrentAbsent', 0, async () => {
+      // 当前回答不在列表里（如被过滤）：首个非当前回答作为下一答。
+      const repository = new FakeQuestionAnswerRepository([
+        { items: [content('7'), content('8')],
+          cursor: { isEnd: true, isStart: true, page: 1, total: 2 } }
+      ]);
+      const navigator = new QuestionAnswerNavigator('123', '99', undefined, repository);
+      await new Promise<void>((resolve): void => { setTimeout(resolve, 0); });
+      expect(navigator.hasNext()).assertTrue();
+      const preview = navigator.nextAnswerPreview();
+      expect(preview?.answerId).assertEqual('7');
+      expect(await navigator.move(1)).assertEqual('7');
+      expect(navigator.hasPrevious()).assertFalse();
+      navigator.dispose();
+    });
   });
 }

--- a/entry/src/test/QuestionAnswerFeed.test.ets
+++ b/entry/src/test/QuestionAnswerFeed.test.ets
@@ -1,0 +1,87 @@
+import { describe, expect, it } from '@ohos/hypium';
+import {
+  buildQuestionAnswerFeedRequestUrl, ChannelContentItem, ChannelFeedItemKind, decodeQuestionAnswerFeedPage,
+  FeedTargetKind, QuestionAnswerFeedPage, QuestionAnswerFeedRepository, QuestionAnswerSortOrder
+} from 'data';
+import { QuestionAnswersController, QuestionAnswersPhase, QuestionAnswersViewState } from '../main/ets/pages/QuestionAnswersState';
+import { QuestionAnswerNavigator } from '../main/ets/pages/QuestionAnswerNavigator';
+
+class FakeQuestionAnswerRepository implements QuestionAnswerFeedRepository {
+  readonly pages: QuestionAnswerFeedPage[];
+  calls: number = 0;
+  constructor(pages: QuestionAnswerFeedPage[]) { this.pages = pages; }
+  loadPage(_questionId: string, _order: QuestionAnswerSortOrder, _cursor?: string,
+    _reset?: boolean): Promise<QuestionAnswerFeedPage> {
+    const page = this.pages[Math.min(this.calls, this.pages.length - 1)];
+    this.calls += 1;
+    return Promise.resolve(page);
+  }
+  cancel(): void {}
+}
+
+function content(id: string): ChannelContentItem {
+  return {
+    kind: ChannelFeedItemKind.CONTENT,
+    feedItem: {
+      id: id, verb: '', createdAt: 1, updatedAt: 2,
+      target: { kind: FeedTargetKind.ANSWER, id: id, title: '', excerpt: '摘要', url: '', voteupCount: 3,
+        commentCount: 4, topicIds: [], author: { id: 'u', name: '作者', headline: '', followerCount: 0,
+          isFollowing: false, isOrganization: false } }
+    },
+    topicIds: []
+  };
+}
+
+export default function questionAnswerFeedTest(): void {
+  describe('questionAnswerFeedTest', () => {
+    it('buildsCanonicalSortUrlsAndRejectsCursorInjection', 0, () => {
+      expect(buildQuestionAnswerFeedRequestUrl('123', QuestionAnswerSortOrder.UPDATED)).assertEqual(
+        'https://www.zhihu.com/api/v4/questions/123/feeds?limit=20&order=updated');
+      let rejected = false;
+      try { buildQuestionAnswerFeedRequestUrl('123', QuestionAnswerSortOrder.DEFAULT, 'https://evil.test/'); }
+      catch (_error) { rejected = true; }
+      expect(rejected).assertTrue();
+    });
+
+    it('decodesQuestionFeedCardAndPaging', 0, () => {
+      const page = decodeQuestionAnswerFeedPage('{"data":[{"type":"question_feed_card","target":{' +
+        '"type":"answer","id":456,"excerpt":"正文","voteup_count":7,"comment_count":2,' +
+        '"author":{"id":"u1","name":"用户","avatar_url":"https://picx.zhimg.com/a.jpg"}}}],' +
+        '"paging":{"is_end":false,"next":"https://www.zhihu.com/api/v4/questions/123/feeds?limit=20&offset=20"}}');
+      expect(page.items.length).assertEqual(1);
+      expect((page.items[0] as ChannelContentItem).feedItem.target.id).assertEqual('456');
+      expect(page.cursor.isEnd).assertFalse();
+    });
+
+    it('controllerSkipsEmptyFilteredPages', 0, async () => {
+      const repository = new FakeQuestionAnswerRepository([
+        { items: [], cursor: { isEnd: false, isStart: true, next: 'next', page: 1, total: 2 } },
+        { items: [content('2')], cursor: { isEnd: true, isStart: false, page: 2, total: 2 } }
+      ]);
+      let state: QuestionAnswersViewState | undefined;
+      const controller = new QuestionAnswersController(repository, '123', (next): void => { state = next; });
+      controller.activate();
+      await new Promise<void>((resolve): void => { setTimeout(resolve, 0); });
+      expect(repository.calls).assertEqual(2);
+      expect(state?.phase).assertEqual(QuestionAnswersPhase.READY);
+      expect(state?.items.length).assertEqual(1);
+    });
+
+    it('navigatorLoadsNextPageAndKeepsPreviousItems', 0, async () => {
+      const seed: QuestionAnswersViewState = {
+        phase: QuestionAnswersPhase.READY, items: [content('1'), content('2')], loadingMore: false,
+        canLoadMore: true, sortOrder: QuestionAnswerSortOrder.DEFAULT, errorMessage: '', requiresLogin: false,
+        nextCursor: 'next'
+      };
+      const repository = new FakeQuestionAnswerRepository([
+        { items: [content('3')], cursor: { isEnd: true, isStart: false, page: 2, total: 3 } }
+      ]);
+      const navigator = new QuestionAnswerNavigator('123', '2', seed, repository);
+      expect(await navigator.move(-1)).assertEqual('1');
+      expect(await navigator.move(1)).assertEqual('2');
+      expect(await navigator.move(1)).assertEqual('3');
+      expect(repository.calls).assertEqual(1);
+      navigator.dispose();
+    });
+  });
+}

--- a/entry/src/test/ReadHistoryState.test.ets
+++ b/entry/src/test/ReadHistoryState.test.ets
@@ -11,17 +11,14 @@ import {
 } from 'data';
 import {
   decodeReadHistoryItem,
-  filterReadHistoryItems,
-  groupReadHistoryItems,
-  mergeReadHistoryItems,
+  LocalHistoryController,
   ReadHistoryContentKind,
   ReadHistoryController,
   ReadHistoryItem,
   readHistoryKindLabel,
   readHistoryOpenTarget,
   ReadHistoryPhase,
-  ReadHistorySourceFilter,
-  readHistorySourceFilterLabel
+  readHistoryTimeLabel
 } from '../main/ets/pages/ReadHistoryState';
 
 class FakeReadHistory implements ReadHistoryGateway {
@@ -53,11 +50,17 @@ class FakeOnlineHistory implements OnlineHistoryRepository {
   pages: Array<OnlineHistoryPage> = [];
   fail: boolean = false;
   authFail: boolean = false;
-  requestedCursors: Array<string | undefined> = [];
-  cancelCount: number = 0;
+  clearAllCount: number = 0;
+  deletedKeys: Array<string> = [];
+  // 与真实仓库一致：首页请求（cursor 为空）总是重置分页进度并返回第一页。
+  private pageIndex: number = 0;
 
   loadPage(cursor?: string): Promise<OnlineHistoryPage> {
-    this.requestedCursors.push(cursor);
+    if (cursor === undefined) {
+      this.pageIndex = 0;
+    } else {
+      this.pageIndex += 1;
+    }
     if (this.fail) {
       return Promise.reject(new Error('sensitive upstream payload'));
     }
@@ -71,13 +74,21 @@ class FakeOnlineHistory implements OnlineHistoryRepository {
       };
       return Promise.resolve(emptyPage);
     }
-    const index = this.requestedCursors.length - 1;
-    const page = this.pages[Math.min(index, this.pages.length - 1)];
+    const page = this.pages[Math.min(this.pageIndex, this.pages.length - 1)];
     return Promise.resolve(page);
   }
 
+  clearAll(): Promise<void> {
+    this.clearAllCount += 1;
+    return Promise.resolve();
+  }
+
+  deleteEntry(contentKey: string): Promise<void> {
+    this.deletedKeys.push(contentKey);
+    return Promise.resolve();
+  }
+
   cancel(): void {
-    this.cancelCount += 1;
   }
 }
 
@@ -105,7 +116,6 @@ export default function readHistoryStateTest(): void {
       const valid = decodeReadHistoryItem({ contentKey: 'answer:123', contentType: 'answer', openedAt: 1 });
       expect(valid?.kind).assertEqual(ReadHistoryContentKind.ANSWER);
       expect(valid?.id).assertEqual('123');
-      expect(valid?.deletable).assertTrue();
       expect(decodeReadHistoryItem({ contentKey: 'answer:../123', contentType: 'answer', openedAt: 1 }))
         .assertUndefined();
       expect(decodeReadHistoryItem({ contentKey: 'answer:123', contentType: 'article', openedAt: 1 }))
@@ -133,98 +143,32 @@ export default function readHistoryStateTest(): void {
       expect(untitled?.title ?? '').assertEqual('');
     });
 
-    it('filtersCorruptRowsAndPublishesReadyHistory', 0, async () => {
-      const history = new FakeReadHistory();
-      history.items = [
-        { contentKey: 'article:3', contentType: 'article', openedAt: 30 },
-        { contentKey: 'bad', contentType: 'answer', openedAt: 20 }
-      ];
-      const controller = new ReadHistoryController(history);
-      controller.activate();
-      await controller.reload();
-      expect(controller.snapshot().phase).assertEqual(ReadHistoryPhase.READY);
-      expect(controller.snapshot().items.length).assertEqual(1);
-      expect(controller.snapshot().items[0].contentKey).assertEqual('article:3');
+    it('formatsCardTimeLabelToMinutePrecision', 0, () => {
+      const label = readHistoryTimeLabel(new Date(2026, 7, 28, 9, 5).getTime());
+      expect(label).assertEqual('2026-08-28 09:05');
+      expect(readHistoryTimeLabel(Number.NaN)).assertEqual('');
     });
 
-    it('deletesOneRecordAndClearsAllWithReloadedState', 0, async () => {
+    it('loadsOnlineHistoryPagesAndMapsEntriesToCards', 0, async () => {
       const history = new FakeReadHistory();
-      history.items = [
-        { contentKey: 'question:1', contentType: 'question', openedAt: 20 },
-        { contentKey: 'answer:2', contentType: 'answer', openedAt: 10 },
-        { contentKey: 'pin:3', contentType: 'pin', openedAt: 5 }
-      ];
-      const controller = new ReadHistoryController(history);
-      controller.activate();
-      await controller.reload();
-      await controller.delete('pin:3');
-      expect(controller.snapshot().items.length).assertEqual(2);
-      expect(controller.snapshot().items.some((item): boolean => item.kind === ReadHistoryContentKind.PIN))
-        .assertFalse();
-      await controller.clear();
-      expect(controller.snapshot().phase).assertEqual(ReadHistoryPhase.EMPTY);
-      expect(history.clearCount).assertEqual(1);
-    });
-
-    it('usesFixedReadErrorWithoutLeakingStoredValues', 0, async () => {
-      const history = new FakeReadHistory();
-      history.fail = true;
-      const controller = new ReadHistoryController(history);
-      controller.activate();
-      await controller.reload();
-      expect(controller.snapshot().phase).assertEqual(ReadHistoryPhase.ERROR);
-      expect(controller.snapshot().message).assertEqual('已读记录读取失败，请重试');
-      expect(controller.snapshot().message.includes('record value')).assertFalse();
-    });
-
-    it('ignoresMutationsAfterDeactivation', 0, async () => {
-      const history = new FakeReadHistory();
-      history.items = [{ contentKey: 'question:1', contentType: 'question', openedAt: 1 }];
-      const controller = new ReadHistoryController(history);
-      controller.activate();
-      await controller.reload();
-      controller.deactivate();
-      await controller.clear();
-      expect(history.clearCount).assertEqual(0);
-      expect(history.items.length).assertEqual(1);
-    });
-
-    it('showsLoginGateAndLocalOnlyWhenOnlineHistoryIsDisabled', 0, async () => {
-      const history = new FakeReadHistory();
-      history.items = [{ contentKey: 'question:1', contentType: 'question', openedAt: 20 }];
-      const controller = new ReadHistoryController(history);
-      controller.activate();
-      await controller.reload();
-      const state = controller.snapshot();
-      expect(state.requiresLogin).assertTrue();
-      expect(state.onlineEnabled).assertFalse();
-      expect(state.canLoadMore).assertFalse();
-      expect(state.items.length).assertEqual(1);
-      expect(state.items[0].deletable).assertTrue();
-      expect(state.items[0].inOnline).assertFalse();
-    });
-
-    it('mergesOnlineHistoryAndDeduplicatesByContentKey', 0, async () => {
-      const history = new FakeReadHistory();
-      history.items = [{ contentKey: 'answer:2', contentType: 'answer', openedAt: 10 }];
       const online = new FakeOnlineHistory();
-      online.pages = [onlinePage([
-        onlineEntry(OnlineHistoryKind.ANSWER, '2', 20, '在线回答标题'),
-        onlineEntry(OnlineHistoryKind.QUESTION, '1', 30)
-      ], undefined, true)];
+      online.pages = [
+        onlinePage([
+          onlineEntry(OnlineHistoryKind.ANSWER, '2', 20, '在线回答标题'),
+          onlineEntry(OnlineHistoryKind.QUESTION, '1', 30)
+        ], 'offset=10', false)
+      ];
       const controller = new ReadHistoryController(history, online, true);
       controller.activate();
       await controller.reload();
       const state = controller.snapshot();
+      expect(state.phase).assertEqual(ReadHistoryPhase.READY);
       expect(state.requiresLogin).assertFalse();
-      expect(state.onlineEnabled).assertTrue();
+      expect(state.canLoadMore).assertTrue();
       expect(state.items.length).assertEqual(2);
-      expect(state.items[0].contentKey).assertEqual('question:1');
-      expect(state.items[1].contentKey).assertEqual('answer:2');
-      expect(state.items[1].title).assertEqual('在线回答标题');
-      expect(state.items[1].openedAt).assertEqual(20);
-      expect(state.items[1].deletable).assertTrue();
-      expect(state.items[1].inOnline).assertTrue();
+      expect(state.items[0].title).assertEqual('在线回答标题');
+      expect(state.items[0].kind).assertEqual(ReadHistoryContentKind.ANSWER);
+      expect(state.items[0].openedAt).assertEqual(20);
     });
 
     it('loadsMoreOnlinePagesUntilEnd', 0, async () => {
@@ -246,123 +190,140 @@ export default function readHistoryStateTest(): void {
       expect(state.loadingMore).assertFalse();
     });
 
-    it('keepsLocalHistoryWhenOnlineFetchFails', 0, async () => {
+    it('deduplicatesItemsAcrossPages', 0, async () => {
       const history = new FakeReadHistory();
-      history.items = [
-        { contentKey: 'question:1', contentType: 'question', openedAt: 20 },
-        { contentKey: 'answer:2', contentType: 'answer', openedAt: 10 }
-      ];
       const online = new FakeOnlineHistory();
-      online.fail = true;
+      online.pages = [
+        onlinePage([onlineEntry(OnlineHistoryKind.ANSWER, '2', 20)], 'offset=10', false),
+        onlinePage([onlineEntry(OnlineHistoryKind.ANSWER, '2', 30)], undefined, true)
+      ];
       const controller = new ReadHistoryController(history, online, true);
       controller.activate();
       await controller.reload();
-      const state = controller.snapshot();
-      expect(state.phase).assertEqual(ReadHistoryPhase.READY);
-      expect(state.items.length).assertEqual(2);
-      expect(state.message.includes('在线历史加载失败')).assertTrue();
-      expect(state.message.includes('sensitive')).assertFalse();
+      await controller.loadMore();
+      expect(controller.snapshot().items.length).assertEqual(1);
+      expect(controller.snapshot().items[0].openedAt).assertEqual(20);
     });
 
-    it('marksSessionExpiredOnOnlineAuthenticationFailure', 0, async () => {
+    it('showsLoginGateWithoutOnlineSession', 0, async () => {
       const history = new FakeReadHistory();
       history.items = [{ contentKey: 'question:1', contentType: 'question', openedAt: 20 }];
-      const online = new FakeOnlineHistory();
-      online.authFail = true;
-      const controller = new ReadHistoryController(history, online, true);
+      const controller = new ReadHistoryController(history);
       controller.activate();
       await controller.reload();
       const state = controller.snapshot();
       expect(state.requiresLogin).assertTrue();
-      expect(state.items.length).assertEqual(1);
-      expect(state.message.includes('登录已失效')).assertTrue();
+      expect(state.phase).assertEqual(ReadHistoryPhase.EMPTY);
+      expect(state.canLoadMore).assertFalse();
+      expect(state.items.length).assertEqual(0);
     });
 
-    it('showsOnlineFailureMessageWhenMergedListIsEmpty', 0, async () => {
-      const history = new FakeReadHistory();
+    it('marksSessionExpiredOnOnlineAuthenticationFailure', 0, async () => {
       const online = new FakeOnlineHistory();
-      online.fail = true;
-      const controller = new ReadHistoryController(history, online, true);
+      online.authFail = true;
+      const controller = new ReadHistoryController(new FakeReadHistory(), online, true);
       controller.activate();
       await controller.reload();
       const state = controller.snapshot();
       expect(state.phase).assertEqual(ReadHistoryPhase.EMPTY);
-      expect(state.items.length).assertEqual(0);
-      expect(state.message.includes('在线历史加载失败')).assertTrue();
+      expect(state.message.includes('登录已失效')).assertTrue();
+      expect(state.message.includes('401')).assertFalse();
+    });
+
+    it('reportsFixedLoadErrorWithoutLeakingUpstreamPayload', 0, async () => {
+      const online = new FakeOnlineHistory();
+      online.fail = true;
+      const controller = new ReadHistoryController(new FakeReadHistory(), online, true);
+      controller.activate();
+      await controller.reload();
+      const state = controller.snapshot();
+      expect(state.phase).assertEqual(ReadHistoryPhase.ERROR);
+      expect(state.message).assertEqual('历史记录加载失败，请重试');
       expect(state.message.includes('sensitive')).assertFalse();
     });
 
-    it('deleteAndClearOnlyAffectLocalRecordsInMergedMode', 0, async () => {
-      const history = new FakeReadHistory();
-      history.items = [
-        { contentKey: 'question:1', contentType: 'question', openedAt: 5 },
-        { contentKey: 'answer:2', contentType: 'answer', openedAt: 4 }
-      ];
+    it('deletesOneOnlineEntryAndRemovesCardFromList', 0, async () => {
       const online = new FakeOnlineHistory();
       online.pages = [onlinePage([
         onlineEntry(OnlineHistoryKind.QUESTION, '1', 30),
         onlineEntry(OnlineHistoryKind.PIN, '3', 40)
       ], undefined, true)];
+      const controller = new ReadHistoryController(new FakeReadHistory(), online, true);
+      controller.activate();
+      await controller.reload();
+      expect(controller.snapshot().items.length).assertEqual(2);
+      await controller.deleteEntry('question:1');
+      const afterDelete = controller.snapshot();
+      expect(afterDelete.items.length).assertEqual(1);
+      expect(afterDelete.items[0].contentKey).assertEqual('pin:3');
+      expect(online.deletedKeys).assertDeepEquals(['question:1']);
+    });
+
+    it('clearAllClearsBothLocalStoreAndOnlineHistory', 0, async () => {
+      const history = new FakeReadHistory();
+      history.items = [{ contentKey: 'question:1', contentType: 'question', openedAt: 5 }];
+      const online = new FakeOnlineHistory();
+      online.pages = [onlinePage([onlineEntry(OnlineHistoryKind.ANSWER, '2', 20)], undefined, true)];
       const controller = new ReadHistoryController(history, online, true);
       controller.activate();
       await controller.reload();
-      expect(controller.snapshot().items.length).assertEqual(3);
-      await controller.delete('question:1');
-      const afterDelete = controller.snapshot();
-      expect(afterDelete.items.length).assertEqual(3);
-      const question = afterDelete.items.find((item): boolean => item.contentKey === 'question:1');
-      expect(question?.deletable).assertFalse();
-      expect(question?.inOnline).assertTrue();
-      await controller.clear();
+      await controller.clearAll();
       const afterClear = controller.snapshot();
       expect(history.clearCount).assertEqual(1);
-      expect(afterClear.items.length).assertEqual(2);
-      expect(afterClear.items.every((item): boolean => !item.deletable)).assertTrue();
+      expect(online.clearAllCount).assertEqual(1);
+      expect(afterClear.phase).assertEqual(ReadHistoryPhase.EMPTY);
+      expect(afterClear.items.length).assertEqual(0);
+      expect(afterClear.message).assertEqual('已清除所有历史记录');
     });
 
-    it('groupsAndMergesItemsInStableOrder', 0, () => {
-      const local: Array<ReadHistoryItem> = [
-        { contentKey: 'answer:1', kind: ReadHistoryContentKind.ANSWER, id: '1', openedAt: Date.UTC(2026, 7, 28, 12),
-          deletable: true, inOnline: false },
-        { contentKey: 'question:2', kind: ReadHistoryContentKind.QUESTION, id: '2', openedAt: Date.UTC(2026, 7, 27, 8),
-          deletable: true, inOnline: false }
-      ];
-      const online: Array<ReadHistoryItem> = [
-        { contentKey: 'answer:1', kind: ReadHistoryContentKind.ANSWER, id: '1', openedAt: Date.UTC(2026, 7, 28, 9),
-          title: '在线回答', deletable: false, inOnline: true },
-        { contentKey: 'pin:3', kind: ReadHistoryContentKind.PIN, id: '3', openedAt: Date.UTC(2026, 7, 27, 10),
-          deletable: false, inOnline: true }
-      ];
-      const merged = mergeReadHistoryItems(local, online);
-      expect(merged.length).assertEqual(3);
-      const mergedAnswer = merged.find((item): boolean => item.contentKey === 'answer:1');
-      expect(mergedAnswer?.deletable).assertTrue();
-      expect(mergedAnswer?.inOnline).assertTrue();
-      expect(mergedAnswer?.title).assertEqual('在线回答');
-      const groups = groupReadHistoryItems(merged);
-      expect(groups.map((group): string => group.dayKey)).assertDeepEquals(['2026-08-28', '2026-08-27']);
-      expect(groups[0].items[0].contentKey).assertEqual('answer:1');
-      expect(groups[1].items.map((item: ReadHistoryItem): string => item.contentKey))
-        .assertDeepEquals(['pin:3', 'question:2']);
+    it('ignoresMutationsAfterDeactivation', 0, async () => {
+      const history = new FakeReadHistory();
+      history.items = [{ contentKey: 'question:1', contentType: 'question', openedAt: 1 }];
+      const online = new FakeOnlineHistory();
+      online.pages = [onlinePage([onlineEntry(OnlineHistoryKind.ANSWER, '2', 20)], undefined, true)];
+      const controller = new ReadHistoryController(history, online, true);
+      controller.activate();
+      await controller.reload();
+      controller.deactivate();
+      await controller.clearAll();
+      await controller.deleteEntry('answer:2');
+      expect(history.clearCount).assertEqual(0);
+      expect(online.clearAllCount).assertEqual(0);
+      expect(online.deletedKeys.length).assertEqual(0);
     });
 
-    it('filtersMergedHistoryByRequestedSourceWithoutDroppingSharedRecords', 0, () => {
-      const items: Array<ReadHistoryItem> = [
-        { contentKey: 'question:1', kind: ReadHistoryContentKind.QUESTION, id: '1', openedAt: 30,
-          deletable: true, inOnline: false },
-        { contentKey: 'answer:2', kind: ReadHistoryContentKind.ANSWER, id: '2', openedAt: 20,
-          deletable: true, inOnline: true },
-        { contentKey: 'article:3', kind: ReadHistoryContentKind.ARTICLE, id: '3', openedAt: 10,
-          deletable: false, inOnline: true }
+    it('localControllerLoadsDeletesAndClearsRecords', 0, async () => {
+      const history = new FakeReadHistory();
+      history.items = [
+        { contentKey: 'article:3', contentType: 'article', openedAt: 30, title: '本地文章' },
+        { contentKey: 'bad', contentType: 'answer', openedAt: 20 },
+        { contentKey: 'question:1', contentType: 'question', openedAt: 10 }
       ];
-      expect(filterReadHistoryItems(items, ReadHistorySourceFilter.ALL).length).assertEqual(3);
-      expect(filterReadHistoryItems(items, ReadHistorySourceFilter.LOCAL)
-        .map((item: ReadHistoryItem): string => item.contentKey)).assertDeepEquals(['question:1', 'answer:2']);
-      expect(filterReadHistoryItems(items, ReadHistorySourceFilter.ONLINE)
-        .map((item: ReadHistoryItem): string => item.contentKey)).assertDeepEquals(['answer:2', 'article:3']);
-      expect(readHistorySourceFilterLabel(ReadHistorySourceFilter.ALL)).assertEqual('全部记录');
-      expect(readHistorySourceFilterLabel(ReadHistorySourceFilter.LOCAL)).assertEqual('本地记录');
-      expect(readHistorySourceFilterLabel(ReadHistorySourceFilter.ONLINE)).assertEqual('在线记录');
+      const controller = new LocalHistoryController(history);
+      controller.activate();
+      await controller.reload();
+      const state = controller.snapshot();
+      expect(state.phase).assertEqual(ReadHistoryPhase.READY);
+      expect(state.items.length).assertEqual(2);
+      expect(state.items[0].contentKey).assertEqual('article:3');
+      expect(state.items[0].title).assertEqual('本地文章');
+      await controller.delete('article:3');
+      expect(controller.snapshot().items.length).assertEqual(1);
+      await controller.clear();
+      expect(history.clearCount).assertEqual(1);
+      expect(controller.snapshot().phase).assertEqual(ReadHistoryPhase.EMPTY);
+    });
+
+    it('localControllerReportsReadFailureWithFixedMessage', 0, async () => {
+      const history = new FakeReadHistory();
+      history.fail = true;
+      const controller = new LocalHistoryController(history);
+      controller.activate();
+      await controller.reload();
+      const state = controller.snapshot();
+      expect(state.phase).assertEqual(ReadHistoryPhase.ERROR);
+      expect(state.message).assertEqual('本地历史记录读取失败，请重试');
+      expect(state.message.includes('record value')).assertFalse();
     });
   });
 }

--- a/entry/src/test/ReaderDocument.test.ets
+++ b/entry/src/test/ReaderDocument.test.ets
@@ -76,15 +76,23 @@ export default function readerDocumentTest(): void {
       expect(isTrustedFormulaUrl('https://www.zhihu.com/equation/extra?tex=x')).assertFalse();
     });
 
-    it('prefersActualZhihuImageAndCaption', 0, () => {
+    it('prefersOriginalZhihuImageAndCaption', 0, () => {
       const blocks = parseZhihuHtml('<figure><noscript><img src="fallback.jpg"></noscript>' +
-        '<img src="placeholder.svg" data-original="https://picx.zhimg.com/original.jpg" ' +
-        'data-actualsrc="https://picx.zhimg.com/reading.jpg">' +
+        '<img src="placeholder.svg" data-actualsrc="https://picx.zhimg.com/reading.jpg" ' +
+        'data-original="https://picx.zhimg.com/original.jpg">' +
         '<figcaption>图片说明</figcaption></figure>');
       expect(blocks.length).assertEqual(1);
       expect(blocks[0].kind).assertEqual(ReaderBlockKind.IMAGE);
-      expect(blocks[0].sourceUrl).assertEqual('https://picx.zhimg.com/reading.jpg');
+      expect(blocks[0].sourceUrl).assertEqual('https://picx.zhimg.com/original.jpg');
       expect(blocks[0].text).assertEqual('图片说明');
+    });
+
+    it('prefersOriginalTokenOverThumbnailAttributes', 0, () => {
+      const blocks = parseZhihuHtml('<figure><img data-actualsrc="https://picx.zhimg.com/reading.jpg" ' +
+        'data-original-token="v2-abc123def" src="https://picx.zhimg.com/thumb.jpg"></figure>');
+      expect(blocks.length).assertEqual(1);
+      expect(blocks[0].kind).assertEqual(ReaderBlockKind.IMAGE);
+      expect(blocks[0].sourceUrl).assertEqual('https://pic1.zhimg.com/v2-abc123def');
     });
 
     it('parsesBlockquoteAndPreAsParagraphs', 0, () => {

--- a/entry/src/test/SearchRepository.test.ets
+++ b/entry/src/test/SearchRepository.test.ets
@@ -3,6 +3,7 @@ import {
   buildInitialSearchUrl,
   buildSearchRequestUrl,
   canonicalSearchCursorKey,
+  decodeSearchHotList,
   decodeSearchResultPage,
   DefaultSearchRepository,
   BlockableContentSummary,
@@ -10,6 +11,8 @@ import {
   BlockingRuleKind,
   ContentBlockingMatcher,
   ContentBlockingSession,
+  defaultSearchFilters,
+  SearchFilters,
   FeedTargetKind,
   HttpFailure,
   HttpFailureKind,
@@ -17,8 +20,14 @@ import {
   PreparedZhihuHttpRequest,
   SearchDecodeError,
   SearchDecodeFailureKind,
+  SearchEntityKind,
   SearchRepositoryFailure,
   SearchRepositoryFailureKind,
+  SearchSortOption,
+  SearchTab,
+  SearchTimeRange,
+  SearchEntity,
+  SearchResultItem,
   SessionCookie,
   SessionCookieProvider,
   ZhihuHttpClient,
@@ -56,7 +65,7 @@ class SearchTransport implements ZhihuHttpTransport {
 
 class SearchTransportFactory implements ZhihuHttpTransportFactory {
   private readonly responses: Array<ZhihuHttpResponse>;
-  private index: number = 0;
+  index: number = 0;
   readonly requests: Array<PreparedZhihuHttpRequest> = [];
 
   constructor(responses: Array<ZhihuHttpResponse>) {
@@ -117,6 +126,7 @@ class RecordingSearchBlockingMatcher implements ContentBlockingMatcher {
 }
 
 const QUERY = 'HarmonyOS ArkTS';
+const FILTERS: SearchFilters = defaultSearchFilters();
 const NEXT_CURSOR = 'https://www.zhihu.com/api/v4/search_v3?t=general&q=HarmonyOS+ArkTS&offset=20&limit=20';
 const FIRST_PAGE = '{"data":[{"type":"search_result","id":"wrapper-answer-1","object":{' +
   '"type":"answer","id":"answer-1","excerpt":"回答摘要","voteup_count":12,' +
@@ -141,25 +151,69 @@ export default function searchRepositoryTest(): void {
     it('buildsAndroidCompatibleSearchUrlAndNormalizesCursor', 0, () => {
       const initial = buildInitialSearchUrl('  HarmonyOS ArkTS  ');
       expect(initial.includes('t=general&q=HarmonyOS+ArkTS')).assertTrue();
-      expect(initial.includes('offset=0&limit=20&search_source=Normal')).assertTrue();
+      expect(initial.includes('offset=0&limit=20&search_source=Normal&show_all_topics=0')).assertTrue();
       expect(initial.includes('include=data%5B%2A%5D.highlight%2Cobject%2Ctype%2Cobject.author%2C' +
         'object.topics%2Cobject.bound_topic_ids%2Cobject.question.topics%2Cobject.question.bound_topic_ids'))
         .assertTrue();
-      expect(buildSearchRequestUrl(QUERY,
+      expect(buildSearchRequestUrl(QUERY, FILTERS, SearchTab.GENERAL,
         'https://www.zhihu.com/api/v4/search_v3?include=stale&t=general&q=HarmonyOS%20ArkTS&offset=20'
       )).assertEqual(
         'https://www.zhihu.com/api/v4/search_v3?t=general&q=HarmonyOS+ArkTS&offset=20&' +
           'include=data%5B%2A%5D.highlight%2Cobject%2Ctype%2Cobject.author%2Cobject.topics%2C' +
             'object.bound_topic_ids%2Cobject.question.topics%2Cobject.question.bound_topic_ids'
       );
-      expect(canonicalSearchCursorKey(QUERY,
+      expect(canonicalSearchCursorKey(QUERY, FILTERS, SearchTab.GENERAL,
         'https://www.zhihu.com/api/v4/search_v3?offset=20&t=general&q=HarmonyOS+ArkTS'
-      )).assertEqual(canonicalSearchCursorKey(QUERY,
+      )).assertEqual(canonicalSearchCursorKey(QUERY, FILTERS, SearchTab.GENERAL,
         'https://www.zhihu.com/api/v4/search_v3?q=HarmonyOS%20ArkTS&t=general&offset=20'
       ));
-      expect(buildSearchRequestUrl(QUERY,
+      expect(buildSearchRequestUrl(QUERY, FILTERS, SearchTab.GENERAL,
         'https://api.zhihu.com/search_v3?offset=20&t=general&q=HarmonyOS+ArkTS'
       ).startsWith('https://www.zhihu.com/api/v4/search_v3?')).assertTrue();
+    });
+
+    it('buildsTabScopedAndFilteredSearchUrlsLikeUpstream', 0, () => {
+      const sortedFilters: SearchFilters = {
+        sort: SearchSortOption.MOST_VOTED,
+        timeRange: SearchTimeRange.WEEK
+      };
+      // 用户/话题 tab 忽略排序与时间筛选（对齐上游 activeFilters 重置行为）。
+      const people = buildInitialSearchUrl(QUERY, sortedFilters, SearchTab.PEOPLE);
+      expect(people.includes('t=people')).assertTrue();
+      expect(people.includes('show_all_topics=0')).assertTrue();
+      expect(people.includes('sort=')).assertFalse();
+      expect(people.includes('time_interval=')).assertFalse();
+
+      const topic = buildInitialSearchUrl(QUERY, sortedFilters, SearchTab.TOPIC);
+      expect(topic.includes('t=topic')).assertTrue();
+      expect(topic.includes('show_all_topics=1')).assertTrue();
+      expect(topic.includes('sort=')).assertFalse();
+
+      const answers = buildInitialSearchUrl(QUERY, FILTERS, SearchTab.ANSWER);
+      expect(answers.includes('t=general')).assertTrue();
+      expect(answers.includes('vertical=answer&vertical_info=0,0,0,0,0,0,0,0,0,0,0,0'))
+        .assertTrue();
+      expect(answers.includes('search_source=Filter')).assertTrue();
+
+      const sorted = buildInitialSearchUrl(QUERY, {
+        sort: SearchSortOption.MOST_VOTED,
+        timeRange: SearchTimeRange.WEEK
+      }, SearchTab.GENERAL);
+      expect(sorted.includes('sort=upvoted_count')).assertTrue();
+      expect(sorted.includes('time_interval=a_week')).assertTrue();
+      expect(sorted.includes('search_source=Filter')).assertTrue();
+
+      // 游标校验：t 必须与当前 tab 的请求参数一致，否则拒绝重放。
+      let failure: SearchRepositoryFailure | undefined = undefined;
+      try {
+        buildSearchRequestUrl(QUERY, FILTERS, SearchTab.PEOPLE,
+          'https://www.zhihu.com/api/v4/search_v3?t=general&q=HarmonyOS+ArkTS&offset=20');
+      } catch (error) {
+        if (error instanceof SearchRepositoryFailure) {
+          failure = error;
+        }
+      }
+      expect(failure?.kind).assertEqual(SearchRepositoryFailureKind.INVALID_CURSOR);
     });
 
     it('rejectsCrossOriginPathFragmentAndQuerySwitchingCursors', 0, () => {
@@ -180,7 +234,7 @@ export default function searchRepositoryTest(): void {
       invalidCursors.forEach((cursor: string): void => {
         let failure: SearchRepositoryFailure | undefined = undefined;
         try {
-          buildSearchRequestUrl(QUERY, cursor);
+          buildSearchRequestUrl(QUERY, FILTERS, SearchTab.GENERAL, cursor);
         } catch (error) {
           if (error instanceof SearchRepositoryFailure) {
             failure = error;
@@ -192,14 +246,45 @@ export default function searchRepositoryTest(): void {
 
     it('decodesQuestionAnswerArticleAndSkipsExplicitUnsupportedCards', 0, () => {
       const page = decodeSearchResultPage(SUPPORTED_RESULT_PAGE);
-      expect(page.items.length).assertEqual(3);
-      expect(page.items[0].kind).assertEqual(FeedTargetKind.QUESTION);
-      expect(page.items[0].contentId).assertEqual('question-1');
-      expect(page.items[1].kind).assertEqual(FeedTargetKind.ANSWER);
-      expect(page.items[1].title).assertEqual('ArkTS 回答问题');
-      expect(page.items[2].kind).assertEqual(FeedTargetKind.ARTICLE);
-      expect(page.items[2].contentId).assertEqual('article-2');
+      expect(page.entities.length).assertEqual(3);
+      const first = contentItemOf(page.entities[0]);
+      expect(first.kind).assertEqual(FeedTargetKind.QUESTION);
+      expect(first.contentId).assertEqual('question-1');
+      const second = contentItemOf(page.entities[1]);
+      expect(second.kind).assertEqual(FeedTargetKind.ANSWER);
+      expect(second.title).assertEqual('ArkTS 回答问题');
+      const third = contentItemOf(page.entities[2]);
+      expect(third.kind).assertEqual(FeedTargetKind.ARTICLE);
+      expect(third.contentId).assertEqual('article-2');
       expect(page.cursor.isEnd).assertTrue();
+    });
+
+    it('decodesPeopleAndTopicEntitiesWithResponseIndexOrdering', 0, () => {
+      const page = decodeSearchResultPage('{"data":[' +
+        '{"type":"search_result","id":"w2","index":"2","object":{"type":"topic","id":"99",' +
+        '"name":"<em>鸿蒙</em>话题","excerpt":"讨论","visit_count":12000,"top_answer_count":34,' +
+        '"is_following":true,"avatar_url":"https://pic.example/t.png"}},' +
+        '{"type":"search_result","id":"w1","index":"1","object":{"type":"people","id":"zhang-san",' +
+        '"name":"张三","url_token":"zhang-san","headline":"开发者","follower_count":1000,' +
+        '"answer_count":20,"avatar_url":"https://pic.example/p.png"}},' +
+        '{"type":"search_result","id":"w0","index":"0","object":{"type":"article","id":"77",' +
+        '"title":"<em>鸿蒙</em>指南"}}],"paging":{"is_end":true}}');
+      expect(page.entities.length).assertEqual(3);
+      expect(page.entities[0].kind).assertEqual(SearchEntityKind.CONTENT);
+      expect(page.entities[1].kind).assertEqual(SearchEntityKind.PERSON);
+      const person = page.entities[1].person;
+      expect(person?.id).assertEqual('zhang-san');
+      expect(person?.name).assertEqual('张三');
+      expect(person?.urlToken).assertEqual('zhang-san');
+      expect(person?.followerCount).assertEqual(1000);
+      expect(person?.answerCount).assertEqual(20);
+      expect(page.entities[2].kind).assertEqual(SearchEntityKind.TOPIC);
+      const topic = page.entities[2].topic;
+      expect(topic?.id).assertEqual('99');
+      expect(topic?.name).assertEqual('<em>鸿蒙</em>话题');
+      expect(topic?.visitCount).assertEqual(12000);
+      expect(topic?.discussCount).assertEqual(34);
+      expect(topic?.isFollowing).assertTrue();
     });
 
     it('fallsBackToObjectIdWhenWrapperIdMissing', 0, () => {
@@ -210,10 +295,11 @@ export default function searchRepositoryTest(): void {
         '{"type":"search_result","id":"wrapper-10","object":{"type":"article","id":"article-10",' +
         '"title":"有包裹 id 的文章"}}],' +
         '"paging":{"is_end":true,"is_start":true}}');
-      expect(page.items.length).assertEqual(2);
-      expect(page.items[0].contentId).assertEqual('answer-9');
-      expect(page.items[0].wrapperId).assertEqual('answer-9');
-      expect(page.items[1].wrapperId).assertEqual('wrapper-10');
+      expect(page.entities.length).assertEqual(2);
+      const first = contentItemOf(page.entities[0]);
+      expect(first.contentId).assertEqual('answer-9');
+      expect(first.wrapperId).assertEqual('answer-9');
+      expect(contentItemOf(page.entities[1]).wrapperId).assertEqual('wrapper-10');
     });
 
     it('mapsMalformedSearchFieldsToStructuredErrors', 0, () => {
@@ -240,6 +326,23 @@ export default function searchRepositoryTest(): void {
       });
     });
 
+    it('decodesHotSearchQueries', 0, () => {
+      const items = decodeSearchHotList('{"hot_search_queries":[' +
+        '{"query":"鸿蒙 next","hot_show":"456万","label":"热"},{"query":"ArkTS","hot_show":""}]}');
+      expect(items.length).assertEqual(2);
+      expect(items[0].query).assertEqual('鸿蒙 next');
+      expect(items[0].hotShow).assertEqual('456万');
+      expect(items[1].label).assertEqual('');
+      expect(decodeSearchHotList('{}').length).assertEqual(0);
+      let malformed = false;
+      try {
+        decodeSearchHotList('{"hot_search_queries":[{"hot_show":"缺 query"}]}');
+      } catch (error) {
+        malformed = error instanceof SearchDecodeError;
+      }
+      expect(malformed).assertTrue();
+    });
+
     it('sendsSignedSessionRequestAndDeduplicatesByContentIdentity', 0, async () => {
       const factory = new SearchTransportFactory([
         { statusCode: 200, body: FIRST_PAGE },
@@ -248,23 +351,25 @@ export default function searchRepositoryTest(): void {
       const client = new ZhihuHttpClient(new SearchCookieProvider(), factory);
       const repository = new DefaultSearchRepository(client);
       const first = await repository.search(QUERY);
-      const second = await repository.search(QUERY, first.cursor.next);
+      const second = await repository.search(QUERY, FILTERS, SearchTab.GENERAL, first.cursor.next);
 
-      expect(first.items.length).assertEqual(1);
-      expect(second.items.length).assertEqual(1);
-      expect(second.items[0].contentId).assertEqual('article-1');
+      expect(first.entities.length).assertEqual(1);
+      expect(second.entities.length).assertEqual(1);
+      expect(contentItemOf(second.entities[0]).contentId).assertEqual('article-1');
       expect(second.cursor.isEnd).assertTrue();
       expect(factory.requests[0].headers.Cookie).assertEqual('z_c0=search-login; d_c0=search-device');
       expect(JSON.stringify(factory.requests[0].headers).includes('x-zse-96')).assertTrue();
       expect(factory.requests[1].url.includes('offset=20')).assertTrue();
     });
 
-    it('filtersEachPageWithOneSnapshotAndDecodedAuthorTopics', 0, async () => {
+    it('filtersEachPageWithOneSnapshotAndSkipsPeopleEntities', 0, async () => {
       const factory = new SearchTransportFactory([{ statusCode: 200, body: '{"data":[' +
         '{"type":"search_result","id":"w1","object":{"type":"article","id":"1",' +
         '"title":"保留","author":{"id":"member-1","name":"作者"},"topics":[{"id":19551275}]}},' +
         '{"type":"search_result","id":"w2","object":{"type":"article","id":"2",' +
-        '"title":"屏蔽内容","bound_topic_ids":[19551276]}}],"paging":{"is_end":true}}' }]);
+        '"title":"屏蔽内容","bound_topic_ids":[19551276]}},' +
+        '{"type":"search_result","id":"w3","object":{"type":"people","id":"someone","name":"路人"}}],' +
+        '"paging":{"is_end":true}}' }]);
       const matcher = new RecordingSearchBlockingMatcher();
       const repository = new DefaultSearchRepository(
         new ZhihuHttpClient(new SearchCookieProvider(), factory),
@@ -276,8 +381,23 @@ export default function searchRepositoryTest(): void {
       expect(matcher.session.summaries.length).assertEqual(2);
       expect(matcher.session.summaries[0].authorId).assertEqual('member-1');
       expect(matcher.session.summaries[0].topicIds[0]).assertEqual('19551275');
-      expect(page.items.length).assertEqual(1);
-      expect(page.items[0].contentId).assertEqual('1');
+      expect(page.entities.length).assertEqual(2);
+      expect(contentItemOf(page.entities[0]).contentId).assertEqual('1');
+      expect(page.entities[1].kind).assertEqual(SearchEntityKind.PERSON);
+    });
+
+    it('fetchesHotSearchWithSessionSigning', 0, async () => {
+      const factory = new SearchTransportFactory([
+        { statusCode: 200, body: '{"hot_search_queries":[{"query":"鸿蒙","hot_show":"12万"}]}' }
+      ]);
+      const repository = new DefaultSearchRepository(
+        new ZhihuHttpClient(new SearchCookieProvider(), factory)
+      );
+      const items = await repository.hotSearch();
+      expect(items.length).assertEqual(1);
+      expect(items[0].query).assertEqual('鸿蒙');
+      expect(factory.requests[0].url).assertEqual('https://www.zhihu.com/api/v4/search/hot_search');
+      expect(JSON.stringify(factory.requests[0].headers).includes('x-zse-96')).assertTrue();
     });
 
     it('doesNotCommitCursorAfterRejectedResponse', 0, async () => {
@@ -296,7 +416,7 @@ export default function searchRepositoryTest(): void {
       }
       const retry = await repository.search(QUERY);
       expect(failed).assertTrue();
-      expect(retry.items.length).assertEqual(1);
+      expect(retry.entities.length).assertEqual(1);
       expect(factory.requests.length).assertEqual(2);
     });
 
@@ -320,4 +440,12 @@ export default function searchRepositoryTest(): void {
       expect(factory.transport.destroyCount).assertEqual(1);
     });
   });
+}
+
+function contentItemOf(entity: SearchEntity): SearchResultItem {
+  const item = entity.content;
+  if (item === undefined) {
+    throw new Error('expected content entity');
+  }
+  return item;
 }

--- a/entry/src/test/SearchState.test.ets
+++ b/entry/src/test/SearchState.test.ets
@@ -1,21 +1,27 @@
 import { describe, expect, it } from '@ohos/hypium';
 import {
+  defaultSearchFilters,
   FeedTargetKind,
   HttpFailure,
   HttpFailureKind,
+  SearchEntity,
+  searchEntityOfContent,
+  SearchFilters,
+  SearchHotItem,
   SearchRepository,
   SearchResultItem,
-  SearchResultPage
+  SearchResultPage,
+  SearchSortOption,
+  SearchTab,
+  SearchTimeRange
 } from 'data';
-import {
-  filterSearchResults,
-  searchResultDestination,
-  SearchResultFilter
-} from '../main/ets/pages/SearchPage';
-import { mergeSearchResults, SearchController, SearchPhase } from '../main/ets/pages/SearchState';
+import { searchResultDestination, searchTabLabel } from '../main/ets/pages/SearchPage';
+import { mergeSearchEntities, SearchController, SearchPhase } from '../main/ets/pages/SearchState';
 
 interface PendingSearch {
   readonly query: string;
+  readonly filters: SearchFilters | undefined;
+  readonly tab: SearchTab | undefined;
   readonly cursor?: string;
   readonly resolve: (page: SearchResultPage) => void;
   readonly reject: (error: Error) => void;
@@ -24,12 +30,25 @@ interface PendingSearch {
 class ControlledSearchRepository implements SearchRepository {
   readonly pending: Array<PendingSearch> = [];
   cancelCount: number = 0;
+  hotSearchCount: number = 0;
 
-  search(query: string, cursor?: string): Promise<SearchResultPage> {
+  search(query: string, filters?: SearchFilters, tab?: SearchTab, cursor?: string): Promise<SearchResultPage> {
     return new Promise<SearchResultPage>((resolve: (page: SearchResultPage) => void,
       reject: (error: Error) => void): void => {
-      this.pending.push({ query: query, cursor: cursor, resolve: resolve, reject: reject });
+      this.pending.push({
+        query: query,
+        filters: filters,
+        tab: tab,
+        cursor: cursor,
+        resolve: resolve,
+        reject: reject
+      });
     });
+  }
+
+  async hotSearch(): Promise<Array<SearchHotItem>> {
+    this.hotSearchCount += 1;
+    return [];
   }
 
   cancel(): void {
@@ -46,11 +65,16 @@ class AuthenticationSearchRepository implements SearchRepository {
     this.firstPage = firstPage;
   }
 
-  async search(_query: string, cursor?: string): Promise<SearchResultPage> {
+  async search(_query: string, _filters?: SearchFilters, _tab?: SearchTab, cursor?: string):
+    Promise<SearchResultPage> {
     if (cursor === undefined && this.firstPage !== undefined) {
       return this.firstPage;
     }
     throw new HttpFailure(HttpFailureKind.AUTHENTICATION, this.status);
+  }
+
+  async hotSearch(): Promise<Array<SearchHotItem>> {
+    return [];
   }
 
   cancel(): void {
@@ -69,10 +93,10 @@ export default function searchStateTest(): void {
 
       const loading = controller.submit('  arkts  ');
       expect(repository.pending[0].query).assertEqual('arkts');
-      repository.pending[0].resolve(page([result('answer-1')], 'next'));
+      repository.pending[0].resolve(pageOf([content('answer-1')], 'next'));
       await loading;
       expect(controller.snapshot().phase).assertEqual(SearchPhase.READY);
-      expect(controller.snapshot().items.length).assertEqual(1);
+      expect(controller.snapshot().entities.length).assertEqual(1);
     });
 
     it('cancelsPreviousQueryAndIgnoresItsLateResult', 0, async () => {
@@ -81,13 +105,13 @@ export default function searchStateTest(): void {
       controller.activate();
       const oldSearch = controller.submit('old');
       const newSearch = controller.submit('new');
-      repository.pending[1].resolve(page([result('new')], undefined, true));
+      repository.pending[1].resolve(pageOf([content('new')], undefined, true));
       await newSearch;
-      repository.pending[0].resolve(page([result('old')], undefined, true));
+      repository.pending[0].resolve(pageOf([content('old')], undefined, true));
       await oldSearch;
 
       expect(controller.snapshot().query).assertEqual('new');
-      expect(controller.snapshot().items[0].contentId).assertEqual('new');
+      expect(controller.snapshot().entities[0].content?.contentId).assertEqual('new');
       expect(repository.cancelCount).assertEqual(2);
     });
 
@@ -96,7 +120,7 @@ export default function searchStateTest(): void {
       const controller = new SearchController(repository);
       controller.activate();
       const first = controller.submit('query');
-      repository.pending[0].resolve(page([result('first')], 'next'));
+      repository.pending[0].resolve(pageOf([content('first')], 'next'));
       await first;
       const failed = controller.loadMore();
       repository.pending[1].reject(new Error('network detail'));
@@ -105,9 +129,9 @@ export default function searchStateTest(): void {
 
       const retry = controller.retry();
       expect(repository.pending[2].cursor).assertEqual('next');
-      repository.pending[2].resolve(page([result('second')], undefined, true));
+      repository.pending[2].resolve(pageOf([content('second')], undefined, true));
       await retry;
-      expect(controller.snapshot().items.length).assertEqual(2);
+      expect(controller.snapshot().entities.length).assertEqual(2);
     });
 
     it('continuesAfterEmptyNonTerminalPage', 0, async () => {
@@ -115,12 +139,12 @@ export default function searchStateTest(): void {
       const controller = new SearchController(repository);
       controller.activate();
       const first = controller.submit('query');
-      repository.pending[0].resolve(page([], 'next-empty'));
+      repository.pending[0].resolve(pageOf([], 'next-empty'));
       await first;
       expect(controller.snapshot().phase).assertEqual(SearchPhase.EMPTY);
       const next = controller.retry();
       expect(repository.pending[1].cursor).assertEqual('next-empty');
-      repository.pending[1].resolve(page([result('visible')], undefined, true));
+      repository.pending[1].resolve(pageOf([content('visible')], undefined, true));
       await next;
       expect(controller.snapshot().phase).assertEqual(SearchPhase.READY);
     });
@@ -130,16 +154,16 @@ export default function searchStateTest(): void {
       const controller = new SearchController(repository);
       controller.activate();
       const initial = controller.submit('query');
-      repository.pending[0].resolve(page([result('visible')], 'next'));
+      repository.pending[0].resolve(pageOf([content('visible')], 'next'));
       await initial;
       const loading = controller.loadMore();
       controller.deactivate();
-      repository.pending[1].resolve(page([result('late')], undefined, true));
+      repository.pending[1].resolve(pageOf([content('late')], undefined, true));
       await loading;
       expect(repository.cancelCount).assertEqual(2);
-      expect(controller.snapshot().items.length).assertEqual(1);
+      expect(controller.snapshot().entities.length).assertEqual(1);
       controller.activate();
-      expect(controller.snapshot().items[0].contentId).assertEqual('visible');
+      expect(controller.snapshot().entities[0].content?.contentId).assertEqual('visible');
 
       const initialRepository = new ControlledSearchRepository();
       const initialController = new SearchController(initialRepository);
@@ -148,11 +172,11 @@ export default function searchStateTest(): void {
       initialController.deactivate();
       initialController.activate();
       expect(initialRepository.pending.length).assertEqual(2);
-      initialRepository.pending[1].resolve(page([result('resumed')], undefined, true));
+      initialRepository.pending[1].resolve(pageOf([content('resumed')], undefined, true));
       await Promise.resolve();
-      initialRepository.pending[0].resolve(page([result('stale')], undefined, true));
+      initialRepository.pending[0].resolve(pageOf([content('stale')], undefined, true));
       await interrupted;
-      expect(initialController.snapshot().items[0].contentId).assertEqual('resumed');
+      expect(initialController.snapshot().entities[0].content?.contentId).assertEqual('resumed');
     });
 
     it('exposesAuthenticationFailureWithoutLeakingTransportDetails', 0, async () => {
@@ -182,44 +206,100 @@ export default function searchStateTest(): void {
     });
 
     it('doesNotMisreportPagination403AsExpiredSession', 0, async () => {
-      const firstPage = page([result('visible')], 'next');
+      const firstPage = pageOf([content('visible')], 'next');
       const controller = new SearchController(new AuthenticationSearchRepository(403, firstPage));
       controller.activate();
       await controller.submit('query');
       await controller.loadMore();
       expect(controller.snapshot().phase).assertEqual(SearchPhase.READY);
-      expect(controller.snapshot().items.length).assertEqual(1);
+      expect(controller.snapshot().entities.length).assertEqual(1);
       expect(controller.snapshot().requiresLogin).assertFalse();
       expect(controller.snapshot().errorMessage)
         .assertEqual('请求被拒绝，可能需要稍后重试或完成风控');
     });
 
     it('deduplicatesStableTargetsAndMapsTypedDestinations', 0, () => {
-      const merged = mergeSearchResults(
-        [result('same', FeedTargetKind.ANSWER, 'wrapper-1')],
-        [result('same', FeedTargetKind.ANSWER, 'wrapper-2'), result('same', FeedTargetKind.ARTICLE, 'wrapper-3')]
+      const merged = mergeSearchEntities(
+        [contentOf('same', FeedTargetKind.ANSWER, 'wrapper-1')],
+        [contentOf('same', FeedTargetKind.ANSWER, 'wrapper-2'), contentOf('same', FeedTargetKind.ARTICLE, 'wrapper-3')]
       );
       expect(merged.length).assertEqual(2);
-      expect(searchResultDestination(merged[0]).name).assertEqual('Answer');
-      expect(searchResultDestination(merged[1]).name).assertEqual('Article');
-      expect(searchResultDestination(result('question', FeedTargetKind.QUESTION)).name).assertEqual('Question');
+      const first = contentItemOf(merged[0]);
+      const second = contentItemOf(merged[1]);
+      expect(searchResultDestination(first).name).assertEqual('Answer');
+      expect(searchResultDestination(second).name).assertEqual('Article');
+      expect(searchResultDestination(contentOf('question', FeedTargetKind.QUESTION).content ?? first).name)
+        .assertEqual('Question');
     });
 
-    it('filtersLoadedGeneralResultsByVisibleResultTab', 0, () => {
-      const results: Array<SearchResultItem> = [
-        result('question', FeedTargetKind.QUESTION),
-        result('answer', FeedTargetKind.ANSWER),
-        result('article', FeedTargetKind.ARTICLE)
-      ];
-      expect(filterSearchResults(results, SearchResultFilter.ALL).length).assertEqual(3);
-      expect(filterSearchResults(results, SearchResultFilter.QUESTION)[0].contentId).assertEqual('question');
-      expect(filterSearchResults(results, SearchResultFilter.ANSWER)[0].contentId).assertEqual('answer');
-      expect(filterSearchResults(results, SearchResultFilter.ARTICLE)[0].contentId).assertEqual('article');
+    it('reloadsFirstPageWhenSelectingTabAndKeepsFilters', 0, async () => {
+      const repository = new ControlledSearchRepository();
+      const controller = new SearchController(repository);
+      controller.activate();
+      const first = controller.submit('query');
+      repository.pending[0].resolve(pageOf([content('general-1')], 'next'));
+      await first;
+
+      const people = controller.selectTab(SearchTab.PEOPLE);
+      expect(repository.pending[1].tab).assertEqual(SearchTab.PEOPLE);
+      expect(repository.pending[1].cursor).assertEqual(undefined);
+      repository.pending[1].resolve(pageOf([], undefined, true));
+      await people;
+      expect(controller.snapshot().activeTab).assertEqual(SearchTab.PEOPLE);
+      expect(controller.snapshot().phase).assertEqual(SearchPhase.EMPTY);
+
+      // 空结果的 tab 再次切换不触发请求；回到综合 tab 重新拉首页。
+      const back = controller.selectTab(SearchTab.GENERAL);
+      expect(repository.pending.length).assertEqual(3);
+      expect(repository.pending[2].tab).assertEqual(SearchTab.GENERAL);
+      repository.pending[2].resolve(pageOf([content('general-2')], undefined, true));
+      await back;
+      expect(controller.snapshot().entities.length).assertEqual(1);
+
+      const noop = controller.selectTab(SearchTab.GENERAL);
+      expect(repository.pending.length).assertEqual(3);
+      await noop;
+    });
+
+    it('reloadsFirstPageWhenFiltersChangeAndSubmitResetsTab', 0, async () => {
+      const repository = new ControlledSearchRepository();
+      const controller = new SearchController(repository);
+      controller.activate();
+      const first = controller.submit('query');
+      repository.pending[0].resolve(pageOf([content('one')], undefined, true));
+      await first;
+
+      const filtered = controller.updateFilters(SearchSortOption.MOST_VOTED, SearchTimeRange.WEEK);
+      expect(repository.pending[1].filters?.sort).assertEqual(SearchSortOption.MOST_VOTED);
+      expect(repository.pending[1].filters?.timeRange).assertEqual(SearchTimeRange.WEEK);
+      repository.pending[1].resolve(pageOf([content('two')], undefined, true));
+      await filtered;
+
+      const second = controller.selectTab(SearchTab.PEOPLE);
+      repository.pending[2].resolve(pageOf([], undefined, true));
+      await second;
+      const resubmit = controller.submit('other');
+      expect(repository.pending[3].tab).assertEqual(SearchTab.GENERAL);
+      expect(repository.pending[3].filters?.sort).assertEqual(SearchSortOption.MOST_VOTED);
+      repository.pending[3].resolve(pageOf([content('three')], undefined, true));
+      await resubmit;
+      expect(controller.snapshot().activeTab).assertEqual(SearchTab.GENERAL);
+      expect(controller.snapshot().sort).assertEqual(SearchSortOption.MOST_VOTED);
+      expect(controller.snapshot().timeRange).assertEqual(SearchTimeRange.WEEK);
+    });
+
+    it('labelsSearchTabsInUpstreamOrder', 0, () => {
+      expect(searchTabLabel(SearchTab.GENERAL)).assertEqual('综合');
+      expect(searchTabLabel(SearchTab.PEOPLE)).assertEqual('用户');
+      expect(searchTabLabel(SearchTab.ANSWER)).assertEqual('回答');
+      expect(searchTabLabel(SearchTab.ARTICLE)).assertEqual('文章');
+      expect(searchTabLabel(SearchTab.TOPIC)).assertEqual('话题');
+      expect(defaultSearchFilters().sort).assertEqual(SearchSortOption.DEFAULT);
     });
   });
 }
 
-function result(contentId: string, kind: FeedTargetKind = FeedTargetKind.ANSWER,
+function content(contentId: string, kind: FeedTargetKind = FeedTargetKind.ANSWER,
   wrapperId: string = `wrapper-${contentId}`): SearchResultItem {
   return {
     wrapperId: wrapperId,
@@ -233,9 +313,22 @@ function result(contentId: string, kind: FeedTargetKind = FeedTargetKind.ANSWER,
   };
 }
 
-function page(items: Array<SearchResultItem>, next?: string, isEnd: boolean = false): SearchResultPage {
+function contentOf(contentId: string, kind: FeedTargetKind = FeedTargetKind.ANSWER,
+  wrapperId: string = `wrapper-${contentId}`): SearchEntity {
+  return searchEntityOfContent(content(contentId, kind, wrapperId));
+}
+
+function contentItemOf(entity: SearchEntity): SearchResultItem {
+  const item = entity.content;
+  if (item === undefined) {
+    throw new Error('expected content entity');
+  }
+  return item;
+}
+
+function pageOf(items: Array<SearchResultItem>, next?: string, isEnd: boolean = false): SearchResultPage {
   return {
-    items: items,
+    entities: items.map((item: SearchResultItem): SearchEntity => searchEntityOfContent(item)),
     cursor: {
       isEnd: isEnd,
       isStart: true,

--- a/entry/src/test/ShareService.test.ets
+++ b/entry/src/test/ShareService.test.ets
@@ -1,10 +1,11 @@
 import { describe, expect, it } from '@ohos/hypium';
 import {
-  createSystemShareWant,
-  ShareAbilityLauncher,
+  createSystemShareRecords,
   ShareFileUriResolver,
-  SystemShareService,
-  SystemShareWant
+  SharePanelLauncher,
+  ShareRecordSpec,
+  ShareThumbnailFetcher,
+  SystemShareService
 } from '../main/ets/platform/SystemShareService';
 import {
   createTemporaryShareLifecycle,
@@ -27,21 +28,33 @@ import {
 const NOW: number = 1770000000000;
 const CACHE_DIR: string = '/data/storage/el2/base/cache';
 
-class RecordingShareLauncher implements ShareAbilityLauncher {
-  readonly wants: Array<SystemShareWant> = [];
+class RecordingShareLauncher implements SharePanelLauncher {
+  readonly panels: Array<Array<ShareRecordSpec>> = [];
   nextError: Error | undefined = undefined;
 
-  async startShare(want: SystemShareWant): Promise<void> {
+  async showPanel(records: Array<ShareRecordSpec>): Promise<void> {
     if (this.nextError !== undefined) {
       throw this.nextError;
     }
-    this.wants.push(want);
+    this.panels.push(records);
   }
 }
 
 class FixedFileUriResolver implements ShareFileUriResolver {
   getUriFromPath(path: string): string {
     return `file://sandbox${path}`;
+  }
+}
+
+class StubShareThumbnailFetcher implements ShareThumbnailFetcher {
+  private readonly result: Uint8Array | undefined;
+
+  constructor(result: Uint8Array | undefined) {
+    this.result = result;
+  }
+
+  async fetchThumbnail(_url: string): Promise<Uint8Array | undefined> {
+    return this.result;
   }
 }
 
@@ -192,28 +205,104 @@ export default function shareServiceTest(): void {
       expect(opened.cleanupAfterMillis <= lifecycle.createdAtMillis + 24 * 60 * 60 * 1000).assertTrue();
     });
 
-    it('buildsNoHeaderWantForTrustedLink', 0, () => {
-      const want = createSystemShareWant(prepareSharePayload(textPayload(), policy()), new FixedFileUriResolver());
-      const serialized = JSON.stringify(want);
+    it('buildsHyperlinkRecordWithoutSensitivePayloadForTrustedLink', 0, () => {
+      const records = createSystemShareRecords(
+        prepareSharePayload(textPayload(), policy()), new FixedFileUriResolver()
+      );
+      const serialized = JSON.stringify(records);
 
-      expect(want.action).assertEqual('ohos.want.action.sendData');
-      expect(want.type).assertEqual('text/plain');
-      expect(want.uri).assertEqual('https://www.zhihu.com/question/123/answer/456');
+      expect(records.length).assertEqual(1);
+      expect(records[0].utd).assertEqual('general.hyperlink');
+      expect(records[0].content).assertEqual('https://www.zhihu.com/question/123/answer/456');
+      expect(records[0].title).assertEqual('鸿蒙迁移进展');
       expect(serialized.includes('cookie')).assertFalse();
       expect(serialized.includes('authorization')).assertFalse();
       expect(serialized.includes('headers')).assertFalse();
     });
 
-    it('usesReadOnlyStreamAuthorizationForTemporaryFiles', 0, () => {
-      const prepared = prepareSharePayload(filePayload(temporaryFile(
+    it('buildsTypedFileRecordForTemporaryFiles', 0, () => {
+      const imagePrepared = prepareSharePayload(temporaryImagePayload(temporaryFile()), policy());
+      const imageRecords = createSystemShareRecords(imagePrepared, new FixedFileUriResolver());
+      const filePrepared = prepareSharePayload(filePayload(temporaryFile(
         `${CACHE_DIR}/p4-share/export-123.pdf`, 'application/pdf', NOW
       )), policy());
-      const want = createSystemShareWant(prepared, new FixedFileUriResolver());
+      const fileRecords = createSystemShareRecords(filePrepared, new FixedFileUriResolver());
 
-      expect(want.type).assertEqual('application/pdf');
-      expect(want.uri).assertEqual(`file://sandbox${CACHE_DIR}/p4-share/export-123.pdf`);
-      expect(want.flags).assertEqual(1);
-      expect(JSON.stringify(want.parameters).includes('ability.params.stream')).assertTrue();
+      expect(imageRecords.length).assertEqual(1);
+      expect(imageRecords[0].utd).assertEqual('general.image');
+      expect(imageRecords[0].uri).assertEqual(`file://sandbox${CACHE_DIR}/p4-share/image-123.png`);
+      expect(fileRecords[0].utd).assertEqual('general.file');
+      expect(fileRecords[0].uri).assertEqual(`file://sandbox${CACHE_DIR}/p4-share/export-123.pdf`);
+    });
+
+    it('validatesOptionalTrustedThumbnailUrlOnTextPayload', 0, () => {
+      const withThumbnail = textPayload();
+      const payload: ShareTextPayload = {
+        kind: withThumbnail.kind,
+        title: withThumbnail.title,
+        summary: withThumbnail.summary,
+        contentUrl: withThumbnail.contentUrl,
+        thumbnailUrl: 'https://picx.zhimg.com/v2-avatar.jpg'
+      };
+      const prepared = prepareSharePayload(payload, policy());
+
+      expect(prepared.thumbnailUrl).assertEqual('https://picx.zhimg.com/v2-avatar.jpg');
+
+      const untrusted: ShareTextPayload = {
+        kind: withThumbnail.kind,
+        title: withThumbnail.title,
+        summary: withThumbnail.summary,
+        contentUrl: withThumbnail.contentUrl,
+        thumbnailUrl: 'https://evil.example/avatar.jpg'
+      };
+
+      expect((): void => { prepareSharePayload(untrusted, policy()); }).assertThrowError('分享内容不受支持');
+    });
+
+    it('attachesFetchedThumbnailAndDescriptionToHyperlinkRecord', 0, async () => {
+      const launcher = new RecordingShareLauncher();
+      const thumbnail = new Uint8Array([1, 2, 3]);
+      const service = new SystemShareService(
+        launcher, policy(), new FixedFileUriResolver(), new StubShareThumbnailFetcher(thumbnail)
+      );
+      const payload = textPayload();
+      const payloadWithThumbnail: ShareTextPayload = {
+        kind: payload.kind,
+        title: payload.title,
+        summary: payload.summary,
+        contentUrl: payload.contentUrl,
+        thumbnailUrl: 'https://picx.zhimg.com/v2-avatar.jpg'
+      };
+
+      const outcome = await service.share(payloadWithThumbnail);
+      const records = launcher.panels[0];
+
+      expect(outcome).assertEqual(ShareOutcome.OPENED);
+      expect(records.length).assertEqual(1);
+      expect(records[0].description).assertEqual('知乎++ 的 P4 执行计划');
+      expect(records[0].thumbnail?.length).assertEqual(3);
+    });
+
+    it('opensPanelWithoutThumbnailWhenFetcherFails', 0, async () => {
+      const launcher = new RecordingShareLauncher();
+      const service = new SystemShareService(
+        launcher, policy(), new FixedFileUriResolver(), new StubShareThumbnailFetcher(undefined)
+      );
+      const payload = textPayload();
+      const payloadWithThumbnail: ShareTextPayload = {
+        kind: payload.kind,
+        title: payload.title,
+        summary: payload.summary,
+        contentUrl: payload.contentUrl,
+        thumbnailUrl: 'https://picx.zhimg.com/v2-avatar.jpg'
+      };
+
+      const outcome = await service.share(payloadWithThumbnail);
+      const records = launcher.panels[0];
+
+      expect(outcome).assertEqual(ShareOutcome.OPENED);
+      expect(records[0].thumbnail).assertUndefined();
+      expect(records[0].content).assertEqual('https://www.zhihu.com/question/123/answer/456');
     });
 
     it('treatsShareCancellationAsNormalOutcome', 0, async () => {
@@ -224,7 +313,7 @@ export default function shareServiceTest(): void {
       const outcome = await service.share(textPayload());
 
       expect(outcome).assertEqual(ShareOutcome.CANCELLED);
-      expect(launcher.wants.length).assertEqual(0);
+      expect(launcher.panels.length).assertEqual(0);
     });
 
     it('mapsMissingHandlerToFixedFailureWithoutRawMessage', 0, async () => {

--- a/reader/src/main/ets/reader/ReaderDocument.ets
+++ b/reader/src/main/ets/reader/ReaderDocument.ets
@@ -81,9 +81,15 @@ function contentOf(blockHtml: string): string {
   return start >= 0 && end > start ? blockHtml.slice(start + 1, end) : '';
 }
 
+/** 对齐上游 ZhihuUtils.extractImageUrl：v2- 原图 token 优先，缩略图字段只作兜底。 */
 function preferredImageSource(tag: string): string {
-  const candidate = decodeHtml(attributeValue(tag, 'data-actualsrc') ||
-    attributeValue(tag, 'data-original') || attributeValue(tag, 'src')).trim();
+  const token = decodeHtml(attributeValue(tag, 'data-original-token')).trim();
+  if (token.startsWith('v2-')) {
+    return `https://pic1.zhimg.com/${token}`;
+  }
+  const candidate = decodeHtml(attributeValue(tag, 'data-original') ||
+    attributeValue(tag, 'data-default-watermark-src') || attributeValue(tag, 'data-actualsrc') ||
+    attributeValue(tag, 'data-thumbnail') || attributeValue(tag, 'src')).trim();
   if (candidate.startsWith('//')) {
     return `https:${candidate}`;
   }


### PR DESCRIPTION
## 概述

本 PR 将 dev 分支累积的 19 个提交合入 main，核心是完成问题详情页（回答流 + 连续阅读）迁移，
并对搜索页、关注页、历史记录页等各信息流页面对齐安卓上游行为。合并后应用版本号升至 0.4.0。

## 问题 / 回答详情页

- 问题详情页回答流与连续阅读迁移（b5025717），支持从回答标题跳转对应问题页（af12838c）
- 回答评论区点赞、子评论展开与图片预览迁移（840575a2）
- 回答切换改为双向过滑预览，支持拖动悬浮按钮（4a10e530）
- 回答/文章顶栏随滚动折叠联动，显示答主信息与标题作者（d51007f3, 7f17ecf1）
- 双击正文支持可配置动作，默认弹窗询问并记住选择（e7826973）
- 沉浸式阅读对齐上游真全屏，支持返回键退出（b3033995）
- 正文图片查看器对齐上游全屏缩放与长按菜单（9d307f5f）
- 修复回答底部异常留白（85d9090e）

## 信息流与其它页面

- 首页信息流顶部新增版本更新卡片（f275a0f2）；热榜卡片展示问题四项统计（a796cd36）
- 日报支持多日浏览与原生日期选择（96e8d716）
- 搜索页对齐上游：顶栏注入、历史热搜、五 tab、排序菜单（76447462）
- 关注页对齐上游推荐/动态双子页滑动切换与规范页签（06d6c54a）
- 新增本地历史记录页，卡片信息流对齐上游，支持清除与单条删除（702e1b3c）
- 分享改用 systemShareKit 真实调起系统面板并渲染链接卡片（484d1209）

## 工程

- 应用版本号升至 0.4.0（3c1898a3）
- 迁移计划文档对齐 API 26 编译 + API 23 最低兼容，补充 AGENTS 约束（cccc70da）